### PR TITLE
Renamed from river_pod to riverpod

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: I have a problem and I need help
-    url: https://github.com/rrousselGit/river_pod/discussions
+    url: https://github.com/rrousselGit/riverpod/discussions
     about: Pleast ask and answer questions here

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
-<a href="https://github.com/rrousselGit/river_pod/actions"><img src="https://github.com/rrousselGit/river_pod/workflows/Build/badge.svg" alt="Build Status"></a>
-<a href="https://codecov.io/gh/rrousselgit/river_pod"><img src="https://codecov.io/gh/rrousselgit/river_pod/branch/master/graph/badge.svg" alt="codecov"></a>
-<a href="https://github.com/rrousselgit/river_pod"><img src="https://img.shields.io/github/stars/rrousselgit/river_pod.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on Github"></a>
+<a href="https://github.com/rrousselGit/riverpod/actions"><img src="https://github.com/rrousselGit/riverpod/workflows/Build/badge.svg" alt="Build Status"></a>
+<a href="https://codecov.io/gh/rrousselgit/riverpod"><img src="https://codecov.io/gh/rrousselgit/riverpod/branch/master/graph/badge.svg" alt="codecov"></a>
+<a href="https://github.com/rrousselgit/riverpod"><img src="https://img.shields.io/github/stars/rrousselgit/riverpod.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on Github"></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
 <a href="https://discord.gg/Bbumvej"><img src="https://img.shields.io/discord/765557403865186374.svg?logo=discord&color=blue" alt="Discord"></a>
 
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-<img src="https://github.com/rrousselGit/river_pod/blob/master/resources/icon/Facebook%20Cover%20A.png?raw=true" width="100%" alt="Riverpod" />
+<img src="https://github.com/rrousselGit/riverpod/blob/master/resources/icon/Facebook%20Cover%20A.png?raw=true" width="100%" alt="Riverpod" />
 </p>
 
 </p>
@@ -191,7 +191,7 @@ to [Riverpod].
 </p>
 
 [provider]: https://github.com/rrousselGit/provider
