### PR TITLE
Fix: In the Marvel Example, characters count is not set to child count.

### DIFF
--- a/examples/marvel/lib/src/screens/home.dart
+++ b/examples/marvel/lib/src/screens/home.dart
@@ -134,14 +134,17 @@ class Home extends HookConsumerWidget {
                         crossAxisCount: 2,
                         childAspectRatio: 0.8,
                       ),
-                      delegate: SliverChildBuilderDelegate((c, index) {
-                        return ProviderScope(
-                          overrides: [
-                            _characterIndex.overrideWithValue(index),
-                          ],
-                          child: const CharacterItem(),
-                        );
-                      }),
+                      delegate: SliverChildBuilderDelegate(
+                        (c, index) {
+                          return ProviderScope(
+                            overrides: [
+                              _characterIndex.overrideWithValue(index),
+                            ],
+                            child: const CharacterItem(),
+                          );
+                        },
+                        childCount: charactersCount,
+                      ),
                     ),
                   ),
                 ],


### PR DESCRIPTION
Hi,
A small bug in Marvel Example was found and has been fixed.
In SliverChildBuilderDelegate, charactersCount is set to childCount.

Thanks!

**Before**
<img src="https://user-images.githubusercontent.com/66857966/182624635-4279aa2b-96a9-4f34-a243-a646ab994d2f.png" width="300">


**After**
<img src="https://user-images.githubusercontent.com/66857966/182626310-ebe49dae-ec90-4aa4-97e5-967a42ab7f56.png" width="300">


