### PR TITLE
Add callbacks to be invoked on refresh. #698

### DIFF
--- a/packages/flutter_riverpod/test/framework_test.dart
+++ b/packages/flutter_riverpod/test/framework_test.dart
@@ -356,6 +356,26 @@ void main() {
     expect(ref.refresh(provider), null);
   });
 
+  testWidgets('ref.refresh calls onRefresh listeners', (tester) async {
+    final onRefreshListener = OnRefreshListener();
+    final provider = Provider((ref) {
+      ref.onRefresh(onRefreshListener);
+    });
+    late WidgetRef ref;
+    await tester.pumpWidget(ProviderScope(
+      child: Consumer(
+        builder: (context, r, _) {
+          ref = r;
+          return Container();
+        },
+      ),
+    ));
+    ref.read(provider);
+    verifyZeroInteractions(onRefreshListener);
+    ref.refresh(provider);
+    verify(onRefreshListener()).called(1);
+  });
+
   // testWidgets('ProviderScope allows specifying a ProviderContainer',
   //     (tester) async {
   //   final provider = FutureProvider((ref) async => 42);

--- a/packages/flutter_riverpod/test/utils.dart
+++ b/packages/flutter_riverpod/test/utils.dart
@@ -8,6 +8,10 @@ class ErrorListener extends Mock {
   void call(Object? error, StackTrace? stackTrace);
 }
 
+class OnRefreshListener extends Mock {
+  void call();
+}
+
 ProviderContainer createContainer({
   ProviderContainer? parent,
   List<Override> overrides = const [],

--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -325,6 +325,13 @@ class ProviderContainer implements Node {
 
   /// {@template riverpod.refresh}
   State refresh<State>(Refreshable<State> provider) {
+    final reader = _getStateReader(provider._origin);
+
+    if (reader._element != null) {
+      final element = reader._element!;
+      element.triggerOnRefresh();
+    }
+
     invalidate(provider._origin);
     return read(provider);
   }

--- a/packages/riverpod/lib/src/framework/element.dart
+++ b/packages/riverpod/lib/src/framework/element.dart
@@ -904,6 +904,7 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     _onDisposeListeners = null;
     _onCancelListeners = null;
     _onResumeListeners = null;
+    _onRefreshListeners = null;
     _onAddListeners = null;
     _onRemoveListeners = null;
     _onChangeSelfListeners = null;

--- a/packages/riverpod/lib/src/framework/element.dart
+++ b/packages/riverpod/lib/src/framework/element.dart
@@ -94,6 +94,7 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
   List<void Function()>? _onCancelListeners;
   List<void Function()>? _onAddListeners;
   List<void Function()>? _onRemoveListeners;
+  List<void Function()>? _onRefreshListeners;
   List<void Function(State?, State)>? _onChangeSelfListeners;
   List<void Function(Object, StackTrace)>? _onErrorSelfListeners;
 
@@ -932,6 +933,17 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
   void onResume(void Function() cb) {
     _onResumeListeners ??= [];
     _onResumeListeners!.add(cb);
+  }
+
+  @override
+  void onRefresh(void Function() cb) {
+    _onRefreshListeners ??= [];
+    _onRefreshListeners!.add(cb);
+  }
+
+  @protected
+  void triggerOnRefresh() {
+    _onRefreshListeners?.forEach(runGuarded);
   }
 
   @override

--- a/packages/riverpod/lib/src/framework/ref.dart
+++ b/packages/riverpod/lib/src/framework/ref.dart
@@ -121,6 +121,10 @@ abstract class Ref<State extends Object?> {
   /// - [onCancel], a life-cycle for when all listeners of a provider are removed.
   void onDispose(void Function() cb);
 
+  /// Adds a listener to perform an operation before the provider is refreshed
+  /// by calling [ProviderContainer.refresh].
+  void onRefresh(void Function() cb);
+
   /// Read the state associated with a provider, without listening to that provider.
   ///
   /// By calling [read] instead of [watch], this will not cause a provider's

--- a/packages/riverpod/test/framework/provider_element_test.dart
+++ b/packages/riverpod/test/framework/provider_element_test.dart
@@ -930,11 +930,10 @@ void main() {
     });
   });
 
-  group('ref.onReload', () {
+  group('ref.onRefresh', () {
     test('is called on refresh', () {
       final container = createContainer();
       final onRefreshListener = OnRefreshListener();
-      when(onRefreshListener()).thenReturn(null);
       final provider = Provider((ref) {
         ref.onRefresh(onRefreshListener);
       });
@@ -942,9 +941,9 @@ void main() {
       verifyZeroInteractions(onRefreshListener);
       container.refresh(provider);
       verify(onRefreshListener()).called(1);
-      // a second refresh will again call the invalidate listener.
+      // a second refresh will again call the invalidate listener once.
       container.refresh(provider);
-      verify(onRefreshListener()).called(2);
+      verify(onRefreshListener()).called(1);
     });
   });
 

--- a/packages/riverpod/test/framework/provider_element_test.dart
+++ b/packages/riverpod/test/framework/provider_element_test.dart
@@ -930,6 +930,24 @@ void main() {
     });
   });
 
+  group('ref.onReload', () {
+    test('is called on refresh', () {
+      final container = createContainer();
+      final onRefreshListener = OnRefreshListener();
+      when(onRefreshListener()).thenReturn(null);
+      final provider = Provider((ref) {
+        ref.onRefresh(onRefreshListener);
+      });
+      container.read(provider);
+      verifyZeroInteractions(onRefreshListener);
+      container.refresh(provider);
+      verify(onRefreshListener()).called(1);
+      // a second refresh will again call the invalidate listener.
+      container.refresh(provider);
+      verify(onRefreshListener()).called(2);
+    });
+  });
+
   test(
       'onDispose is triggered only once if within autoDispose unmount, a dependency chnaged',
       () async {

--- a/packages/riverpod/test/utils.dart
+++ b/packages/riverpod/test/utils.dart
@@ -74,6 +74,10 @@ class ErrorListener extends Mock {
   void call(Object? error, StackTrace? stackTrace);
 }
 
+class OnRefreshListener extends Mock {
+  void call();
+}
+
 class Selector<Input, Output> extends Mock {
   Selector(this.fake, Output Function(Input) selector) {
     when(call(any)).thenAnswer((i) {


### PR DESCRIPTION
I honestly didn't quite understand what we agreed upon ;-) I hope this fits better with your expectations..
When digging through the code it looked to me to be cleaner to just have a callback for invalidate. 1. it required less code changes (only in the `ProviderElementBase`, not in the container) and 2. I think invalidate and refresh would serve similar use cases..
