### PR TITLE
Fix codecov badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <a href="https://github.com/rrousselGit/river_pod/actions"><img src="https://github.com/rrousselGit/river_pod/workflows/Build/badge.svg" alt="Build Status"></a>
-<a href="https://codecov.io/gh/rrousselgit/river_pod"><img src="https://codecov.io/gh/rrousselgit/river_pod/branch/master/graph/badge.svg" alt="codecov"></a>
+<a href="https://codecov.io/gh/rrousselgit/riverpod"><img src="https://codecov.io/gh/rrousselgit/riverpod/branch/master/graph/badge.svg" alt="codecov"></a>
 <a href="https://github.com/rrousselgit/river_pod"><img src="https://img.shields.io/github/stars/rrousselgit/river_pod.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on Github"></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
 <a href="https://discord.gg/Bbumvej"><img src="https://img.shields.io/discord/765557403865186374.svg?logo=discord&color=blue" alt="Discord"></a>


### PR DESCRIPTION
I was making an update to my Flutter state management stats and noticed that the Codecov badge for Riverpod is broken.
 
![image](https://user-images.githubusercontent.com/39990307/184540669-e4be87a6-f21c-4361-93d0-4e295497302c.png)

I was about to report codecov as "not provided", but saw it is available if you get it via its new URL. This fixes the broken URL for the badge.
![image](https://user-images.githubusercontent.com/39990307/184540737-e5c74ccb-520f-46e0-8edc-4c921262fc2c.png)

Then I don't have to report is as not provided in the stats update :)