### PR TITLE
fix: Docs example on ref.refresh

### DIFF
--- a/packages/flutter_riverpod/lib/src/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/consumer.dart
@@ -155,7 +155,10 @@ abstract class WidgetRef {
   ///     final Products products = ref.watch(productsProvider);
   ///
   ///     return RefreshIndicator(
-  ///       onRefresh: () => ref.refresh(productsProvider.future),
+  ///       onRefresh: () {
+  ///         ref.refresh(productsProvider),
+  ///         return ref.read(productsProvider.future),
+  ///       }
   ///       child: ListView(
   ///         children: [
   ///           for (final product in products.items) ProductItem(product: product),


### PR DESCRIPTION
Following the stackoverflow example, I believe the usage with RefreshIndicator should be 

```dart
onRefresh: () {
  ref.refresh(productsProvider),
  return ref.read(productsProvider.future),
}
```

I tried the original `onRefresh: () => ref.refresh(productsProvider.future),` but the future doesn't re-run.