### PR TITLE
Add `onInvalidateSelf` to be invoked when provider is invalidated

### DIFF
--- a/packages/flutter_riverpod/test/framework_test.dart
+++ b/packages/flutter_riverpod/test/framework_test.dart
@@ -311,11 +311,10 @@ void main() {
     expect(ref.refresh(provider), null);
   });
 
-  testWidgets('ref.refresh causes onInvalidateSelf to be called',
-      (tester) async {
-    int value = 42;
-    final provider = Provider<int>((ref) { 
-      ref.onInvalidateSelf(() => value++);
+  testWidgets('ref.refresh causes onRefresh to be called', (tester) async {
+    var value = 42;
+    final provider = Provider<int>((ref) {
+      ref.onRefresh(() => value++);
       return value;
     });
     late WidgetRef ref;

--- a/packages/flutter_riverpod/test/framework_test.dart
+++ b/packages/flutter_riverpod/test/framework_test.dart
@@ -311,6 +311,30 @@ void main() {
     expect(ref.refresh(provider), null);
   });
 
+  testWidgets('ref.refresh causes onInvalidateSelf to be called',
+      (tester) async {
+    int value = 42;
+    final provider = Provider<int>((ref) { 
+      ref.onInvalidateSelf(() => value++);
+      return value;
+    });
+    late WidgetRef ref;
+
+    await tester.pumpWidget(ProviderScope(
+      child: Consumer(
+        builder: (context, r, _) {
+          ref = r;
+          return Container();
+        },
+      ),
+    ));
+
+    expect(ref.read(provider), 42);
+
+    expect(ref.refresh(provider), 43);
+    expect(ref.refresh(provider), 44);
+  });
+
   testWidgets('ProviderScope allows specifying a ProviderContainer',
       (tester) async {
     final provider = FutureProvider((ref) async => 42);

--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -360,6 +360,13 @@ class ProviderContainer implements Node {
 
   /// {@template riverpod.refresh}
   Created refresh<Created>(ProviderBase<Created> provider) {
+    final reader = _getStateReader(provider.originProvider);
+
+    if (reader._element != null) {
+      final element = reader._element!;
+      element.runOnRefresh();
+    }
+
     invalidate(provider);
     return read(provider);
   }

--- a/packages/riverpod/lib/src/framework/provider_base.dart
+++ b/packages/riverpod/lib/src/framework/provider_base.dart
@@ -260,7 +260,7 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
   List<void Function()>? _onCancelListeners;
   List<void Function()>? _onAddListeners;
   List<void Function()>? _onRemoveListeners;
-  List<void Function()>? _onInvalidateSelfListeners;
+  List<void Function()>? _onRefreshListeners;
   List<void Function(State?, State)>? _onChangeSelfListeners;
   List<void Function(Object, StackTrace)>? _onErrorSelfListeners;
 
@@ -404,7 +404,6 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
     if (_mustRecomputeState) return;
 
     _mustRecomputeState = true;
-    _runOnInvalidateSelf();
     _runOnDispose();
     _container._scheduler.scheduleProviderRefresh(this);
 
@@ -946,15 +945,15 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     _onResumeListeners = null;
     _onAddListeners = null;
     _onRemoveListeners = null;
-    _onInvalidateSelfListeners = null;
+    _onRefreshListeners = null;
     _onChangeSelfListeners = null;
     _onErrorSelfListeners = null;
     _didCancelOnce = false;
   }
 
   @protected
-  void _runOnInvalidateSelf() {
-    _onInvalidateSelfListeners?.forEach(_runGuarded);
+  void runOnRefresh() {
+    _onRefreshListeners?.forEach(_runGuarded);
   }
 
   @override
@@ -981,10 +980,10 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     _onResumeListeners!.add(cb);
   }
 
-  @override 
-  void onInvalidateSelf(void Function() cb) {
-    _onInvalidateSelfListeners ??= [];
-    _onInvalidateSelfListeners!.add(cb);
+  @override
+  void onRefresh(void Function() cb) {
+    _onRefreshListeners ??= [];
+    _onRefreshListeners!.add(cb);
   }
 
   @override

--- a/packages/riverpod/lib/src/framework/provider_base.dart
+++ b/packages/riverpod/lib/src/framework/provider_base.dart
@@ -260,6 +260,7 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
   List<void Function()>? _onCancelListeners;
   List<void Function()>? _onAddListeners;
   List<void Function()>? _onRemoveListeners;
+  List<void Function()>? _onInvalidateSelfListeners;
   List<void Function(State?, State)>? _onChangeSelfListeners;
   List<void Function(Object, StackTrace)>? _onErrorSelfListeners;
 
@@ -403,6 +404,7 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
     if (_mustRecomputeState) return;
 
     _mustRecomputeState = true;
+    _runOnInvalidateSelf();
     _runOnDispose();
     _container._scheduler.scheduleProviderRefresh(this);
 
@@ -944,9 +946,15 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     _onResumeListeners = null;
     _onAddListeners = null;
     _onRemoveListeners = null;
+    _onInvalidateSelfListeners = null;
     _onChangeSelfListeners = null;
     _onErrorSelfListeners = null;
     _didCancelOnce = false;
+  }
+
+  @protected
+  void _runOnInvalidateSelf() {
+    _onInvalidateSelfListeners?.forEach(_runGuarded);
   }
 
   @override
@@ -971,6 +979,12 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
   void onResume(void Function() cb) {
     _onResumeListeners ??= [];
     _onResumeListeners!.add(cb);
+  }
+
+  @override 
+  void onInvalidateSelf(void Function() cb) {
+    _onInvalidateSelfListeners ??= [];
+    _onInvalidateSelfListeners!.add(cb);
   }
 
   @override

--- a/packages/riverpod/lib/src/framework/ref.dart
+++ b/packages/riverpod/lib/src/framework/ref.dart
@@ -122,13 +122,10 @@ abstract class Ref<State extends Object?> {
   void onDispose(void Function() cb);
 
   /// Adds a listener to perform an operation right before the provider is refreshed
-  /// or invalidated
   ///
   /// This includes:
   /// - when using [refresh].
-  /// - when using [invalidate].
-  /// - when using [invalidateSelf].
-  void onInvalidateSelf(void Function() cb);
+  void onRefresh(void Function() cb);
 
   /// Read the state associated with a provider, without listening to that provider.
   ///

--- a/packages/riverpod/lib/src/framework/ref.dart
+++ b/packages/riverpod/lib/src/framework/ref.dart
@@ -121,6 +121,15 @@ abstract class Ref<State extends Object?> {
   /// - [onCancel], a life-cycle for when all listeners of a provider are removed.
   void onDispose(void Function() cb);
 
+  /// Adds a listener to perform an operation right before the provider is refreshed
+  /// or invalidated
+  ///
+  /// This includes:
+  /// - when using [refresh].
+  /// - when using [invalidate].
+  /// - when using [invalidateSelf].
+  void onInvalidateSelf(void Function() cb);
+
   /// Read the state associated with a provider, without listening to that provider.
   ///
   /// By calling [read] instead of [watch], this will not cause a provider's

--- a/packages/riverpod/test/framework/provider_element_test.dart
+++ b/packages/riverpod/test/framework/provider_element_test.dart
@@ -1338,52 +1338,28 @@ void main() {
     });
   });
 
-  group('ref.onInvalidateSelf', () {
-    test('is called when provider is refreshed',
-        () async {
+  group('ref.onRefresh', () {
+    test('is called when provider is refreshed', () async {
       final container = createContainer();
-      final onInvalidateSelfListener = OnInvalidateSelfListener();
+      final onRefreshListener = OnRefreshListener();
 
-      final provider = Provider((ref) { 
-        ref.onInvalidateSelf(onInvalidateSelfListener);
+      final provider = Provider((ref) {
+        ref.onRefresh(onRefreshListener);
       });
 
       container.read(provider);
 
-      verifyZeroInteractions(onInvalidateSelfListener);
+      verifyZeroInteractions(onRefreshListener);
 
       container.refresh(provider);
 
-      verify(onInvalidateSelfListener()).called(1);
+      verify(onRefreshListener()).called(1);
 
       await container.pump();
 
-      verifyNoMoreInteractions(onInvalidateSelfListener);
-    });
-
-    test('is called when provider is invalidated',
-        () async {
-      final container = createContainer();
-      final onInvalidateSelfListener = OnInvalidateSelfListener();
-
-      final provider = Provider((ref) { 
-        ref.onInvalidateSelf(onInvalidateSelfListener);
-      });
-
-      container.read(provider);
-
-      verifyZeroInteractions(onInvalidateSelfListener);
-
-      container.invalidate(provider);
-
-      verify(onInvalidateSelfListener()).called(1);
-
-      await container.pump();
-
-      verifyNoMoreInteractions(onInvalidateSelfListener);
+      verifyNoMoreInteractions(onRefreshListener);
     });
   });
-
 
   test(
       'onDispose is triggered only once if within autoDispose unmount, a dependency chnaged',

--- a/packages/riverpod/test/framework/provider_element_test.dart
+++ b/packages/riverpod/test/framework/provider_element_test.dart
@@ -1338,6 +1338,53 @@ void main() {
     });
   });
 
+  group('ref.onInvalidateSelf', () {
+    test('is called when provider is refreshed',
+        () async {
+      final container = createContainer();
+      final onInvalidateSelfListener = OnInvalidateSelfListener();
+
+      final provider = Provider((ref) { 
+        ref.onInvalidateSelf(onInvalidateSelfListener);
+      });
+
+      container.read(provider);
+
+      verifyZeroInteractions(onInvalidateSelfListener);
+
+      container.refresh(provider);
+
+      verify(onInvalidateSelfListener()).called(1);
+
+      await container.pump();
+
+      verifyNoMoreInteractions(onInvalidateSelfListener);
+    });
+
+    test('is called when provider is invalidated',
+        () async {
+      final container = createContainer();
+      final onInvalidateSelfListener = OnInvalidateSelfListener();
+
+      final provider = Provider((ref) { 
+        ref.onInvalidateSelf(onInvalidateSelfListener);
+      });
+
+      container.read(provider);
+
+      verifyZeroInteractions(onInvalidateSelfListener);
+
+      container.invalidate(provider);
+
+      verify(onInvalidateSelfListener()).called(1);
+
+      await container.pump();
+
+      verifyNoMoreInteractions(onInvalidateSelfListener);
+    });
+  });
+
+
   test(
       'onDispose is triggered only once if within autoDispose unmount, a dependency chnaged',
       () async {

--- a/packages/riverpod/test/framework/provider_reference_test.dart
+++ b/packages/riverpod/test/framework/provider_reference_test.dart
@@ -65,10 +65,10 @@ void main() {
         expect(container.read(state), 42);
       });
 
-      test('causes onInvalidateSelf to be called', () {
+      test('causes onRefresh to be called', () {
         var value = 0;
-        final state = Provider((ref) { 
-          ref.onInvalidateSelf(() => value = 42);
+        final state = Provider((ref) {
+          ref.onRefresh(() => value = 42);
           return value;
         });
         late Ref ref;

--- a/packages/riverpod/test/framework/provider_reference_test.dart
+++ b/packages/riverpod/test/framework/provider_reference_test.dart
@@ -64,6 +64,26 @@ void main() {
         expect(ref.refresh(state), 42);
         expect(container.read(state), 42);
       });
+
+      test('causes onInvalidateSelf to be called', () {
+        var value = 0;
+        final state = Provider((ref) { 
+          ref.onInvalidateSelf(() => value = 42);
+          return value;
+        });
+        late Ref ref;
+        final provider = Provider((r) {
+          ref = r;
+        });
+        final container = createContainer();
+
+        container.read(provider);
+
+        expect(container.read(state), 0);
+
+        expect(ref.refresh(state), 42);
+        expect(container.read(state), 42);
+      });
     });
 
     test('ref.read should keep providers alive', () {}, skip: true);

--- a/packages/riverpod/test/utils.dart
+++ b/packages/riverpod/test/utils.dart
@@ -76,7 +76,7 @@ class ErrorListener extends Mock {
   void call(Object? error, StackTrace? stackTrace);
 }
 
-class OnInvalidateSelfListener extends Mock {
+class OnRefreshListener extends Mock {
   void call();
 }
 

--- a/packages/riverpod/test/utils.dart
+++ b/packages/riverpod/test/utils.dart
@@ -76,6 +76,10 @@ class ErrorListener extends Mock {
   void call(Object? error, StackTrace? stackTrace);
 }
 
+class OnInvalidateSelfListener extends Mock {
+  void call();
+}
+
 class Selector<Input, Output> extends Mock {
   Selector(this.fake, Output Function(Input) selector) {
     when(call(any)).thenAnswer((i) {


### PR DESCRIPTION
Picking up from the work done in [this PR](https://github.com/rrousselGit/riverpod/pull/1352), but changing it slightly to fit the requirements I outlined [in this feature request](https://github.com/rrousselGit/riverpod/issues/1404).

I decided to the have the callback be invoked when `invalidateSelf` is called, as this will happen for both `refresh` and `invalidate`.

