### PR TITLE
Minor typo

### DIFF
--- a/website/docs/concepts/reading.mdx
+++ b/website/docs/concepts/reading.mdx
@@ -170,7 +170,7 @@ the content from a provider and update the user interface whenever that content 
 
 <CodeBlock>{trimSnippet(watchBuild)}</CodeBlock>
 
-This snippet shows a widgets that listens to a provider which stores a `count`.
+This snippet shows a widget that listens to a provider which stores a `count`.
 And if that `count` changes, the widget will rebuild and the UI will update
 to show the new value.
 


### PR DESCRIPTION
Widget should be singular in this context.