### PR TITLE
Add 3rd party example: Piano Chords Test

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -130,6 +130,11 @@ module.exports = {
           label: "GoRouter with Riverpod",
           href: "https://github.com/lucavenir/go_router_riverpod",
         },
+        {
+          type: "link",
+          label: "Piano Chords Test",
+          href: "https://github.com/akvus/piano_fun",
+        },
       ],
     },
     {


### PR DESCRIPTION
This PR adds a 3rd party example where Riverpod is powering an app designed to help memorize piano chords. The app displays a name of a chord and expects a user to play it either on the virtual keyboard or at a digital piano connected via USB.