### PR TITLE
Fix typo in german translation

### DIFF
--- a/website/i18n/de/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -54,7 +54,7 @@ dependencies:
   hooks_riverpod: ^2.0.0-dev.0
 ```
 
-Dann führe `flutter pug get` aus.
+Dann führe `flutter pub get` aus.
 
 </TabItem>
 <TabItem value="flutter_riverpod">
@@ -70,7 +70,7 @@ dependencies:
   flutter_riverpod: ^2.0.0-dev.0
 ```
 
-Dann führe `flutter pug get` aus.
+Dann führe `flutter pub get` aus.
 
 </TabItem>
 <TabItem value="riverpod">
@@ -83,7 +83,7 @@ dependencies:
   riverpod: ^2.0.0-dev.0
 ```
 
-Dann führe `flutter pug get` aus.
+Dann führe `flutter pub get` aus.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Hi,
while reading through the german version of getting started, I found these small typos.
Thanks!