-[riverpod]: https://github.com/rrousselGit/river_pod
+[riverpod]: https://github.com/rrousselGit/riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks
 [inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,11 +48,11 @@
 
 - "unused_widget_parameter"
 - "what caused a widget to rebuild?"
-- Don't create providers inside `build` (https://github.com/rrousselGit/river_pod/issues/144#issuecomment-695361486)
-- don't mutate other providers inside "create" (https://github.com/rrousselGit/river_pod/issues/144#issuecomment-695764973)
+- Don't create providers inside `build` (https://github.com/rrousselGit/riverpod/issues/144#issuecomment-695361486)
+- don't mutate other providers inside "create" (https://github.com/rrousselGit/riverpod/issues/144#issuecomment-695764973)
 - wrap with `Consumer`
 - No circular dependencies
-- warn about `ref.watch(autoDispose)` after an await (https://github.com/rrousselGit/river_pod/issues/243)
+- warn about `ref.watch(autoDispose)` after an await (https://github.com/rrousselGit/riverpod/issues/243)
 - warn watch(autoDispose) in non-autoDispose provider
 - `always_specify_name`
 - `name_match_variable`

--- a/examples/marvel/README.md
+++ b/examples/marvel/README.md
@@ -11,9 +11,9 @@ This example demonstrates how to:
 - support deep-linking to an item
 - optimize widget rebuilds (only what needs to update does update).
 
-![search](https://github.com/rrousselGit/river_pod/blob/master/examples/marvel/resources/search.png)
+![search](https://github.com/rrousselGit/riverpod/blob/master/examples/marvel/resources/search.png)
 
-![home](https://github.com/rrousselGit/river_pod/blob/master/examples/marvel/resources/home.png)
+![home](https://github.com/rrousselGit/riverpod/blob/master/examples/marvel/resources/home.png)
 
 
 # Installation
@@ -40,7 +40,7 @@ The content of this file looks like this:
 
 Where `public_key` and `private_key` are obtained from https://developer.marvel.com/account
 
-![marvel_account](https://github.com/rrousselGit/river_pod/blob/master/examples/marvel/resources/marvel_portal.png)
+![marvel_account](https://github.com/rrousselGit/riverpod/blob/master/examples/marvel/resources/marvel_portal.png)
 
 Since this project uses [freezed](https://pub.dev/packages/freezed) for code generation, be sure to run the generator with the following command before attempting to build/run the application:
 
@@ -48,4 +48,4 @@ Since this project uses [freezed](https://pub.dev/packages/freezed) for code gen
 flutter pub run build_runner build
 ```
 
-[riverpod]: https://github.com/rrousselGit/river_pod
+[riverpod]: https://github.com/rrousselGit/riverpod

--- a/examples/todos/README.md
+++ b/examples/todos/README.md
@@ -2,7 +2,7 @@ A todo-list built with [Riverpod]
 
 This showcase slightly more advanced state manipulation, using [Computed].
 
-<img alt="todo screenshot" src="https://github.com/rrousselGit/river_pod/blob/master/examples/todos/todo_screenshot.jpg" width="400px">
+<img alt="todo screenshot" src="https://github.com/rrousselGit/riverpod/blob/master/examples/todos/todo_screenshot.jpg" width="400px">
 
 
-[riverpod]: https://github.com/rrousselGit/river_pod
+[riverpod]: https://github.com/rrousselGit/riverpod

--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -694,7 +694,7 @@ Removed an assert that could cause issues when an application is partially migra
   }
   ```
 
-  See also https://github.com/rrousselGit/river_pod/issues/341 for more information.
+  See also https://github.com/rrousselGit/riverpod/issues/341 for more information.
 
 - **BREAKING CHANGE** It is no longer possible to override `StreamProvider.stream/last` and `FutureProvider.future`.
 - feat: Calling `ProviderContainer.dispose` multiple time no longer throws.
@@ -711,7 +711,7 @@ Fixed an issue where `context.read` and `ProviderListener` were unable to read p
 
 ## 0.13.1
 
-- Fixed a bug where overriding a `FutureProvider` with an error value could cause tests to fail (see https://github.com/rrousselGit/river_pod/issues/355)
+- Fixed a bug where overriding a `FutureProvider` with an error value could cause tests to fail (see https://github.com/rrousselGit/riverpod/issues/355)
 
 ## 0.13.0
 
@@ -750,18 +750,18 @@ Migrated to null-safety
 
 ## 0.12.1
 
-- Fixed an remaining memory leak related to StreamProvider (see also https://github.com/rrousselGit/river_pod/issues/193)
+- Fixed an remaining memory leak related to StreamProvider (see also https://github.com/rrousselGit/riverpod/issues/193)
 
 ## 0.12.0
 
 - **Breaking** FutureProvider and StreamProvider no longer supports `null` as a valid value.
-- Fixed a memory leak with StreamProvider (see also https://github.com/rrousselGit/river_pod/issues/193)
+- Fixed a memory leak with StreamProvider (see also https://github.com/rrousselGit/riverpod/issues/193)
 - Fixed an error message typo related to Consumer
 
 ## 0.11.2
 
 - Fixed a bug where providers (usually ScopedProviders) did not dispose correctly
-  (see also https://github.com/rrousselGit/river_pod/issues/154).
+  (see also https://github.com/rrousselGit/riverpod/issues/154).
 
 ## 0.11.1
 
@@ -808,7 +808,7 @@ Migrated to null-safety
 
 - Renamed `ProviderContainer.debugProviderStates` to `ProviderContainer.debugProviderElements`
 - Fixed a bug where updating `ProviderScope.overrides` may cause an exception
-  for no reason (see https://github.com/rrousselGit/river_pod/issues/107)
+  for no reason (see https://github.com/rrousselGit/riverpod/issues/107)
 
 ## 0.7.2
 
@@ -816,7 +816,7 @@ Fixed a bug that prevented the use of `ConsumerWidget` under normal circumstance
 
 ## 0.7.1
 
-- Fixed a bug where in release mode, `ScopedProvider` did not update correctly (https://github.com/rrousselGit/river_pod/issues/101)
+- Fixed a bug where in release mode, `ScopedProvider` did not update correctly (https://github.com/rrousselGit/riverpod/issues/101)
 
 ## 0.7.0
 

--- a/packages/flutter_riverpod/pubspec.yaml
+++ b/packages/flutter_riverpod/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   while robust and testable.
 version: 2.0.0-dev.9
 homepage: https://riverpod.dev
-repository: https://github.com/rrousselGit/river_pod
+repository: https://github.com/rrousselGit/riverpod
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -751,7 +751,7 @@ Removed an assert that could cause issues when an application is partially migra
   }
   ```
 
-  See also https://github.com/rrousselGit/river_pod/issues/341 for more information.
+  See also https://github.com/rrousselGit/riverpod/issues/341 for more information.
 
 - **BREAKING CHANGE** It is no longer possible to override `StreamProvider.stream/last` and `FutureProvider.future`.
 - feat: Calling `ProviderContainer.dispose` multiple time no longer throws.
@@ -766,7 +766,7 @@ Fixed an issue where `context.read` and `ProviderListener` were unable to read p
 
 ## 0.13.1
 
-- Fixed a bug where overriding a `FutureProvider` with an error value could cause tests to fail (see https://github.com/rrousselGit/river_pod/issues/355)
+- Fixed a bug where overriding a `FutureProvider` with an error value could cause tests to fail (see https://github.com/rrousselGit/riverpod/issues/355)
 
 ## 0.13.0
 
@@ -805,18 +805,18 @@ Migrated to null-safety
 
 ## 0.12.1
 
-- Fixed an remaining memory leak related to StreamProvider (see also https://github.com/rrousselGit/river_pod/issues/193)
+- Fixed an remaining memory leak related to StreamProvider (see also https://github.com/rrousselGit/riverpod/issues/193)
 
 ## 0.12.0
 
 - **Breaking** FutureProvider and StreamProvider no longer supports `null` as a valid value.
-- Fixed a memory leak with StreamProvider (see also https://github.com/rrousselGit/river_pod/issues/193)
+- Fixed a memory leak with StreamProvider (see also https://github.com/rrousselGit/riverpod/issues/193)
 - Fixed an error message typo related to Consumer
 
 ## 0.11.2
 
 - Fixed a bug where providers (usually ScopedProviders) did not dispose correctly
-  (see also https://github.com/rrousselGit/river_pod/issues/154).
+  (see also https://github.com/rrousselGit/riverpod/issues/154).
 
 ## 0.11.1
 
@@ -867,7 +867,7 @@ Migrated to null-safety
 
 - Renamed `ProviderContainer.debugProviderStates` to `ProviderContainer.debugProviderElements`
 - Fixed a bug where updating `ProviderScope.overrides` may cause an exception
-  for no reason (see https://github.com/rrousselGit/river_pod/issues/107)
+  for no reason (see https://github.com/rrousselGit/riverpod/issues/107)
 
 ## 0.7.2
 
@@ -875,7 +875,7 @@ Fixed a bug that prevented the use of `ConsumerWidget` under normal circumstance
 
 ## 0.7.1
 
-- Fixed a bug where in release mode, `ScopedProvider` did not update correctly (https://github.com/rrousselGit/river_pod/issues/101)
+- Fixed a bug where in release mode, `ScopedProvider` did not update correctly (https://github.com/rrousselGit/riverpod/issues/101)
 
 ## 0.7.0
 

--- a/packages/hooks_riverpod/pubspec.yaml
+++ b/packages/hooks_riverpod/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   while robust and testable.
 version: 2.0.0-dev.9
 homepage: https://riverpod.dev
-repository: https://github.com/rrousselGit/river_pod
+repository: https://github.com/rrousselGit/riverpod
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -606,7 +606,7 @@ Removed an assert that could cause issues when an application is partially migra
   }
   ```
 
-  See also https://github.com/rrousselGit/river_pod/issues/341 for more information.
+  See also https://github.com/rrousselGit/riverpod/issues/341 for more information.
 
 - **BREAKING CHANGE** It is no longer possible to override `StreamProvider.stream/last` and `FutureProvider.future`.
 - feat: Calling `ProviderContainer.dispose` multiple time no longer throws.
@@ -617,7 +617,7 @@ Removed an assert that could cause issues when an application is partially migra
 
 ## 0.13.1
 
-- Fixed a bug where overriding a `FutureProvider` with an error value could cause tests to fail (see https://github.com/rrousselGit/river_pod/issues/355)
+- Fixed a bug where overriding a `FutureProvider` with an error value could cause tests to fail (see https://github.com/rrousselGit/riverpod/issues/355)
 
 ## 0.13.0
 
@@ -646,17 +646,17 @@ Migrated to null-safety
 
 ## 0.12.1
 
-- Fixed an remaining memory leak related to StreamProvider (see also https://github.com/rrousselGit/river_pod/issues/193)
+- Fixed an remaining memory leak related to StreamProvider (see also https://github.com/rrousselGit/riverpod/issues/193)
 
 ## 0.12.0
 
 - **Breaking** FutureProvider and StreamProvider no longer supports `null` as a valid value.
-- Fixed a memory leak with StreamProvider (see also https://github.com/rrousselGit/river_pod/issues/193)
+- Fixed a memory leak with StreamProvider (see also https://github.com/rrousselGit/riverpod/issues/193)
 
 ## 0.11.2
 
 - Fixed a bug where providers (usually ScopedProviders) did not dispose correctly
-  (see also https://github.com/rrousselGit/river_pod/issues/154).
+  (see also https://github.com/rrousselGit/riverpod/issues/154).
 
 ## 0.11.0
 
@@ -690,7 +690,7 @@ Migrated to null-safety
 
 - Renamed `ProviderContainer.debugProviderStates` to `ProviderContainer.debugProviderElements`
 - Fixed a bug where updating `ProviderScope.overrides` may cause an exception
-  for no reason (see https://github.com/rrousselGit/river_pod/issues/107)
+  for no reason (see https://github.com/rrousselGit/riverpod/issues/107)
 
 ## 0.7.0
 

--- a/packages/riverpod/example/README.md
+++ b/packages/riverpod/example/README.md
@@ -35,6 +35,6 @@ The content of this file looks like this:
 
 Where `public_key` and `private_key` are obtained from https://developer.marvel.com/account
 
-![marvel_account](https://github.com/rrousselGit/river_pod/blob/master/packages/riverpod/example/resources/marvel_portal.png)
+![marvel_account](https://github.com/rrousselGit/riverpod/blob/master/packages/riverpod/example/resources/marvel_portal.png)
 
-[riverpod]: https://github.com/rrousselGit/river_pod
+[riverpod]: https://github.com/rrousselGit/riverpod

--- a/packages/riverpod/lib/src/framework/element.dart
+++ b/packages/riverpod/lib/src/framework/element.dart
@@ -37,7 +37,7 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
   var _debugSkipNotifyListenersAsserts = false;
 
   /// The provider associated with this [ProviderElementBase], before applying overrides.
-  // Not typed as <State> because of https://github.com/rrousselGit/river_pod/issues/1100
+  // Not typed as <State> because of https://github.com/rrousselGit/riverpod/issues/1100
   ProviderBase<Object?> get origin => _origin;
   late ProviderBase<Object?> _origin;
 

--- a/packages/riverpod/pubspec.yaml
+++ b/packages/riverpod/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   and testable.
 version: 2.0.0-dev.9
 homepage: https://riverpod.dev
-repository: https://github.com/rrousselGit/river_pod
+repository: https://github.com/rrousselGit/riverpod
 
 environment:
   sdk: ">=2.17.0 <3.0.0"

--- a/packages/riverpod/test/framework/provider_element_test.dart
+++ b/packages/riverpod/test/framework/provider_element_test.dart
@@ -1449,7 +1449,7 @@ void main() {
   test(
       'onDispose is triggered only once if within autoDispose unmount, a dependency chnaged',
       () async {
-    // regression test for https://github.com/rrousselGit/river_pod/issues/1064
+    // regression test for https://github.com/rrousselGit/riverpod/issues/1064
     final container = createContainer();
     final onDispose = OnDisposeMock();
     final dep = StateProvider((ref) => 0);

--- a/packages/riverpod_cli/CHANGELOG.md
+++ b/packages/riverpod_cli/CHANGELOG.md
@@ -39,7 +39,7 @@ Enable debugging the command line.
 
 # 1.0.0-dev.0
 
-- Migration for unifying syntax (riverpod 1.0.0) [RFC](https://github.com/rrousselGit/river_pod/issues/335)
+- Migration for unifying syntax (riverpod 1.0.0) [RFC](https://github.com/rrousselGit/riverpod/issues/335)
 
 # 0.0.2+2
 

--- a/packages/riverpod_cli/README.md
+++ b/packages/riverpod_cli/README.md
@@ -1,13 +1,13 @@
 <p align="center">
-<a href="https://github.com/rrousselGit/river_pod/actions"><img src="https://github.com/rrousselGit/river_pod/workflows/Build/badge.svg" alt="Build Status"></a>
-<a href="https://codecov.io/gh/rrousselgit/river_pod"><img src="https://codecov.io/gh/rrousselgit/river_pod/branch/master/graph/badge.svg" alt="codecov"></a>
-<a href="https://github.com/rrousselgit/river_pod"><img src="https://img.shields.io/github/stars/rrousselgit/river_pod.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on Github"></a>
+<a href="https://github.com/rrousselGit/riverpod/actions"><img src="https://github.com/rrousselGit/riverpod/workflows/Build/badge.svg" alt="Build Status"></a>
+<a href="https://codecov.io/gh/rrousselgit/riverpod"><img src="https://codecov.io/gh/rrousselgit/riverpod/branch/master/graph/badge.svg" alt="codecov"></a>
+<a href="https://github.com/rrousselgit/riverpod"><img src="https://img.shields.io/github/stars/rrousselgit/riverpod.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on Github"></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
 <a href="https://discord.gg/Bbumvej"><img src="https://img.shields.io/discord/765557403865186374.svg?logo=discord&color=blue" alt="Discord"></a>
 <a href="https://www.buymeacoffee.com/remirousselet" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="25px"></a>
 
 <p align="center">
-<img src="https://github.com/rrousselGit/river_pod/blob/master/resources/icon/Facebook%20Cover%20A.png?raw=true" width="100%" alt="Riverpod" />
+<img src="https://github.com/rrousselGit/riverpod/blob/master/resources/icon/Facebook%20Cover%20A.png?raw=true" width="100%" alt="Riverpod" />
 </p>
 
 </p>

--- a/packages/riverpod_cli/pubspec.yaml
+++ b/packages/riverpod_cli/pubspec.yaml
@@ -2,7 +2,7 @@ name: riverpod_cli
 description: A command line tool for Riverpod
 version: 1.0.3
 homepage: https://riverpod.dev
-repository: https://github.com/rrousselGit/river_pod
+repository: https://github.com/rrousselGit/riverpod
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/riverpod_graph/pubspec.yaml
+++ b/packages/riverpod_graph/pubspec.yaml
@@ -1,7 +1,7 @@
 name: riverpod_graph
 version: 0.0.1
 homepage: https://riverpod.dev
-repository: https://github.com/rrousselGit/river_pod
+repository: https://github.com/rrousselGit/riverpod
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/website/docs/concepts/combining_providers.mdx
+++ b/website/docs/concepts/combining_providers.mdx
@@ -99,7 +99,7 @@ Using such an approach, the UI will automatically update when either the filter
 or the todo-list changes.
 
 To see this approach in action, you can look at the source code of the [Todo List
-example](https://github.com/rrousselGit/river_pod/tree/master/examples/todos).
+example](https://github.com/rrousselGit/riverpod/tree/master/examples/todos).
 
 :::info
 This behavior is not specific to [Provider], and works with all providers.

--- a/website/docs/concepts/providers.mdx
+++ b/website/docs/concepts/providers.mdx
@@ -159,7 +159,7 @@ Alternatively, you can see [How to combine providers](/docs/concepts/combining_p
 [inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
 [stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
 [ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/docs/concepts/reading.mdx
+++ b/website/docs/concepts/reading.mdx
@@ -414,7 +414,7 @@ final label = ref.watch(userProvider.select((user) => 'Mr ${user.name}'));
 [useprovider]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ref.watch(.html
 [elevatedbutton]: https://api.flutter.dev/flutter/material/ElevatedButton-class.html
 [streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [text]: https://api.flutter.dev/flutter/widgets/Text-class.html
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [future]: https://api.dart.dev/stable/2.13.4/dart-async/Future-class.html

--- a/website/docs/cookbooks/testing.mdx
+++ b/website/docs/cookbooks/testing.mdx
@@ -152,7 +152,7 @@ Wrapping up, here is the entire full code for our Flutter test.
 
 <CodeBlock>{trimSnippet(testFull)}</CodeBlock>
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
 [providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
 [futureprovider]: ../providers/future_provider

--- a/website/docs/getting_started.mdx
+++ b/website/docs/getting_started.mdx
@@ -24,7 +24,7 @@ You can refer to the following table to help you decide which package to use:
 | ------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | Flutter only              | [flutter_riverpod]                                                                 | A basic way of using [Riverpod] with flutter.                                 |
 | Flutter + [flutter_hooks] | [hooks_riverpod]                                                                   | A way to use both [flutter_hooks] and [Riverpod] together.                    |
-| Dart only (No Flutter)    | [riverpod](https://github.com/rrousselGit/river_pod/tree/master/packages/riverpod) | A version of [Riverpod] with all the classes related to Flutter stripped out. |
+| Dart only (No Flutter)    | [riverpod](https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod) | A version of [Riverpod] with all the classes related to Flutter stripped out. |
 
 ## Installing the package
 
@@ -150,7 +150,7 @@ Follow a cookbook:
 
 - [How to test providers](/docs/cookbooks/testing)
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/docs/migration/0.13.0_to_0.14.0.mdx
+++ b/website/docs/migration/0.13.0_to_0.14.0.mdx
@@ -3,7 +3,7 @@ title: ^0.13.0 to ^0.14.0
 ---
 
 With the release of version `0.14.0` of Riverpod, the syntax for using [StateNotifierProvider] changed
-(see https://github.com/rrousselGit/river_pod/issues/341 for the explanation).
+(see https://github.com/rrousselGit/riverpod/issues/341 for the explanation).
 
 For the entire article, consider the following [StateNotifier]:
 

--- a/website/docs/providers/state_provider.mdx
+++ b/website/docs/providers/state_provider.mdx
@@ -94,7 +94,7 @@ re-render the list of products when the sort type changes.
 Here is the complete example on Dartpad:
 
 <iframe
-  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=river_pod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
+  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=riverpod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
   style={{ border: 0, width: "100%", aspectRatio: "2/1.5" }}
 ></iframe>
 

--- a/website/docs/providers/state_provider/full.dart
+++ b/website/docs/providers/state_provider/full.dart
@@ -1,6 +1,6 @@
 // This code is distributed under the MIT License.
 // Copyright (c) 2022 Remi Rousselet.
-// You can find the original at https://github.com/rrousselGit/river_pod.
+// You can find the original at https://github.com/rrousselGit/riverpod.
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -47,7 +47,7 @@ module.exports = {
           position: "right",
         },
         {
-          href: "https://github.com/rrousselGit/river_pod",
+          href: "https://github.com/rrousselGit/riverpod",
           label: "GitHub",
           position: "right",
         },
@@ -81,11 +81,11 @@ module.exports = {
             },
             {
               label: "GitHub",
-              href: "https://github.com/rrousselgit/river_pod",
+              href: "https://github.com/rrousselgit/riverpod",
             },
             {
               label: "Code of conduct",
-              href: "https://github.com/rrousselGit/river_pod/blob/master/CODE_OF_CONDUCT.md",
+              href: "https://github.com/rrousselGit/riverpod/blob/master/CODE_OF_CONDUCT.md",
             },
           ],
         },
@@ -109,7 +109,7 @@ module.exports = {
           editLocalizedFiles: true,
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl:
-            "https://github.com/rrousselGit/river_pod/edit/master/website/",
+            "https://github.com/rrousselGit/riverpod/edit/master/website/",
         },
         theme: {
           customCss: require.resolve("./src/scss/main.scss"),

--- a/website/i18n/bn/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current.json
@@ -33,15 +33,15 @@
     },
     "sidebar.Sidebar.link.Counter": {
         "message": "কাউন্টার এ্যাপ",
-        "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/counter"
+        "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/counter"
     },
     "sidebar.Sidebar.link.Todo list": {
         "message": "টুডু-লিস্ট এ্যাপ",
-        "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/todos"
+        "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/todos"
     },
     "sidebar.Sidebar.link.Marvel API": {
         "message": "মারবেল এপিয়াই এ্যাপ",
-        "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/marvel"
+        "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/marvel"
     },
     "sidebar.Sidebar.link.Android Launcher": {
         "message": "Android Launcher",

--- a/website/i18n/bn/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -89,7 +89,7 @@ final todoListProvider = StateNotifierProvider((ref) => TodoList());
 
 তারপর, ফিল্টার করা টোডো-তালিকা রিড করতে আমাদের UI `filteredTodoListProvider` রিড করতে পারে। এই ধরনের পদ্ধতি ব্যবহার করে, ফিল্টার বা টোডো-তালিকা পরিবর্তন হলে UI স্বয়ংক্রিয়ভাবে আপডেট হবে।
 
-এই পদ্ধতিটি কার্যকরভাবে দেখতে, আপনি [টুডো তালিকা উদাহরণ](https://github.com/rrousselGit/river_pod/tree/master/examples/todos) এর সোর্স কোডটি দেখতে পারেন।
+এই পদ্ধতিটি কার্যকরভাবে দেখতে, আপনি [টুডো তালিকা উদাহরণ](https://github.com/rrousselGit/riverpod/tree/master/examples/todos) এর সোর্স কোডটি দেখতে পারেন।
 
 :::info
 এই আচরণ [Provider] এর জন্য নির্দিষ্ট নয়, এবং সমস্ত প্রভাইডারের সাথে কাজ করে।

--- a/website/i18n/bn/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -169,7 +169,7 @@ final userProvider = FutureProvider.autoDispose.family<User, int>((ref, userId) 
 [inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
 [stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
 [ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/bn/docusaurus-plugin-content-docs/current/concepts/reading.mdx
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current/concepts/reading.mdx
@@ -400,7 +400,7 @@ final label = ref.watch(userProvider.select((user) => 'Mr ${user.name}'));
 [useprovider]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ref.watch(.html
 [elevatedbutton]: https://api.flutter.dev/flutter/material/ElevatedButton-class.html
 [streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [text]: https://api.flutter.dev/flutter/widgets/Text-class.html
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [future]: https://api.dart.dev/stable/2.13.4/dart-async/Future-class.html

--- a/website/i18n/bn/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -134,7 +134,7 @@ myProvider('12345').overrideWithValue(...));
 
 <CodeBlock>{trimSnippet(testFull)}</CodeBlock>
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
 [providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
 [futureprovider]: ../providers/future_provider

--- a/website/i18n/bn/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -25,7 +25,7 @@ import { trimSnippet } from "../../../../src/components/CodeSnippet";
 | ------------------------------ | ---------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | Flutter + [flutter_hooks]      | [hooks_riverpod]                                                                   | একইসাথে [flutter_hooks] এবং [Riverpod] ব্যবহার করতে পারবেন. |
 | Flutter uniquement             | [flutter_riverpod]                                                                 | ফ্লাটার এ [Riverpod] ব্যবহার করার একটি সহজ উপায়.            |
-| Dart uniquement (ফ্লাটার ছাড়া) | [riverpod](https://github.com/rrousselGit/river_pod/tree/master/packages/riverpod) | একটি [Riverpod] ভার্সন যেটিতে ফ্লাটার এর কোন ক্লাস নেই.               |
+| Dart uniquement (ফ্লাটার ছাড়া) | [riverpod](https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod) | একটি [Riverpod] ভার্সন যেটিতে ফ্লাটার এর কোন ক্লাস নেই.               |
 
 
 ## ইন্সটল প্রক্রিয়া
@@ -145,7 +145,7 @@ This will render "Hello world" in on your device.
 
 ![img](/img/snippets/greetingProvider.gif)
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/bn/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
@@ -4,7 +4,7 @@ title: ^0.13.0 to ^0.14.0
 
 
 রিভারপডের `0.14.0` সংস্করণ প্রকাশের সাথে সাথে, [StateNotifierProvider] ব্যবহারের সিনট্যাক্স পরিবর্তিত হয়েছে
-(ব্যাখ্যার জন্য https://github.com/rrousselGit/river_pod/issues/341 দেখুন)।
+(ব্যাখ্যার জন্য https://github.com/rrousselGit/riverpod/issues/341 দেখুন)।
 
 সম্পূর্ণ আর্টিকেলের জন্য, নিম্নলিখিত [StateNotifier] বিবেচনা করুন:
 

--- a/website/i18n/bn/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
@@ -83,7 +83,7 @@ import { trimSnippet } from "../../../../../src/components/CodeSnippet";
 এখানে ডার্টপ্যাডের সম্পূর্ণ উদাহরণ রয়েছেঃ
 
 <iframe
-  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=river_pod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
+  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=riverpod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
   style={{ border: 0, width: "100%", aspectRatio: "2/1.5" }}
 ></iframe>
 

--- a/website/i18n/bn/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
@@ -1,6 +1,6 @@
 // This code is distributed under the MIT License.
 // Copyright (c) 2022 Remi Rousselet.
-// You can find the original at https://github.com/rrousselGit/river_pod.
+// You can find the original at https://github.com/rrousselGit/riverpod.
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';

--- a/website/i18n/bn/docusaurus-theme-classic/footer.json
+++ b/website/i18n/bn/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/river_pod"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/riverpod"
   },
   "copyright": {
     "message": "কপিরাইট © 2021 Remi Rousselet. Docusaurus দিয়ে তৈরি",

--- a/website/i18n/de/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current.json
@@ -37,15 +37,15 @@
   },
   "sidebar.Sidebar.link.Counter": {
     "message": "Counter",
-    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/counter"
+    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/counter"
   },
   "sidebar.Sidebar.link.Todo list": {
     "message": "Todo list",
-    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/todos"
+    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/todos"
   },
   "sidebar.Sidebar.link.Marvel API": {
     "message": "Marvel API",
-    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/marvel"
+    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/marvel"
   },
   "sidebar.Sidebar.link.Android Launcher": {
     "message": "Android Launcher",

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -97,7 +97,7 @@ gefilterte Todo-Liste abzufragen. Mit diesem Ansatz wird das UI automatisch
 aktualisiert, wenn sich entweder der Filter oder die ToDo-Liste ändert.
 
 Um diesen Ansatz in Aktion zu sehen, können Sie sich den Quellcode hier anschauen [Todo List
-Beispiel](https://github.com/rrousselGit/river_pod/tree/master/examples/todos)
+Beispiel](https://github.com/rrousselGit/riverpod/tree/master/examples/todos)
 
 :::info
 Dieses Verhalten ist nicht spezifisch für [Provider], sondern funktioniert mit allen Providern.

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -169,7 +169,7 @@ Alternativ, kannst du dir auch das durchlesen [How to combine providers](/docs/c
 [inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
 [stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
 [ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/concepts/reading.mdx
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/concepts/reading.mdx
@@ -429,7 +429,7 @@ final label = ref.watch(userProvider.select((user) => 'Mr ${user.name}'));
 [useprovider]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ref.watch(.html
 [elevatedbutton]: https://api.flutter.dev/flutter/material/ElevatedButton-class.html
 [streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [text]: https://api.flutter.dev/flutter/widgets/Text-class.html
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [future]: https://api.dart.dev/stable/2.13.4/dart-async/Future-class.html

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -155,7 +155,7 @@ Abschließend finden Sie hier den vollständigen Code für unseren Flutter-Test.
 
 <CodeBlock>{trimSnippet(testFull)}</CodeBlock>
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
 [providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
 [futureprovider]: ../providers/future_provider

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -25,7 +25,7 @@ You can refer to the following table to help you decide which package to use:
 | ------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | Flutter + [flutter_hooks] | [hooks_riverpod]                                                                   | Erlaubt die Nutzung von beiden Paketen [flutter_hooks] und [Riverpod].        |
 | Flutter only              | [flutter_riverpod]                                                                 | Ein einfacher Weg um [Riverpod] in Flutter Applikationen zu verwenden.        |
-| Dart only (No Flutter)    | [riverpod](https://github.com/rrousselGit/river_pod/tree/master/packages/riverpod) | Eine [Riverpod] Version ohne die Flutter Klassen.                             |
+| Dart only (No Flutter)    | [riverpod](https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod) | Eine [Riverpod] Version ohne die Flutter Klassen.                             |
 
 ## Installation des Pakets
 
@@ -142,7 +142,7 @@ Wenn du `Flutter` und `Android Studio` oder `IntelliJ` verwendest, schau dir [Fl
 
 ![img](/img/snippets/greetingProvider.gif)
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
@@ -3,7 +3,7 @@ title: ^0.13.0 to ^0.14.0
 ---
 
 Mit der Veröffentlichung der Version `0.14.0` von Riverpod hat sich die Syntax für die Verwendung von [StateNotifierProvider] geändert
-(für weitere Erklärungen siehe: https://github.com/rrousselGit/river_pod/issues/341).
+(für weitere Erklärungen siehe: https://github.com/rrousselGit/riverpod/issues/341).
 
 Für den gesamten Artikel benutzen wir folgenden [StateNotifier]:
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
@@ -94,7 +94,7 @@ Produkte automatisch neu anzeigt, wenn sich der Sortierart ändert.
 Hier ist das vollständige Beispiel auf Dartpad:
 
 <iframe
-  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=river_pod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
+  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=riverpod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
   style={{ border: 0, width: "100%", aspectRatio: "2/1.5" }}
 ></iframe>
 

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
@@ -1,6 +1,6 @@
 // This code is distributed under the MIT License.
 // Copyright (c) 2022 Remi Rousselet.
-// You can find the original at https://github.com/rrousselGit/river_pod.
+// You can find the original at https://github.com/rrousselGit/riverpod.
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';

--- a/website/i18n/de/docusaurus-theme-classic/footer.json
+++ b/website/i18n/de/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/river_pod"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/riverpod"
   },
   "copyright": {
     "message": "Copyright © 2022 Remi Rousselet.<br /> Built with Docusaurus.",

--- a/website/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -33,15 +33,15 @@
   },
   "sidebar.Sidebar.link.Counter": {
     "message": "Contador",
-    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/counter"
+    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/counter"
   },
   "sidebar.Sidebar.link.Todo list": {
     "message": "Lista de Tareas",
-    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/todos"
+    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/todos"
   },
   "sidebar.Sidebar.link.Marvel API": {
     "message": "API de Marvel",
-    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/marvel"
+    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/marvel"
   },
   "sidebar.Sidebar.link.Android Launcher": {
     "message": "Android Launcher",

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -94,7 +94,7 @@ Una manera fácil de implementar tal escenario sería:
 Luego, nuestra interfaz de usuario puede escuchar a `filteredTodoListProvider` para escuchar la lista de tareas filtrada.
 Con este enfoque, la interfaz de usuario se actualizará automáticamente cuando cambie el filtro o la lista de tareas pendientes.
 
-Para ver este enfoque en acción, puede consultar el código fuente del ejemplo de [Lista de Tareas](https://github.com/rrousselGit/river_pod/tree/master/examples/todos).
+Para ver este enfoque en acción, puede consultar el código fuente del ejemplo de [Lista de Tareas](https://github.com/rrousselGit/riverpod/tree/master/examples/todos).
 
 :::info
 Este comportamiento no es específico de [Provider] y funciona con todos los providers.

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -163,7 +163,7 @@ Alternativamente, puede ver [Cómo combinar providers](/docs/concepts/combining_
 [inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
 [stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
 [ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/reading.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/concepts/reading.mdx
@@ -555,7 +555,7 @@ final label = ref.watch(userProvider.select((user) => 'Mr ${user.name}'));
 [useprovider]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ref.watch(.html
 [elevatedbutton]: https://api.flutter.dev/flutter/material/ElevatedButton-class.html
 [streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [text]: https://api.flutter.dev/flutter/widgets/Text-class.html
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [future]: https://api.dart.dev/stable/2.13.4/dart-async/Future-class.html

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -418,7 +418,7 @@ void main() {
 }
 ```
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
 [providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
 [futureprovider]: ../providers/future_provider

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -19,7 +19,7 @@ Puedes consultar la siguiente tabla para decidir qué paquete usar:
 | ------------------------------ | ---------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | Flutter + [flutter_hooks]      | [hooks_riverpod]                                                                   | Permite usar [flutter_hooks] y [Riverpod] juntos.              |
 | Solo Flutter                   | [flutter_riverpod]                                                                 | Una forma básica de usar [Riverpod] para aplicaciones Flutter. |
-| Solo Dart (Sin Flutter)        | [riverpod](https://github.com/rrousselGit/river_pod/tree/master/packages/riverpod) | [Riverpod] sin todas las clases dependientes de Flutter.       |
+| Solo Dart (Sin Flutter)        | [riverpod](https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod) | [Riverpod] sin todas las clases dependientes de Flutter.       |
 
 ## Instalación
 
@@ -219,7 +219,7 @@ Si usas `Flutter` y `Android Studio` o `IntelliJ`, considera usar [Flutter River
 
 ![img](/img/snippets/greetingProvider.gif)
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
@@ -3,7 +3,7 @@ title: ^0.13.0 a ^0.14.0
 ---
 
 Con el lanzamiento de la versión `0.14.0` de Riverpod, la sintaxis para usar [StateNotifierProvider] cambió
-(ve a https://github.com/rrousseGit/river_pod/issues/341 por la explicación).
+(ve a https://github.com/rrousseGit/riverpod/issues/341 por la explicación).
 
 
 Para ver todo el artículo, considere el siguiente [StateNotifier]:

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
@@ -127,7 +127,7 @@ automáticamente la lista de productos cuando cambia el tipo de clasificación.
 Aquí está el ejemplo completo en Dartpad:
 
 <iframe
-  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=river_pod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
+  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=riverpod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
   style={{ border: 0, width: "100%", aspectRatio: "2/1.5" }}
 ></iframe>
 

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
@@ -1,6 +1,6 @@
 // This code is distributed under the MIT License.
 // Copyright (c) 2022 Remi Rousselet.
-// You can find the original at https://github.com/rrousselGit/river_pod.
+// You can find the original at https://github.com/rrousselGit/riverpod.
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';

--- a/website/i18n/es/docusaurus-theme-classic/footer.json
+++ b/website/i18n/es/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/river_pod"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/riverpod"
   },
   "copyright": {
     "message": "Derechos de autor © 2022 Remi Rousselet. <br /> Construido con Docusaurus.",

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current.json
@@ -33,15 +33,15 @@
   },
   "sidebar.Sidebar.link.Counter": {
     "message": "Compteur",
-    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/counter"
+    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/counter"
   },
   "sidebar.Sidebar.link.Todo list": {
     "message": "Liste de taches",
-    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/todos"
+    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/todos"
   },
   "sidebar.Sidebar.link.Marvel API": {
     "message": "Marvel API",
-    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/marvel"
+    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/marvel"
   },
   "sidebar.Sidebar.link.Android Launcher": {
     "message": "Android Launcher",

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -97,7 +97,7 @@ En utilisant cette approche, l'interface sera automatiquement mise à jour lorsq
 la liste de tâches changera. ou la todo-list change.
 
 Pour voir cette approche en action, vous pouvez consulter le code source de 
-[exemple de Todo List](https://github.com/rrousselGit/river_pod/tree/master/examples/todos).
+[exemple de Todo List](https://github.com/rrousselGit/riverpod/tree/master/examples/todos).
 
 :::info
 Ce comportement n'est pas spécifique à [Provider], et fonctionne avec tous les providers.

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -172,7 +172,7 @@ Alternativement, vous pouvez lire [Comment combiner des providers](/docs/concept
 [inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
 [stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
 [ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/reading.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/reading.mdx
@@ -424,7 +424,7 @@ final label = ref.watch(userProvider.select((user) => 'Mr ${user.name}'));
 [useprovider]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ref.watch(.html
 [elevatedbutton]: https://api.flutter.dev/flutter/material/ElevatedButton-class.html
 [streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [text]: https://api.flutter.dev/flutter/widgets/Text-class.html
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [future]: https://api.dart.dev/stable/2.13.4/dart-async/Future-class.html

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -402,7 +402,7 @@ void main() {
 }
 ```
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
 [providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
 [futureprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/FutureProvider-class.html

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -19,7 +19,7 @@ Pour choisir, vous pouvez vous référer au tableau suivant:
 | ------------------------------ | ---------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | Flutter + [flutter_hooks]      | [hooks_riverpod]                                                                   | Permet d'utiliser [flutter_hooks] et [Riverpod] en même temps. |
 | Flutter uniquement             | [flutter_riverpod]                                                                 | Une librarie pour utiliser [Riverpod] avec Flutter.            |
-| Dart uniquement (Sans Flutter) | [riverpod](https://github.com/rrousselGit/river_pod/tree/master/packages/riverpod) | Le core de [Riverpod] sans dépendence à Flutter.               |
+| Dart uniquement (Sans Flutter) | [riverpod](https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod) | Le core de [Riverpod] sans dépendence à Flutter.               |
 
 ## Installation
 
@@ -226,7 +226,7 @@ Si vous utilisez `Flutter` et `Android Studio`/`IntelliJ`, considérez l'install
 
 ![img](/img/snippets/greetingProvider.gif)
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
@@ -3,7 +3,7 @@ title: ^0.13.0 vers ^0.14.0
 ---
 
 Avec la sortie de la version `0.14.0` de Riverpod, la syntaxe d'utilisation de [StateNotifierProvider] a changé.  
-(voir https://github.com/rrousselGit/river_pod/issues/341 pour l'explication).
+(voir https://github.com/rrousselGit/riverpod/issues/341 pour l'explication).
 
 Pour l'ensemble de l'article, considérez ce qui suit [StateNotifier] :
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
@@ -92,7 +92,7 @@ re-affiche la liste des produits lorsque le type de tri change.
 Voici l'exemple complet sur Dartpad :
 
 <iframe
-  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=river_pod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
+  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=riverpod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
   style={{ border: 0, width: "100%", aspectRatio: "2/1.5" }}
 ></iframe>
 

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
@@ -1,6 +1,6 @@
 // This code is distributed under the MIT License.
 // Copyright (c) 2022 Remi Rousselet.
-// You can find the original at https://github.com/rrousselGit/river_pod.
+// You can find the original at https://github.com/rrousselGit/riverpod.
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';

--- a/website/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/website/i18n/fr/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/river_pod"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/riverpod"
   },
   "copyright": {
     "message": "Copyright © 2021 Remi Rousselet. Construit avec Docusaurus.",

--- a/website/i18n/it/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current.json
@@ -33,15 +33,15 @@
   },
   "sidebar.Sidebar.link.Counter": {
     "message": "Contatore",
-    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/counter"
+    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/counter"
   },
   "sidebar.Sidebar.link.Todo list": {
     "message": "Lista Cose da fare",
-    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/todos"
+    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/todos"
   },
   "sidebar.Sidebar.link.Marvel API": {
     "message": "API Marvel",
-    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/marvel"
+    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/marvel"
   },
   "sidebar.Sidebar.link.Android Launcher": {
     "message": "Launcher Android",

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -97,7 +97,7 @@ la todo-list filtrata.
 Con questo approccio, l'UI si aggiornerà automaticamente quando o il filtro o la 
 todo-list cambia.
 
-Per vedere in azione questo approccio puoi guardare il codice sorgente dell'[esempio Todo List](https://github.com/rrousselGit/river_pod/tree/master/examples/todos).
+Per vedere in azione questo approccio puoi guardare il codice sorgente dell'[esempio Todo List](https://github.com/rrousselGit/riverpod/tree/master/examples/todos).
 
 :::info
 Questo comportamento non è specifico di [Provider] e funziona con tutti i tipi provider.

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -163,7 +163,7 @@ In alternativa, puoi vedere [Come combinare i provider](/docs/concepts/combining
 [inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
 [stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
 [ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/concepts/reading.mdx
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/concepts/reading.mdx
@@ -410,7 +410,7 @@ final label = ref.watch(userProvider.select((user) => 'Mr ${user.name}'));
 [useprovider]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ref.watch(.html
 [elevatedbutton]: https://api.flutter.dev/flutter/material/ElevatedButton-class.html
 [streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [text]: https://api.flutter.dev/flutter/widgets/Text-class.html
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [future]: https://api.dart.dev/stable/2.13.4/dart-async/Future-class.html

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -150,7 +150,7 @@ Riassumendo, di seguito l'intero codice per il nostro Flutter test.
 
 <CodeBlock>{trimSnippet(testFull)}</CodeBlock>
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
 [providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
 [futureprovider]: ../providers/future_provider

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -19,7 +19,7 @@ Fai riferimento alla seguente tabella per decidere quale pacchetto installare:
 | ------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | Flutter + [flutter_hooks] | [hooks_riverpod]                                                                   | Permette l'utilizzo di entrambi [flutter_hooks] e [Riverpod] insieme.  |
 | Solo Flutter              | [flutter_riverpod]                                                                 | Per utilizzare [Riverpod] per App Flutter                              |
-| Solo Dart (No Flutter)    | [riverpod](https://github.com/rrousselGit/river_pod/tree/master/packages/riverpod) | Versione di [Riverpod] con tutte le classi collegate a Flutter rimosse |
+| Solo Dart (No Flutter)    | [riverpod](https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod) | Versione di [Riverpod] con tutte le classi collegate a Flutter rimosse |
 
 ## Installare il pacchetto
 
@@ -231,7 +231,7 @@ Segui un cookbook:
 
 - [Come testare i provider](/docs/cookbooks/testing)
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
@@ -3,7 +3,7 @@ title: da ^0.13.0 a ^0.14.0
 ---
 
 Con il rilascio della versione `0.14.0` di Riverpod, la sintassi per usare [StateNotifierProvider] è cambiata.  
-(vedere https://github.com/rrousselGit/river_pod/issues/341 per la spiegazione).
+(vedere https://github.com/rrousselGit/riverpod/issues/341 per la spiegazione).
 
 Per l'intero articolo, considera leggere [StateNotifier]:
 

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
@@ -95,7 +95,7 @@ ri-renderizzi automaticamente la lista dei prodotti quando il tipo di ordinament
 Di seguito l'esempio completo su Dartpad:
 
 <iframe
-  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=river_pod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
+  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=riverpod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
   style={{ border: 0, width: "100%", aspectRatio: "2/1.5" }}
 ></iframe>
 

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
@@ -1,6 +1,6 @@
 // This code is distributed under the MIT License.
 // Copyright (c) 2022 Remi Rousselet.
-// You can find the original at https://github.com/rrousselGit/river_pod.
+// You can find the original at https://github.com/rrousselGit/riverpod.
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';

--- a/website/i18n/it/docusaurus-theme-classic/footer.json
+++ b/website/i18n/it/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/river_pod"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/riverpod"
   },
   "copyright": {
     "message": "Copyright © 2021 Remi Rousselet. Creato con Docusaurus.",

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current.json
@@ -33,15 +33,15 @@
   },
   "sidebar.Sidebar.link.Counter": {
     "message": "カウンターアプリ",
-    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/counter"
+    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/counter"
   },
   "sidebar.Sidebar.link.Todo list": {
     "message": "Todo アプリ",
-    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/todos"
+    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/todos"
   },
   "sidebar.Sidebar.link.Marvel API": {
     "message": "マーベル API",
-    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/marvel"
+    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/marvel"
   },
   "sidebar.Sidebar.link.Android Launcher": {
     "message": "Android ランチャー",

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -88,7 +88,7 @@ final todoListProvider = StateNotifierProvider((ref) => TodoList());
 これで UI 側にこの `filteredTodoListProvider` を監視させることで、その値の変化に応じて Todo リストを表示することができるようになりました。
 フィルタの種類もしくは Todo リストの内容が変われば、UI も自動的に再構築されます。
 
-この手法を使って作成された Todo アプリのサンプルコードは[こちら](https://github.com/rrousselGit/river_pod/tree/master/examples/todos)でご覧いただけます。
+この手法を使って作成された Todo アプリのサンプルコードは[こちら](https://github.com/rrousselGit/riverpod/tree/master/examples/todos)でご覧いただけます。
 
 :::info
 依存するプロバイダの値が変わると自動で値が再評価されるプロバイダは [Provider] だけではありません。

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -147,7 +147,7 @@ final userProvider = FutureProvider.autoDispose.family<User, int>((ref, userId) 
 [inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
 [stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
 [ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/reading.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/reading.mdx
@@ -376,7 +376,7 @@ final label = ref.watch(userProvider.select((user) => 'Mr ${user.name}'));
 [useprovider]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ref.watch(.html
 [elevatedbutton]: https://api.flutter.dev/flutter/material/ElevatedButton-class.html
 [streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [text]: https://api.flutter.dev/flutter/widgets/Text-class.html
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [future]: https://api.dart.dev/stable/2.13.4/dart-async/Future-class.html

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -138,7 +138,7 @@ myProvider('12345').overrideWithValue(...));
 
 <CodeBlock>{trimSnippet(testFull)}</CodeBlock>
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
 [providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
 [futureprovider]: ../providers/future_provider

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -24,7 +24,7 @@ import { trimSnippet } from "../../../../src/components/CodeSnippet";
 | ----------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------- |
 | Flutter のみ                   | [flutter_riverpod]                                                                 | Flutter アプリで [Riverpod] を使用する場合の基本のパッケージ。 |
 | Flutter + [flutter_hooks]     | [hooks_riverpod]                                                                   | [flutter_hooks] と [Riverpod] を併用する場合のパッケージ。   |
-| Dart のみ（Flutter は使用しない） | [riverpod](https://github.com/rrousselGit/river_pod/tree/master/packages/riverpod) | Flutter 関連のクラスをすべて除いた [Riverpod] パッケージ。    |
+| Dart のみ（Flutter は使用しない） | [riverpod](https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod) | Flutter 関連のクラスをすべて除いた [Riverpod] パッケージ。    |
 
 ## パッケージのインストール方法
 
@@ -154,7 +154,7 @@ export const foo = 42;
 
 - [プロバイダのテストについて](/docs/cookbooks/testing)
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
@@ -3,7 +3,7 @@ title: ^0.13.0 → ^0.14.0
 ---
 
 Riverpod ではバージョン `0.14.0` のリリースより [StateNotifierProvider]
-を使用する際の構文が変わりました（変更の背景についての詳細は https://github.com/rrousselGit/river_pod/issues/341 をご覧ください）。
+を使用する際の構文が変わりました（変更の背景についての詳細は https://github.com/rrousselGit/riverpod/issues/341 をご覧ください）。
 
 本セクションでは次の [StateNotifier] を使用して説明します。
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
@@ -89,7 +89,7 @@ import { trimSnippet } from "../../../../../src/components/CodeSnippet";
 本サンプルコードのフルバージョンです。
 
 <iframe
-  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=river_pod&gh_path=website%2Fi18n%2Fja%2Fdocusaurus-plugin-content-docs%2Fcurrent%2Fproviders%2Fstate_provider"
+  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=riverpod&gh_path=website%2Fi18n%2Fja%2Fdocusaurus-plugin-content-docs%2Fcurrent%2Fproviders%2Fstate_provider"
   style={{ border: 0, width: "100%", aspectRatio: "2/1.5" }}
 ></iframe>
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
@@ -1,6 +1,6 @@
 // This code is distributed under the MIT License.
 // Copyright (c) 2022 Remi Rousselet.
-// You can find the original at https://github.com/rrousselGit/river_pod.
+// You can find the original at https://github.com/rrousselGit/riverpod.
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';

--- a/website/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/website/i18n/ja/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/river_pod"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/riverpod"
   },
   "link.item.label.Code of conduct": {
     "message": "行動規範",

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current.json
@@ -33,15 +33,15 @@
   },
   "sidebar.Sidebar.link.Counter": {
     "message": "카운터 앱",
-    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/counter"
+    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/counter"
   },
   "sidebar.Sidebar.link.Todo list": {
     "message": "Todo 앱",
-    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/todos"
+    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/todos"
   },
   "sidebar.Sidebar.link.Marvel API": {
     "message": "Marvel API",
-    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/river_pod/tree/master/examples/marvel"
+    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/marvel"
   },
   "sidebar.Sidebar.link.Android Launcher": {
     "message": "Android Launcher",

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -93,7 +93,7 @@ final todoListProvider = StateNotifierProvider((ref) => TodoList());
 필터와 할일 목록이 각각 갱신(변경)될때 마다 자동적으로 UI 업데이트가 이루어 집니다.  
 
 이러한 방법으로 접근한 애플리케이션 샘플은 [Todo List
-example](https://github.com/rrousselGit/river_pod/tree/master/examples/todos)에서 확인해 볼 수 있습니다.
+example](https://github.com/rrousselGit/riverpod/tree/master/examples/todos)에서 확인해 볼 수 있습니다.
 
 :::info
 이 행위는 [Provider]에 국한되지 않습니다. 그리고 모든 프로바이더에 적용하여 사용 가능합니다. 

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -166,7 +166,7 @@ final userProvider = FutureProvider.autoDispose.family<User, int>((ref, userId) 
 [inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
 [stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
 [ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/reading.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/reading.mdx
@@ -399,7 +399,7 @@ final label = ref.watch(userProvider.select((user) => 'Mr ${user.name}'));
 [useprovider]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ref.watch(.html
 [elevatedbutton]: https://api.flutter.dev/flutter/material/ElevatedButton-class.html
 [streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [text]: https://api.flutter.dev/flutter/widgets/Text-class.html
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [future]: https://api.dart.dev/stable/2.13.4/dart-async/Future-class.html

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -136,7 +136,7 @@ myProvider('12345').overrideWithValue(...));
 
 <CodeBlock>{trimSnippet(testFull)}</CodeBlock>
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
 [providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
 [futureprovider]: ../providers/future_provider

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/getting_started.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/getting_started.mdx
@@ -24,7 +24,7 @@ import { trimSnippet } from "../../../../src/components/CodeSnippet";
 | ----------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------   |
 | Flutter + [flutter_hooks]     | [hooks_riverpod]                                                                   | [flutter_hooks] 과 [Riverpod]을 함께 병용한 패키지          |
 | Flutter                       | [flutter_riverpod]                                                                 | Flutter 앱에 [Riverpod] 을 사용할 경우의 기본 패키지         |
-| Dart（Flutter 사용안함）       | [riverpod](https://github.com/rrousselGit/river_pod/tree/master/packages/riverpod) | Flutter 에 관련된 모든 클래스가 완전제거된  [Riverpod] 패키지 |
+| Dart（Flutter 사용안함）       | [riverpod](https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod) | Flutter 에 관련된 모든 클래스가 완전제거된  [Riverpod] 패키지 |
 
 ## 패키지 설치 방법
 
@@ -143,7 +143,7 @@ export const foo = 42;
 
 ![img](/img/snippets/greetingProvider.gif)
 
-[riverpod]: https://github.com/rrousselgit/river_pod
+[riverpod]: https://github.com/rrousselgit/riverpod
 [hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
 [flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
 [flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
@@ -3,7 +3,7 @@ title: ^0.13.0 to ^0.14.0
 ---
 
 With the release of version `0.14.0` of Riverpod, the syntax for using [StateNotifierProvider] changed
-(see https://github.com/rrousselGit/river_pod/issues/341 for the explanation).
+(see https://github.com/rrousselGit/riverpod/issues/341 for the explanation).
 
 For the entire article, consider the following [StateNotifier]:
 

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
@@ -94,7 +94,7 @@ re-render the list of products when the sort type changes.
 Here is the complete example on Dartpad:
 
 <iframe
-  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=river_pod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
+  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=riverpod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
   style={{ border: 0, width: "100%", aspectRatio: "2/1.5" }}
 ></iframe>
 

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
@@ -1,6 +1,6 @@
 // This code is distributed under the MIT License.
 // Copyright (c) 2022 Remi Rousselet.
-// You can find the original at https://github.com/rrousselGit/river_pod.
+// You can find the original at https://github.com/rrousselGit/riverpod.
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';

--- a/website/i18n/ko/docusaurus-theme-classic/footer.json
+++ b/website/i18n/ko/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/river_pod"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/riverpod"
   },
   "copyright": {
     "message": "Copyright © 2021 Remi Rousselet.<br /> Built with Docusaurus.",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -41,17 +41,17 @@ module.exports = {
         {
           type: "link",
           label: "Counter",
-          href: "https://github.com/rrousselGit/river_pod/tree/master/examples/counter",
+          href: "https://github.com/rrousselGit/riverpod/tree/master/examples/counter",
         },
         {
           type: "link",
           label: "Todo list",
-          href: "https://github.com/rrousselGit/river_pod/tree/master/examples/todos",
+          href: "https://github.com/rrousselGit/riverpod/tree/master/examples/todos",
         },
         {
           type: "link",
           label: "Marvel API",
-          href: "https://github.com/rrousselGit/river_pod/tree/master/examples/marvel",
+          href: "https://github.com/rrousselGit/riverpod/tree/master/examples/marvel",
         },
       ],
     },


### PR DESCRIPTION
Repository name was renamed to `riverpod` from `river_pod`, so it is better to follow all the parts that are river_pod, even though GitHub has a redirect function.

This will also prevent bugs like #1556.