### PR TITLE
Add some additional lints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ lib/generated_plugin_registrant.dart
 
 # Exceptions to above rules.
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+.vscode/settings.json

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,6 +61,7 @@
 
 ## Devtool:
 
+- "what caused a widget to rebuild?"
 - entire app state for the root `ProviderContainer`
 - highlight state changes
 - Show the number of widgets that rebuilt in the same frame than the state change

--- a/examples/counter/analysis_options.yaml
+++ b/examples/counter/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  # plugins:
+  #   - custom_lint

--- a/examples/counter/pubspec.yaml
+++ b/examples/counter/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
     path: ../../packages/riverpod
 
 dev_dependencies:
-  custom_lint: ^0.0.6
+  custom_lint: ^0.0.7
   riverpod_lint:
     path: ../../packages/riverpod_lint
   flutter_test:

--- a/examples/counter/pubspec.yaml
+++ b/examples/counter/pubspec.yaml
@@ -20,6 +20,9 @@ dependencies:
     path: ../../packages/riverpod
 
 dev_dependencies:
+  custom_lint: 0.0.3
+  riverpod_lint:
+    path: ../../packages/riverpod_lint
   flutter_test:
     sdk: flutter
 

--- a/examples/counter/pubspec.yaml
+++ b/examples/counter/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
     path: ../../packages/riverpod
 
 dev_dependencies:
-  custom_lint: 0.0.3
+  custom_lint: ^0.0.6
   riverpod_lint:
     path: ../../packages/riverpod_lint
   flutter_test:

--- a/examples/marvel/lib/src/marvel.dart
+++ b/examples/marvel/lib/src/marvel.dart
@@ -20,7 +20,7 @@ part 'marvel.g.dart';
 
 final dioProvider = Provider((ref) => Dio());
 
-const repositoryProvider = Provider(MarvelRepository.new);
+final repositoryProvider = Provider((ref) => MarvelRepository(ref));
 
 class MarvelRepository {
   MarvelRepository(

--- a/examples/marvel/lib/src/marvel.dart
+++ b/examples/marvel/lib/src/marvel.dart
@@ -20,7 +20,7 @@ part 'marvel.g.dart';
 
 final dioProvider = Provider((ref) => Dio());
 
-final repositoryProvider = Provider((ref) => MarvelRepository(ref));
+const repositoryProvider = Provider(MarvelRepository.new);
 
 class MarvelRepository {
   MarvelRepository(

--- a/packages/flutter_riverpod/example/lib/main.dart
+++ b/packages/flutter_riverpod/example/lib/main.dart
@@ -23,6 +23,8 @@ class MyApp extends StatelessWidget {
 final counterProvider = StateProvider((ref) => 0);
 
 class Home extends ConsumerWidget {
+  Home({super.key});
+  
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(

--- a/packages/flutter_riverpod/example/lib/main.dart
+++ b/packages/flutter_riverpod/example/lib/main.dart
@@ -15,7 +15,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(home: Home());
+    return const MaterialApp(home: Home());
   }
 }
 
@@ -23,8 +23,8 @@ class MyApp extends StatelessWidget {
 final counterProvider = StateProvider((ref) => 0);
 
 class Home extends ConsumerWidget {
-  Home({super.key});
-  
+  const Home({super.key});
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(

--- a/packages/flutter_riverpod/example/pubspec.yaml
+++ b/packages/flutter_riverpod/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   cupertino_icons: ^0.1.3

--- a/packages/riverpod/example/lib/models.dart
+++ b/packages/riverpod/example/lib/models.dart
@@ -45,6 +45,9 @@ class Repository {
         'hash': hash,
       },
     );
+    if (result.data == null) {
+      return [];
+    }
     final response = MarvelResponse.fromJson(result.data!);
 
     return response //

--- a/packages/riverpod/example/pubspec.yaml
+++ b/packages/riverpod/example/pubspec.yaml
@@ -3,13 +3,13 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   crypto: ^3.0.0
+  dio: ^4.0.0
+  freezed_annotation: ^2.0.0
   json_annotation: ^4.6.0
-  dio: ^4.0.6
-  freezed_annotation: ^2.1.0
   riverpod:
     path: ..
 

--- a/packages/riverpod/example/pubspec.yaml
+++ b/packages/riverpod/example/pubspec.yaml
@@ -7,14 +7,14 @@ environment:
 
 dependencies:
   crypto: ^3.0.0
-  dio: ^4.0.0
-  freezed_annotation: ^2.0.0
   json_annotation: ^4.6.0
+  dio: ^4.0.6
+  freezed_annotation: ^2.1.0
   riverpod:
     path: ..
 
 dev_dependencies:
   build_runner: ^2.0.0
-  freezed: ^2.0.0
+  freezed: ^2.1.0+1
   json_serializable: ^6.3.0
   test: ^1.16.0

--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -12,28 +12,23 @@ export 'package:state_notifier/state_notifier.dart' hide Listener, LocatorMixin;
 export 'src/common.dart' hide AsyncTransition;
 
 export 'src/framework.dart'
-    show
-        Create,
-        // ignore: deprecated_member_use_from_same_package
-        Reader,
-        AlwaysAliveProviderBase,
-        Family,
-        CircularDependencyError,
-        ProviderBase,
-        Override,
-        AutoDisposeRef,
-        Ref,
-        ProviderListenable,
-        ProviderContainer,
-        ProviderObserver,
-        ProviderSubscription,
-        AutoDisposeProviderBase,
-        AutoDisposeProviderElementBase,
-        ProviderElementBase,
-        ProviderOverride,
+    hide
+        FamilyCreate,
+        AsyncSelector,
+        FamilyBase,
+        AutoDisposeProviderElementMixin,
         FamilyOverride,
+        NotifierFamilyBase,
+        SetupFamilyOverride,
         SetupOverride,
-        AlwaysAliveProviderListenable;
+        AutoDisposeNotifierFamilyBase,
+        ProviderOverride,
+        AutoDisposeFamilyBase,
+        AlwaysAliveAsyncSelector,
+        handleFireImmediately,
+        Create,
+        Node,
+        ProviderElementProxy;
 
 export 'src/future_provider.dart';
 

--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -12,23 +12,28 @@ export 'package:state_notifier/state_notifier.dart' hide Listener, LocatorMixin;
 export 'src/common.dart' hide AsyncTransition;
 
 export 'src/framework.dart'
-    hide
-        FamilyCreate,
-        AsyncSelector,
-        FamilyBase,
-        AutoDisposeProviderElementMixin,
-        FamilyOverride,
-        NotifierFamilyBase,
-        SetupFamilyOverride,
-        SetupOverride,
-        AutoDisposeNotifierFamilyBase,
-        ProviderOverride,
-        AutoDisposeFamilyBase,
-        AlwaysAliveAsyncSelector,
-        handleFireImmediately,
+    show
         Create,
-        Node,
-        ProviderElementProxy;
+        // ignore: deprecated_member_use_from_same_package
+        Reader,
+        AlwaysAliveProviderBase,
+        Family,
+        CircularDependencyError,
+        ProviderBase,
+        Override,
+        AutoDisposeRef,
+        Ref,
+        ProviderListenable,
+        ProviderContainer,
+        ProviderObserver,
+        ProviderSubscription,
+        AutoDisposeProviderBase,
+        AutoDisposeProviderElementBase,
+        ProviderElementBase,
+        ProviderOverride,
+        FamilyOverride,
+        SetupOverride,
+        AlwaysAliveProviderListenable;
 
 export 'src/future_provider.dart';
 

--- a/packages/riverpod/pubspec.yaml
+++ b/packages/riverpod/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   state_notifier: ^0.7.0
 
 dev_dependencies:
+  analyzer: ^4.6.0
   build_runner: ^2.0.0
   expect_error: ^1.0.0
   mockito: ^5.0.0

--- a/packages/riverpod_lint/analysis_options.yaml
+++ b/packages/riverpod_lint/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../../analysis_options.yaml
+linter:
+  rules:
+    # Riverpod_lint has no public API
+    public_member_api_docs: false

--- a/packages/riverpod_lint/bin/custom_lint.dart
+++ b/packages/riverpod_lint/bin/custom_lint.dart
@@ -301,7 +301,7 @@ class RiverpodVisitor extends AsyncRecursiveVisitor<Lint>
       for (final expectedDependency in expectedDependencies) {
         if (!actualDependencies.contains(expectedDependency.origin)) {
           yield Lint(
-            code: 'riverpod_extra_dependency',
+            code: 'riverpod_unused_dependency',
             message:
                 'This provider specifies that it depends on "${expectedDependency.origin.name}" '
                 'yet it never uses that provider.',

--- a/packages/riverpod_lint/bin/custom_lint.dart
+++ b/packages/riverpod_lint/bin/custom_lint.dart
@@ -1,0 +1,261 @@
+import 'dart:isolate';
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:collection/collection.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:riverpod_lint/src/type_checker.dart';
+
+const _providerBase = TypeChecker.fromRuntime(ProviderBase);
+const _family = TypeChecker.fromRuntime(Family);
+const _providerOrFamily = TypeChecker.any([_providerBase, _family]);
+
+const _widget =
+    TypeChecker.fromUrl('package:flutter/src/widgets/framework.dart#Widget');
+
+const _widgetRef =
+    TypeChecker.fromUrl('package:flutter_riverpod/src/consumer.dart#WidgetRef');
+
+const _consumerWidget = TypeChecker.fromUrl(
+  'package:flutter_riverpod/src/consumer.dart#ConsumerWidget',
+);
+const _consumerState = TypeChecker.fromUrl(
+  'package:flutter_riverpod/src/consumer.dart#ConsumerState',
+);
+const _ref = TypeChecker.fromRuntime(Ref);
+
+void main(List<String> args, SendPort sendPort) {
+  startPlugin(sendPort, _RiverpodLint());
+}
+
+class _RiverpodLint extends PluginBase {
+  @override
+  Iterable<Lint> getLints(ResolvedUnitResult unit) {
+    final visitor = ProviderVisitor(unit);
+    unit.unit.accept(visitor);
+
+    return visitor.lints;
+  }
+}
+
+class ProviderVisitor extends RecursiveAstVisitor<void> {
+  ProviderVisitor(this.unit);
+
+  final ResolvedUnitResult unit;
+  final lints = <Lint>[];
+
+  void visitRefInvocation(MethodInvocation node) {
+    bool? _isWithinBuild() {
+      var hasFoundFunctionExpression = false;
+
+      for (final parent in node.parents) {
+        if (parent is FunctionExpression) {
+          if (hasFoundFunctionExpression) return false;
+
+          if (parent.isWidgetBuilder ?? false) {
+            return true;
+          }
+
+          // Since anonymous functions could be the build of a provider,
+          // we need to check their ancestors for more information.
+          hasFoundFunctionExpression = true;
+        }
+        if (parent is InstanceCreationExpression) {
+          return parent.isProviderCreation;
+        }
+        if (parent is FunctionExpressionInvocation) {
+          return parent.isProviderCreation;
+        }
+        if (parent is MethodDeclaration) {
+          if (hasFoundFunctionExpression || parent.name.name != 'build') {
+            return false;
+          }
+
+          final classElement = parent.parents
+              .whereType<ClassDeclaration>()
+              .firstOrNull
+              ?.declaredElement;
+
+          if (classElement == null) return null;
+          return _consumerWidget.isAssignableFrom(classElement) ||
+              _consumerState.isAssignableFrom(classElement);
+        }
+      }
+      return false;
+    }
+
+    // Whther the invocation is inside or ouside the build method of a provider/widget
+    // Null if unknown
+    late final isWithinBuild = _isWithinBuild();
+
+    switch (node.methodName.name) {
+      case 'read':
+        if (isWithinBuild ?? false) {
+          lints.add(
+            Lint(
+              code: 'riverpod_avoid_read_inside_build',
+              message:
+                  'Avoid using ref.read inside the build method of widgets/providers.',
+              location: LintLocation.fromOffsets(
+                offset: node.offset,
+                length: node.length,
+              ),
+            ),
+          );
+        }
+        break;
+      case 'watch':
+        if (isWithinBuild == false) {
+          lints.add(
+            Lint(
+              code: 'riverpod_avoid_watch_outside_build',
+              message:
+                  'Avoid using ref.watch outside the build method of widgets/providers.',
+              location: LintLocation.fromOffsets(
+                offset: node.offset,
+                length: node.length,
+              ),
+            ),
+          );
+        }
+        break;
+      default:
+    }
+  }
+
+  void visitProviderCreation(AstNode providerNode) {
+    final declaration =
+        providerNode.parents.whereType<VariableDeclaration>().firstOrNull;
+    final variable = declaration?.declaredElement;
+
+    if (variable == null) {
+      lints.add(
+        Lint(
+          code: 'riverpod_final_provider',
+          message: 'Providers should always be declared as final',
+          location: LintLocation.fromOffsets(
+            offset: providerNode.offset,
+            length: providerNode.length,
+          ),
+        ),
+      );
+      return;
+    }
+
+    final isGlobal = declaration!.parents.any((element) =>
+        element is TopLevelVariableDeclaration ||
+        (element is FieldDeclaration && element.isStatic));
+
+    if (!isGlobal) {
+      lints.add(
+        Lint(
+          code: 'riverpod_avoid_dynamic_provider',
+          message:
+              'Providers should be either top level variables or static properties',
+          location: LintLocation.fromOffsets(
+            offset: variable.nameOffset,
+            length: variable.nameLength,
+          ),
+        ),
+      );
+    }
+
+    if (!variable.isFinal) {
+      lints.add(
+        Lint(
+          code: 'riverpod_final_provider',
+          message: 'Providers should always be declared as final',
+          location: LintLocation.fromOffsets(
+            offset: variable.nameOffset,
+            length: variable.nameLength,
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    super.visitMethodInvocation(node);
+    final targetType = node.target?.staticType?.element;
+    if (targetType == null) return;
+
+    if (_ref.isAssignableFrom(targetType) ||
+        _widgetRef.isAssignableFrom(targetType)) {
+      visitRefInvocation(node);
+    }
+  }
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    super.visitFunctionExpressionInvocation(node);
+
+    if (node.isProviderCreation ?? false) {
+      visitProviderCreation(node);
+    }
+  }
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    super.visitClassDeclaration(node);
+
+    final classElement = node.declaredElement;
+    if (classElement == null) return;
+  }
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    super.visitInstanceCreationExpression(node);
+
+    final createdType = node.staticType?.element;
+    if (createdType == null) return;
+
+    if (_providerOrFamily.isAssignableFrom(createdType)) {
+      visitProviderCreation(node);
+    }
+  }
+}
+
+extension on AstNode {
+  Iterable<AstNode> get parents sync* {
+    for (var node = parent; node != null; node = node.parent) {
+      yield node;
+    }
+  }
+}
+
+extension on FunctionExpressionInvocation {
+  /// Null if unknown
+  bool? get isProviderCreation {
+    final returnType = staticType?.element;
+    if (returnType == null) return null;
+
+    final function = this.function;
+
+    return _providerOrFamily.isAssignableFrom(returnType) &&
+        function is PropertyAccess &&
+        (function.propertyName.name == 'autoDispose' ||
+            function.propertyName.name == 'family');
+  }
+}
+
+extension on FunctionExpression {
+  bool? get isWidgetBuilder {
+    final returnType = declaredElement?.returnType.element;
+    if (returnType == null) return null;
+
+    return _widget.isAssignableFrom(returnType);
+  }
+}
+
+extension on InstanceCreationExpression {
+  /// Null if unknown
+  bool? get isProviderCreation {
+    final type = staticType?.element;
+    if (type == null) return null;
+
+    return _providerOrFamily.isAssignableFrom(type);
+  }
+}

--- a/packages/riverpod_lint/bin/custom_lint.dart
+++ b/packages/riverpod_lint/bin/custom_lint.dart
@@ -37,10 +37,10 @@ const _ref = TypeChecker.fromRuntime(Ref);
 const _refBinders = {'read', 'watch', 'listen'};
 
 void main(List<String> args, SendPort sendPort) {
-  startPlugin(sendPort, _RiverpodLint());
+  startPlugin(sendPort, RiverpodLint());
 }
 
-class _RiverpodLint extends PluginBase {
+class RiverpodLint extends PluginBase {
   @override
   Stream<Lint> getLints(ResolvedUnitResult unit) {
     final visitor = RiverpodVisitor(unit);

--- a/packages/riverpod_lint/bin/custom_lint.dart
+++ b/packages/riverpod_lint/bin/custom_lint.dart
@@ -242,6 +242,7 @@ extension on FunctionExpressionInvocation {
 }
 
 extension on FunctionExpression {
+  /// Null if unknown
   bool? get isWidgetBuilder {
     final returnType = declaredElement?.returnType.element;
     if (returnType == null) return null;

--- a/packages/riverpod_lint/bin/custom_lint.dart
+++ b/packages/riverpod_lint/bin/custom_lint.dart
@@ -1,12 +1,14 @@
+import 'dart:async';
 import 'dart:isolate';
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:collection/collection.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:meta/meta.dart';
 import 'package:riverpod/riverpod.dart';
+import 'package:riverpod_lint/src/analyzer_utils.dart';
 import 'package:riverpod_lint/src/type_checker.dart';
 
 const _providerBase = TypeChecker.fromRuntime(ProviderBase);
@@ -28,41 +30,50 @@ const _consumerState = TypeChecker.fromName(
 );
 const _ref = TypeChecker.fromRuntime(Ref);
 
+/// [Ref] methods that can make a provider depend on another provider.
+const _refBinders = {'read', 'watch', 'listen'};
+
 void main(List<String> args, SendPort sendPort) {
   startPlugin(sendPort, _RiverpodLint());
 }
 
 class _RiverpodLint extends PluginBase {
   @override
-  Iterable<Lint> getLints(ResolvedUnitResult unit) {
+  Stream<Lint> getLints(ResolvedUnitResult unit) {
     final visitor = RiverpodVisitor(unit);
-    unit.unit.accept(visitor);
-
-    return visitor.lints;
+    return unit.unit.accept(visitor) ?? const Stream<Lint>.empty();
   }
 }
 
-mixin _ProviderCreationVisitor on RecursiveAstVisitor<void> {
+mixin _ProviderCreationVisitor<T> on AsyncRecursiveVisitor<T> {
   /// The initialization of a provider was found
-  void visitProviderCreation(AstNode providerNode);
+  Stream<T>? visitProviderCreation(AstNode node);
 
   @override
-  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
-    super.visitFunctionExpressionInvocation(node);
+  Stream<T>? visitFunctionExpressionInvocation(
+    FunctionExpressionInvocation node,
+  ) async* {
+    final superStream = super.visitFunctionExpressionInvocation(node);
+    if (superStream != null) yield* superStream;
 
     if (node.isProviderCreation ?? false) {
-      visitProviderCreation(node);
+      final stream = visitProviderCreation(node);
+      if (stream != null) yield* stream;
     }
   }
 
   @override
-  void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    super.visitInstanceCreationExpression(node);
+  Stream<T>? visitInstanceCreationExpression(
+    InstanceCreationExpression node,
+  ) async* {
+    final superStream = super.visitInstanceCreationExpression(node);
+    if (superStream != null) yield* superStream;
 
     final createdType = node.staticType?.element;
     if (createdType != null &&
         _providerOrFamily.isAssignableFrom(createdType)) {
-      visitProviderCreation(node);
+      final stream = visitProviderCreation(node);
+      if (stream != null) yield* stream;
     }
   }
 }
@@ -116,59 +127,106 @@ class RefLifecycleInvocation {
   late final bool? isWithinBuild = _isWithinBuild(invocation);
 }
 
-mixin _RefLifecycleVisitor on RecursiveAstVisitor<void> {
+mixin _RefLifecycleVisitor<T> on AsyncRecursiveVisitor<T> {
   /// A Ref/WidgetRef method was invoked. It isn't guaranted to be watch/listen/read
-  void visitRefInvocation(RefLifecycleInvocation node);
+  Stream<T>? visitRefInvocation(RefLifecycleInvocation node);
 
   @override
-  void visitMethodInvocation(MethodInvocation node) {
-    super.visitMethodInvocation(node);
+  Stream<T>? visitMethodInvocation(MethodInvocation node) async* {
+    final superStream = super.visitMethodInvocation(node);
+    if (superStream != null) yield* superStream;
+
     final targetType = node.target?.staticType?.element;
     if (targetType == null) return;
 
     if (_ref.isAssignableFrom(targetType) ||
         _widgetRef.isAssignableFrom(targetType)) {
-      visitRefInvocation(RefLifecycleInvocation._(node));
+      final refInvocStream = visitRefInvocation(RefLifecycleInvocation._(node));
+      if (refInvocStream != null) yield* refInvocStream;
     }
   }
 }
 
-class RiverpodVisitor extends RecursiveAstVisitor<void>
+/// Recursively search all the places where a Provider's `ref` is used
+// TODO handle Service()..ref=
+// TODO handle Ref fn() => ref;
+class ProviderRefUsageVisitor extends AsyncRecursiveVisitor<ProviderDeclaration>
+    with _RefLifecycleVisitor {
+  @override
+  Stream<ProviderDeclaration>? visitArgumentList(ArgumentList node) async* {
+    final superStream = super.visitArgumentList(node);
+    if (superStream != null) yield* superStream;
+
+    argumentsLoop:
+    for (final arg in node.arguments) {
+      final type = arg.staticType?.element;
+      if (type != null && _ref.isAssignableFrom(type)) {
+        // "ref" was passed as argument to a constructor/function.
+        // We now will search for the constructor/function invoked, to see how
+        // it uses ref.
+
+        for (final parent in node.parents) {
+          if (parent is Expression) {
+            final createdObject = parent.staticType?.element;
+
+            if (createdObject != null) {
+              final ast = await findAstNodeForElement(createdObject);
+              final createdObjectStream = ast?.accept(this);
+              if (createdObjectStream != null) yield* createdObjectStream;
+            }
+
+            continue argumentsLoop;
+          }
+        }
+      }
+    }
+  }
+
+  @override
+  Stream<ProviderDeclaration>? visitRefInvocation(
+    RefLifecycleInvocation node,
+  ) async* {
+    if (_refBinders.contains(node.invocation.methodName.name)) {
+      final providerExpression = node.invocation.argumentList.arguments.first;
+      final providerOrigin =
+          await ProviderDeclaration.tryParse(providerExpression);
+
+      if (providerOrigin != null) yield providerOrigin;
+    }
+  }
+}
+
+class RiverpodVisitor extends AsyncRecursiveVisitor<Lint>
     with _RefLifecycleVisitor, _ProviderCreationVisitor {
   RiverpodVisitor(this.unit);
 
   final ResolvedUnitResult unit;
-  final lints = <Lint>[];
 
   @override
-  void visitRefInvocation(RefLifecycleInvocation node) {
+  Stream<Lint> visitRefInvocation(RefLifecycleInvocation node) async* {
     switch (node.invocation.methodName.name) {
       case 'read':
         if (node.isWithinBuild ?? false) {
-          lints.add(
-            Lint(
-              code: 'riverpod_avoid_read_inside_build',
-              message:
-                  'Avoid using ref.read inside the build method of widgets/providers.',
-              location: unit.lintLocationFromOffset(
-                node.invocation.offset,
-                length: node.invocation.length,
-              ),
+          yield Lint(
+            code: 'riverpod_avoid_read_inside_build',
+            message:
+                'Avoid using ref.read inside the build method of widgets/providers.',
+            location: unit.lintLocationFromOffset(
+              node.invocation.offset,
+              length: node.invocation.length,
             ),
           );
         }
         break;
       case 'watch':
         if (node.isWithinBuild == false) {
-          lints.add(
-            Lint(
-              code: 'riverpod_avoid_watch_outside_build',
-              message:
-                  'Avoid using ref.watch outside the build method of widgets/providers.',
-              location: unit.lintLocationFromOffset(
-                node.invocation.offset,
-                length: node.invocation.length,
-              ),
+          yield Lint(
+            code: 'riverpod_avoid_watch_outside_build',
+            message:
+                'Avoid using ref.watch outside the build method of widgets/providers.',
+            location: unit.lintLocationFromOffset(
+              node.invocation.offset,
+              length: node.invocation.length,
             ),
           );
         }
@@ -178,39 +236,104 @@ class RiverpodVisitor extends RecursiveAstVisitor<void>
   }
 
   @override
-  void visitProviderCreation(AstNode providerNode) {
-    _checkValidProviderDeclaration(providerNode);
-    _checkProviderDependencies(providerNode);
-  }
+  Stream<Lint> visitProviderCreation(AstNode node) async* {
+    final variableDeclaration =
+        node.parents.whereType<VariableDeclaration>().firstOrNull;
+    final providerDeclaration = variableDeclaration?.declaredElement != null
+        ? ProviderDeclaration._(
+            variableDeclaration!,
+            variableDeclaration.declaredElement!,
+          )
+        : null;
+    yield* _checkValidProviderDeclaration(node);
 
-  void _checkProviderDependencies(AstNode providerNode) {
-    if (providerNode is InstanceCreationExpression) {
-      final dependenciesExpression = providerNode.argumentList.arguments
-          .whereType<NamedExpression>()
-          .firstWhereOrNull((e) => e.name.label.name == 'dependencies')
-          ?.expression;
-
-      if (dependenciesExpression is ListLiteral) {
-        print(
-            'Provider creation $providerNode ----- dependencies ${dependenciesExpression.elements.map((e) => e.runtimeType)}');
-      }
+    if (providerDeclaration != null) {
+      yield* _checkProviderDependencies(providerDeclaration);
     }
   }
 
-  void _checkValidProviderDeclaration(AstNode providerNode) {
+  Stream<Lint> _checkProviderDependencies(ProviderDeclaration provider) async* {
+    final providerDependencies = await provider.dependencies;
+    if (providerDependencies == null) return;
+    final expectedDependencies = providerDependencies.value;
+    final visitor = ProviderRefUsageVisitor();
+    final actualDependencies = await provider.node.accept(visitor)!.toList();
+
+    if (expectedDependencies == null) {
+      // no `dependencies` specified
+
+      for (final actualDependency in actualDependencies) {
+        if (await actualDependency.isScoped) {
+          yield Lint(
+            code: 'riverpod_unspecified_dependencies',
+            message: 'This provider does not specifies `dependencies`, '
+                'yet depends on "${actualDependency.name}" which did specify its dependencies.',
+            correction: 'Add `dependencies` to this provider '
+                'or remove `dependencies` from "${actualDependency.name}".',
+            severity: LintSeverity.warning,
+            location: unit.lintLocationFromOffset(
+              provider.node.offset,
+              length: provider.name.length,
+            ),
+          );
+        }
+      }
+    } else {
+      for (final actualDependency in actualDependencies) {
+        if (!expectedDependencies.any((e) => e.origin == actualDependency)) {
+          yield Lint(
+            code: 'riverpod_missing_dependency',
+            message: 'This provider depends on "${actualDependency.name}" '
+                'yet "${actualDependency.name}" isn\'t listed in the dependencies.',
+            correction:
+                'Add "${actualDependency.name}" to the list of dependencies '
+                'of this provider.',
+            severity: LintSeverity.warning,
+            location: unit.lintLocationFromOffset(
+              // TODO is there a better way to do this?
+              provider.dependenciesExpression!.value!.offset,
+              length: 'dependencies'.length,
+            ),
+          );
+        }
+      }
+
+      for (final expectedDependency in expectedDependencies) {
+        if (!actualDependencies.contains(expectedDependency.origin)) {
+          yield Lint(
+            code: 'riverpod_extra_dependency',
+            message:
+                'This provider specifies that it depends on "${expectedDependency.origin.name}" '
+                'yet it never uses that provider.',
+            correction:
+                'Remove "${expectedDependency.origin.name}" from the list of dependencies.',
+            severity: LintSeverity.warning,
+            location: unit.lintLocationFromOffset(
+              // TODO is there a better way to do this?
+              expectedDependency.node.offset,
+              length: expectedDependency.node.length,
+            ),
+          );
+        }
+      }
+    }
+
+    // print(
+    //     'Provider\n - origin: $node\n - expected: ${dependencies.value}\n - dependencies: ${visitor.dependencies}');
+  }
+
+  Stream<Lint> _checkValidProviderDeclaration(AstNode providerNode) async* {
     final declaration =
         providerNode.parents.whereType<VariableDeclaration>().firstOrNull;
     final variable = declaration?.declaredElement;
 
     if (variable == null) {
-      lints.add(
-        Lint(
-          code: 'riverpod_final_provider',
-          message: 'Providers should always be declared as final',
-          location: unit.lintLocationFromOffset(
-            providerNode.offset,
-            length: providerNode.length,
-          ),
+      yield Lint(
+        code: 'riverpod_final_provider',
+        message: 'Providers should always be declared as final',
+        location: unit.lintLocationFromOffset(
+          providerNode.offset,
+          length: providerNode.length,
         ),
       );
       return;
@@ -221,28 +344,24 @@ class RiverpodVisitor extends RecursiveAstVisitor<void>
         (element is FieldDeclaration && element.isStatic));
 
     if (!isGlobal) {
-      lints.add(
-        Lint(
-          code: 'riverpod_avoid_dynamic_provider',
-          message:
-              'Providers should be either top level variables or static properties',
-          location: unit.lintLocationFromOffset(
-            variable.nameOffset,
-            length: variable.nameLength,
-          ),
+      yield Lint(
+        code: 'riverpod_avoid_dynamic_provider',
+        message:
+            'Providers should be either top level variables or static properties',
+        location: unit.lintLocationFromOffset(
+          variable.nameOffset,
+          length: variable.nameLength,
         ),
       );
     }
 
     if (!variable.isFinal) {
-      lints.add(
-        Lint(
-          code: 'riverpod_final_provider',
-          message: 'Providers should always be declared as final',
-          location: unit.lintLocationFromOffset(
-            variable.nameOffset,
-            length: variable.nameLength,
-          ),
+      yield Lint(
+        code: 'riverpod_final_provider',
+        message: 'Providers should always be declared as final',
+        location: unit.lintLocationFromOffset(
+          variable.nameOffset,
+          length: variable.nameLength,
         ),
       );
     }
@@ -257,7 +376,151 @@ extension on AstNode {
   }
 }
 
-VariableDeclaration? findProviderDeclaration(AstNode node) {}
+class Result<T> {
+  const Result(this.value);
+  final T value;
+
+  @override
+  String toString() => 'Result($value)';
+}
+
+@immutable
+class ProviderDeclaration {
+  ProviderDeclaration._(this.node, this.element);
+
+  /// Decode a provider expression to extract the provider listened.
+  ///
+  /// For example, for:
+  ///
+  /// ```dart
+  /// family(42).select(...)
+  /// ```
+  ///
+  /// this will return the variable definition of `family`.
+  ///
+  /// Returns `null` if failed to decode the expression.
+  // TODO fuse with riverpod_graph
+  static FutureOr<ProviderDeclaration?> tryParse(AstNode providerExpression) {
+    if (providerExpression is PropertyAccess) {
+      // watch(family(0).modifier)
+      final target = providerExpression.target;
+      if (target != null) return ProviderDeclaration.tryParse(target);
+    } else if (providerExpression is PrefixedIdentifier) {
+      // watch(provider.modifier)
+      return ProviderDeclaration.tryParse(providerExpression.prefix);
+    } else if (providerExpression is Identifier) {
+      // watch(variable)
+      final Object? staticElement = providerExpression.staticElement;
+      if (staticElement is PropertyAccessorElement) {
+        // TODO can this be removed?
+        return findAstNodeForElement(staticElement.declaration.variable)
+            .then((ast) {
+          if (ast is VariableDeclaration) {
+            return ProviderDeclaration._(
+                ast, staticElement.declaration.variable);
+          }
+          return null;
+        });
+      }
+    } else if (providerExpression is FunctionExpressionInvocation) {
+      // watch(family(id))
+      return ProviderDeclaration.tryParse(providerExpression.function);
+    } else if (providerExpression is MethodInvocation) {
+      // watch(variable.select(...)) or watch(family(id).select(...))
+      final target = providerExpression.target;
+      if (target != null) return ProviderDeclaration.tryParse(target);
+    }
+
+    return null;
+  }
+
+  /// Finds the "dependencies:" expression in a provider creation
+  ///
+  /// Returns null if failed to parse.
+  /// Returns Result(null) if successfuly passed but no dependencies was specified
+  static Result<NamedExpression?>? _findDependenciesExpression(
+    VariableDeclaration node,
+  ) {
+    final initializer = node.initializer;
+    ArgumentList argumentList;
+
+    if (initializer is InstanceCreationExpression) {
+      argumentList = initializer.argumentList;
+    } else if (initializer is FunctionExpressionInvocation) {
+      argumentList = initializer.argumentList;
+    } else {
+      return null;
+    }
+
+    return Result(
+      argumentList.arguments
+          .whereType<NamedExpression>()
+          .firstWhereOrNull((e) => e.name.label.name == 'dependencies'),
+    );
+  }
+
+  /// Decode the parameter "dependencies" from a provider
+  ///
+  /// Returns null if failed to decode.
+  /// Returns a [Result] with `value` as null if the parameter "dependencies" was
+  /// not specified.
+  static Future<Result<List<ProviderDependency>?>?> _findDependencies(
+    Result<NamedExpression?>? dependenciesExpressionResult,
+  ) async {
+    if (dependenciesExpressionResult == null) return null;
+    final namedExpression = dependenciesExpressionResult.value;
+    if (namedExpression == null) return const Result(null);
+    final value = namedExpression.expression;
+    if (value is! ListLiteral) return null;
+
+    return Result(
+      await Stream.fromIterable(value.elements)
+          .asyncMap((node) async {
+            final origin = await ProviderDeclaration.tryParse(node);
+            if (origin == null) return null;
+            return ProviderDependency(origin, node);
+          })
+          .where((e) => e != null)
+          .cast<ProviderDependency>()
+          .toList(),
+    );
+  }
+
+  final VariableDeclaration node;
+  final VariableElement element;
+
+  /// The [AstNode] that points to the `dependencies` parameter of a provider
+  late final dependenciesExpression = _findDependenciesExpression(node);
+
+  /// The decoded `dependencpes` of a provider
+  late final dependencies = _findDependencies(dependenciesExpression);
+
+  late final Future<bool> isScoped = dependencies.then((e) => e?.value != null);
+
+  String get name => node.name.name;
+
+  @override
+  String toString() => node.toString();
+
+  @override
+  bool operator ==(Object other) {
+    return other is ProviderDeclaration && element == other.element;
+  }
+
+  @override
+  int get hashCode => element.hashCode;
+}
+
+@immutable
+class ProviderDependency {
+  const ProviderDependency(this.origin, this.node);
+
+  /// The provider that is depended on
+  final ProviderDeclaration origin;
+
+  /// The [AstNode] associated with this dependency
+  final AstNode node;
+}
 
 extension on FunctionExpressionInvocation {
   /// Null if unknown

--- a/packages/riverpod_lint/bin/custom_lint.dart
+++ b/packages/riverpod_lint/bin/custom_lint.dart
@@ -12,17 +12,18 @@ const _providerBase = TypeChecker.fromRuntime(ProviderBase);
 const _family = TypeChecker.fromRuntime(Family);
 const _providerOrFamily = TypeChecker.any([_providerBase, _family]);
 
-const _widget =
-    TypeChecker.fromUrl('package:flutter/src/widgets/framework.dart#Widget');
+const _widget = TypeChecker.fromName('Widget', packageName: 'flutter');
 
 const _widgetRef =
-    TypeChecker.fromUrl('package:flutter_riverpod/src/consumer.dart#WidgetRef');
+    TypeChecker.fromName('WidgetRef', packageName: 'flutter_riverpod');
 
-const _consumerWidget = TypeChecker.fromUrl(
-  'package:flutter_riverpod/src/consumer.dart#ConsumerWidget',
+const _consumerWidget = TypeChecker.fromName(
+  'ConsumerWidget',
+  packageName: 'flutter_riverpod',
 );
-const _consumerState = TypeChecker.fromUrl(
-  'package:flutter_riverpod/src/consumer.dart#ConsumerState',
+const _consumerState = TypeChecker.fromName(
+  'ConsumerState',
+  packageName: 'flutter_riverpod',
 );
 const _ref = TypeChecker.fromRuntime(Ref);
 
@@ -83,7 +84,7 @@ class ProviderVisitor extends RecursiveAstVisitor<void> {
               _consumerState.isAssignableFrom(classElement);
         }
       }
-      return false;
+      return null;
     }
 
     // Whther the invocation is inside or ouside the build method of a provider/widget
@@ -98,8 +99,8 @@ class ProviderVisitor extends RecursiveAstVisitor<void> {
               code: 'riverpod_avoid_read_inside_build',
               message:
                   'Avoid using ref.read inside the build method of widgets/providers.',
-              location: LintLocation.fromOffsets(
-                offset: node.offset,
+              location: unit.lintLocationFromOffset(
+                node.offset,
                 length: node.length,
               ),
             ),
@@ -113,8 +114,8 @@ class ProviderVisitor extends RecursiveAstVisitor<void> {
               code: 'riverpod_avoid_watch_outside_build',
               message:
                   'Avoid using ref.watch outside the build method of widgets/providers.',
-              location: LintLocation.fromOffsets(
-                offset: node.offset,
+              location: unit.lintLocationFromOffset(
+                node.offset,
                 length: node.length,
               ),
             ),
@@ -135,8 +136,8 @@ class ProviderVisitor extends RecursiveAstVisitor<void> {
         Lint(
           code: 'riverpod_final_provider',
           message: 'Providers should always be declared as final',
-          location: LintLocation.fromOffsets(
-            offset: providerNode.offset,
+          location: unit.lintLocationFromOffset(
+            providerNode.offset,
             length: providerNode.length,
           ),
         ),
@@ -154,8 +155,8 @@ class ProviderVisitor extends RecursiveAstVisitor<void> {
           code: 'riverpod_avoid_dynamic_provider',
           message:
               'Providers should be either top level variables or static properties',
-          location: LintLocation.fromOffsets(
-            offset: variable.nameOffset,
+          location: unit.lintLocationFromOffset(
+            variable.nameOffset,
             length: variable.nameLength,
           ),
         ),
@@ -167,8 +168,8 @@ class ProviderVisitor extends RecursiveAstVisitor<void> {
         Lint(
           code: 'riverpod_final_provider',
           message: 'Providers should always be declared as final',
-          location: LintLocation.fromOffsets(
-            offset: variable.nameOffset,
+          location: unit.lintLocationFromOffset(
+            variable.nameOffset,
             length: variable.nameLength,
           ),
         ),

--- a/packages/riverpod_lint/bin/test_custom_lint.dart
+++ b/packages/riverpod_lint/bin/test_custom_lint.dart
@@ -1,0 +1,60 @@
+// Hotreloader and watcher are really more of dev-dependencies
+// ignore_for_file: depend_on_referenced_packages
+
+import 'dart:developer' as dev;
+
+import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:hotreloader/hotreloader.dart';
+import 'package:path/path.dart';
+import 'package:watcher/watcher.dart';
+
+import 'custom_lint.dart';
+
+void main() async {
+  final collection = AnalysisContextCollection(
+      includedPaths: [canonicalize('../riverpod_lint_flutter_test/')]);
+  const test = 'ref_escape_scope';
+  final file =
+      canonicalize('../riverpod_lint_flutter_test/test/goldens/$test.dart');
+  final watcher = FileWatcher(file);
+  ResolvedUnitResult? unit;
+  Future<void> analyzeTestFile() async {
+    final context = collection.contextFor(file);
+    final result = await context.currentSession.getResolvedUnit(file);
+    if (result is ResolvedUnitResult) {
+      unit = result;
+    } else {
+      dev.log('Error finding or analyzing file $file');
+    }
+  }
+
+  Future<void> getLints() async {
+    if (unit == null) {
+      return;
+    }
+    await for (final lint in RiverpodLint().getLints(unit!)) {
+      dev.log(
+          'Got lint ${lint.code} "${lint.message}" at location ${lint.location.startLine}:${lint.location.startColumn}');
+    }
+  }
+
+  watcher.events.listen((_) async {
+    dev.log('Test file changed, rerunning dart analyzer');
+    await analyzeTestFile();
+    dev.log('Rerunning lint analysis');
+    await getLints();
+  });
+
+  final _ = await HotReloader.create(onBeforeReload: (_) {
+    dev.log('Linter changed, reloading linter code');
+    return true;
+  }, onAfterReload: (_) async {
+    dev.log('Rerunning lint analysis');
+    await getLints();
+  });
+  dev.log('Analyzing test file');
+  await analyzeTestFile();
+  dev.log('Running lint analysis');
+  await getLints();
+}

--- a/packages/riverpod_lint/bin/test_custom_lint.dart
+++ b/packages/riverpod_lint/bin/test_custom_lint.dart
@@ -14,7 +14,7 @@ import 'custom_lint.dart';
 void main() async {
   final collection = AnalysisContextCollection(
       includedPaths: [canonicalize('../riverpod_lint_flutter_test/')]);
-  const test = 'ref_escape_scope';
+  const test = 'mutate_in_create';
   final file =
       canonicalize('../riverpod_lint_flutter_test/test/goldens/$test.dart');
   final watcher = FileWatcher(file);

--- a/packages/riverpod_lint/lib/src/analyzer_utils.dart
+++ b/packages/riverpod_lint/lib/src/analyzer_utils.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/analysis/session.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
@@ -8,19 +7,12 @@ import 'package:analyzer/dart/element/element.dart';
 Future<AstNode?> findAstNodeForElement(Element element) async {
   final libraryElement = element.library;
   if (libraryElement == null) return null;
-  try {
-    final parsedLibrary =
-        await element.session?.getResolvedLibraryByElement(libraryElement);
-    if (parsedLibrary is! ResolvedLibraryResult) return null;
+  final parsedLibrary =
+      await element.session?.getResolvedLibraryByElement(libraryElement);
+  if (parsedLibrary is! ResolvedLibraryResult) return null;
 
-    final declaration = parsedLibrary.getElementDeclaration(element);
-    return declaration?.node;
-  } on InconsistentAnalysisException {
-    final libraryResult =
-        await element.session?.getLibraryByUri(libraryElement.source.fullName);
-    if (libraryResult is! LibraryElementResult) return null;
-    return findAstNodeForElement(libraryResult.element);
-  }
+  final declaration = parsedLibrary.getElementDeclaration(element);
+  return declaration?.node;
 }
 
 class AsyncRecursiveVisitor<T> extends GeneralizingAstVisitor<Stream<T>> {

--- a/packages/riverpod_lint/lib/src/analyzer_utils.dart
+++ b/packages/riverpod_lint/lib/src/analyzer_utils.dart
@@ -1,0 +1,36 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+
+/// Obtains the [AstNode] of an [Element]
+Future<AstNode?> findAstNodeForElement(Element element) async {
+  final libraryElement = element.library;
+  if (libraryElement == null) return null;
+  final parsedLibrary =
+      await element.session?.getResolvedLibraryByElement(libraryElement);
+  if (parsedLibrary is! ResolvedLibraryResult) return null;
+
+  final declaration = parsedLibrary.getElementDeclaration(element);
+  return declaration?.node;
+}
+
+class AsyncRecursiveVisitor<T> extends GeneralizingAstVisitor<Stream<T>> {
+  @override
+  Stream<T>? visitNode(AstNode node) {
+    final visitor = _VisitChildren();
+    node.visitChildren(visitor);
+
+    return Stream.fromIterable(visitor._children)
+        .asyncExpand((event) => event.accept(this));
+  }
+}
+
+class _VisitChildren extends GeneralizingAstVisitor<void> {
+  final List<AstNode> _children = [];
+
+  @override
+  void visitNode(AstNode node) {
+    _children.add(node);
+  }
+}

--- a/packages/riverpod_lint/lib/src/analyzer_utils.dart
+++ b/packages/riverpod_lint/lib/src/analyzer_utils.dart
@@ -26,6 +26,16 @@ class AsyncRecursiveVisitor<T> extends GeneralizingAstVisitor<Stream<T>> {
   }
 }
 
+class CombiningRecursiveVisitor<T> extends GeneralizingAstVisitor<Iterable<T>> {
+  @override
+  Iterable<T> visitNode(AstNode node) {
+    final visitor = _VisitChildren();
+    node.visitChildren(visitor);
+
+    return visitor._children.expand((e) => e.accept(this) ?? const []);
+  }
+}
+
 class _VisitChildren extends GeneralizingAstVisitor<void> {
   final List<AstNode> _children = [];
 

--- a/packages/riverpod_lint/lib/src/type_checker.dart
+++ b/packages/riverpod_lint/lib/src/type_checker.dart
@@ -1,0 +1,358 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Code imported from source_gen
+
+import 'dart:mirrors' hide SourceLocation;
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:meta/meta.dart';
+import 'package:source_span/source_span.dart';
+
+import 'utils.dart';
+
+/// An abstraction around doing static type checking at compile/build time.
+abstract class TypeChecker {
+  const TypeChecker._();
+
+  /// Creates a new [TypeChecker] that delegates to other [checkers].
+  ///
+  /// This implementation will return `true` for type checks if _any_ of the
+  /// provided type checkers return true, which is useful for deprecating an
+  /// API:
+  /// ```dart
+  /// const $Foo = const TypeChecker.fromRuntime(Foo);
+  /// const $Bar = const TypeChecker.fromRuntime(Bar);
+  ///
+  /// // Used until $Foo is deleted.
+  /// const $FooOrBar = const TypeChecker.forAny(const [$Foo, $Bar]);
+  /// ```
+  const factory TypeChecker.any(Iterable<TypeChecker> checkers) = _AnyChecker;
+
+  /// Create a new [TypeChecker] backed by a runtime [type].
+  ///
+  /// This implementation uses `dart:mirrors` (runtime reflection).
+  const factory TypeChecker.fromRuntime(Type type) = _MirrorTypeChecker;
+
+  /// Create a new [TypeChecker] backed by a static [type].
+  const factory TypeChecker.fromStatic(DartType type) = _LibraryTypeChecker;
+
+  /// Create a new [TypeChecker] backed by a library [url].
+  ///
+  /// Example of referring to a `LinkedHashMap` from `dart:collection`:
+  /// ```dart
+  /// const linkedHashMap = const TypeChecker.fromUrl(
+  ///   'dart:collection#LinkedHashMap',
+  /// );
+  /// ```
+  ///
+  /// **NOTE**: This is considered a more _brittle_ way of determining the type
+  /// because it relies on knowing the _absolute_ path (i.e. after resolved
+  /// `export` directives). You should ideally only use `fromUrl` when you know
+  /// the full path (likely you own/control the package) or it is in a stable
+  /// package like in the `dart:` SDK.
+  const factory TypeChecker.fromUrl(dynamic url) = _UriTypeChecker;
+
+  /// Returns the first constant annotating [element] assignable to this type.
+  ///
+  /// Otherwise returns `null`.
+  ///
+  /// Throws on unresolved annotations unless [throwOnUnresolved] is `false`.
+  DartObject? firstAnnotationOf(
+    Element element, {
+    bool throwOnUnresolved = true,
+  }) {
+    if (element.metadata.isEmpty) {
+      return null;
+    }
+    final results =
+        annotationsOf(element, throwOnUnresolved: throwOnUnresolved);
+    return results.isEmpty ? null : results.first;
+  }
+
+  /// Returns if a constant annotating [element] is assignable to this type.
+  ///
+  /// Throws on unresolved annotations unless [throwOnUnresolved] is `false`.
+  bool hasAnnotationOf(Element element, {bool throwOnUnresolved = true}) =>
+      firstAnnotationOf(element, throwOnUnresolved: throwOnUnresolved) != null;
+
+  /// Returns the first constant annotating [element] that is exactly this type.
+  ///
+  /// Throws [UnresolvedAnnotationException] on unresolved annotations unless
+  /// [throwOnUnresolved] is explicitly set to `false` (default is `true`).
+  DartObject? firstAnnotationOfExact(
+    Element element, {
+    bool throwOnUnresolved = true,
+  }) {
+    if (element.metadata.isEmpty) {
+      return null;
+    }
+    final results =
+        annotationsOfExact(element, throwOnUnresolved: throwOnUnresolved);
+    return results.isEmpty ? null : results.first;
+  }
+
+  /// Returns if a constant annotating [element] is exactly this type.
+  ///
+  /// Throws [UnresolvedAnnotationException] on unresolved annotations unless
+  /// [throwOnUnresolved] is explicitly set to `false` (default is `true`).
+  bool hasAnnotationOfExact(Element element, {bool throwOnUnresolved = true}) =>
+      firstAnnotationOfExact(element, throwOnUnresolved: throwOnUnresolved) !=
+      null;
+
+  DartObject? _computeConstantValue(
+    Element element,
+    int annotationIndex, {
+    bool throwOnUnresolved = true,
+  }) {
+    final annotation = element.metadata[annotationIndex];
+    final result = annotation.computeConstantValue();
+    if (result == null && throwOnUnresolved) {
+      throw UnresolvedAnnotationException._from(element, annotationIndex);
+    }
+    return result;
+  }
+
+  /// Returns annotating constants on [element] assignable to this type.
+  ///
+  /// Throws [UnresolvedAnnotationException] on unresolved annotations unless
+  /// [throwOnUnresolved] is explicitly set to `false` (default is `true`).
+  Iterable<DartObject> annotationsOf(
+    Element element, {
+    bool throwOnUnresolved = true,
+  }) =>
+      _annotationsWhere(
+        element,
+        isAssignableFromType,
+        throwOnUnresolved: throwOnUnresolved,
+      );
+
+  Iterable<DartObject> _annotationsWhere(
+    Element element,
+    bool Function(DartType) predicate, {
+    bool throwOnUnresolved = true,
+  }) sync* {
+    for (var i = 0; i < element.metadata.length; i++) {
+      final value = _computeConstantValue(
+        element,
+        i,
+        throwOnUnresolved: throwOnUnresolved,
+      );
+      if (value?.type != null && predicate(value!.type!)) {
+        yield value;
+      }
+    }
+  }
+
+  /// Returns annotating constants on [element] of exactly this type.
+  ///
+  /// Throws [UnresolvedAnnotationException] on unresolved annotations unless
+  /// [throwOnUnresolved] is explicitly set to `false` (default is `true`).
+  Iterable<DartObject> annotationsOfExact(
+    Element element, {
+    bool throwOnUnresolved = true,
+  }) =>
+      _annotationsWhere(
+        element,
+        isExactlyType,
+        throwOnUnresolved: throwOnUnresolved,
+      );
+
+  /// Returns `true` if the type of [element] can be assigned to this type.
+  bool isAssignableFrom(Element element) =>
+      isExactly(element) ||
+      (element is ClassElement && element.allSupertypes.any(isExactlyType));
+
+  /// Returns `true` if [staticType] can be assigned to this type.
+  bool isAssignableFromType(DartType staticType) =>
+      isAssignableFrom(staticType.element!);
+
+  /// Returns `true` if representing the exact same class as [element].
+  bool isExactly(Element element);
+
+  /// Returns `true` if representing the exact same type as [staticType].
+  bool isExactlyType(DartType staticType) => isExactly(staticType.element!);
+
+  /// Returns `true` if representing a super class of [element].
+  ///
+  /// This check only takes into account the *extends* hierarchy. If you wish
+  /// to check mixins and interfaces, use [isAssignableFrom].
+  bool isSuperOf(Element element) {
+    if (element is ClassElement) {
+      var theSuper = element.supertype;
+
+      do {
+        if (isExactlyType(theSuper!)) {
+          return true;
+        }
+
+        theSuper = theSuper.superclass;
+      } while (theSuper != null);
+    }
+
+    return false;
+  }
+
+  /// Returns `true` if representing a super type of [staticType].
+  ///
+  /// This only takes into account the *extends* hierarchy. If you wish
+  /// to check mixins and interfaces, use [isAssignableFromType].
+  bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element!);
+}
+
+// Checks a static type against another static type;
+class _LibraryTypeChecker extends TypeChecker {
+  const _LibraryTypeChecker(this._type) : super._();
+
+  final DartType _type;
+
+  @override
+  bool isExactly(Element element) =>
+      element is ClassElement && element == _type.element;
+
+  @override
+  String toString() => urlOfElement(_type.element!);
+}
+
+// Checks a runtime type against a static type.
+class _MirrorTypeChecker extends TypeChecker {
+  const _MirrorTypeChecker(this._type) : super._();
+
+  static Uri _uriOf(ClassMirror mirror) =>
+      normalizeUrl((mirror.owner! as LibraryMirror).uri)
+          .replace(fragment: MirrorSystem.getName(mirror.simpleName));
+
+  // Precomputed type checker for types that already have been used.
+  static final _cache = Expando<TypeChecker>();
+
+  final Type _type;
+
+  TypeChecker get _computed =>
+      _cache[this] ??= TypeChecker.fromUrl(_uriOf(reflectClass(_type)));
+
+  @override
+  bool isExactly(Element element) => _computed.isExactly(element);
+
+  @override
+  String toString() => _computed.toString();
+}
+
+// Checks a runtime type against an Uri and Symbol.
+@immutable
+class _UriTypeChecker extends TypeChecker {
+  const _UriTypeChecker(dynamic url)
+      : _url = '$url',
+        super._();
+
+  // Precomputed cache of String --> Uri.
+  static final _cache = Expando<Uri>();
+
+  final String _url;
+
+  /// Url as a [Uri] object, lazily constructed.
+  Uri get uri => _cache[this] ??= normalizeUrl(Uri.parse(_url));
+
+  /// Returns whether this type represents the same as [url].
+  bool hasSameUrl(dynamic url) =>
+      uri.toString() ==
+      (url is String ? url : normalizeUrl(url as Uri).toString());
+
+  @override
+  bool isExactly(Element element) => hasSameUrl(urlOfElement(element));
+
+  @override
+  bool operator ==(Object o) => o is _UriTypeChecker && o._url == _url;
+
+  @override
+  int get hashCode => _url.hashCode;
+
+  @override
+  String toString() => '$uri';
+}
+
+class _AnyChecker extends TypeChecker {
+  const _AnyChecker(this._checkers) : super._();
+
+  final Iterable<TypeChecker> _checkers;
+
+  @override
+  bool isExactly(Element element) => _checkers.any((c) => c.isExactly(element));
+}
+
+/// Exception thrown when [TypeChecker] fails to resolve a metadata annotation.
+///
+/// Methods such as [TypeChecker.firstAnnotationOf] may throw this exception
+/// when one or more annotations are not resolvable. This is usually a sign that
+/// something was misspelled, an import is missing, or a dependency was not
+/// defined (for build systems such as Bazel).
+class UnresolvedAnnotationException implements Exception {
+  /// Creates an exception from an annotation ([annotationIndex]) that was not
+  /// resolvable while traversing [Element.metadata] on [annotatedElement].
+  factory UnresolvedAnnotationException._from(
+    Element annotatedElement,
+    int annotationIndex,
+  ) {
+    final sourceSpan = _findSpan(annotatedElement, annotationIndex);
+    return UnresolvedAnnotationException._(annotatedElement, sourceSpan);
+  }
+
+  const UnresolvedAnnotationException._(
+    this.annotatedElement,
+    this.annotationSource,
+  );
+
+  static SourceSpan? _findSpan(
+    Element annotatedElement,
+    int annotationIndex,
+  ) {
+    final parsedLibrary = annotatedElement.session!
+            .getParsedLibraryByElement(annotatedElement.library!)
+        as ParsedLibraryResult;
+    final declaration = parsedLibrary.getElementDeclaration(annotatedElement);
+    if (declaration == null) {
+      return null;
+    }
+    final node = declaration.node;
+    final List<Annotation> metadata;
+    if (node is AnnotatedNode) {
+      metadata = node.metadata;
+    } else if (node is FormalParameter) {
+      metadata = node.metadata;
+    } else {
+      throw StateError(
+        'Unhandled Annotated AST node type: ${node.runtimeType}',
+      );
+    }
+    final annotation = metadata[annotationIndex];
+    final start = annotation.offset;
+    final end = start + annotation.length;
+    final parsedUnit = declaration.parsedUnit!;
+    return SourceSpan(
+      SourceLocation(start, sourceUrl: parsedUnit.uri),
+      SourceLocation(end, sourceUrl: parsedUnit.uri),
+      parsedUnit.content.substring(start, end),
+    );
+  }
+
+  /// Element that was annotated with something we could not resolve.
+  final Element annotatedElement;
+
+  /// Source span of the annotation that was not resolved.
+  ///
+  /// May be `null` if the import library was not found.
+  final SourceSpan? annotationSource;
+
+  @override
+  String toString() {
+    final message = 'Could not resolve annotation for `$annotatedElement`.';
+    if (annotationSource != null) {
+      return annotationSource!.message(message);
+    }
+    return message;
+  }
+}

--- a/packages/riverpod_lint/lib/src/type_checker.dart
+++ b/packages/riverpod_lint/lib/src/type_checker.dart
@@ -181,13 +181,13 @@ abstract class TypeChecker {
 
   /// Returns `true` if [staticType] can be assigned to this type.
   bool isAssignableFromType(DartType staticType) =>
-      isAssignableFrom(staticType.element!);
+      isAssignableFrom(staticType.element2!);
 
   /// Returns `true` if representing the exact same class as [element].
   bool isExactly(Element element);
 
   /// Returns `true` if representing the exact same type as [staticType].
-  bool isExactlyType(DartType staticType) => isExactly(staticType.element!);
+  bool isExactlyType(DartType staticType) => isExactly(staticType.element2!);
 
   /// Returns `true` if representing a super class of [element].
   ///
@@ -213,7 +213,7 @@ abstract class TypeChecker {
   ///
   /// This only takes into account the *extends* hierarchy. If you wish
   /// to check mixins and interfaces, use [isAssignableFromType].
-  bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element!);
+  bool isSuperTypeOf(DartType staticType) => isSuperOf(staticType.element2!);
 }
 
 // Checks a static type against another static type;
@@ -224,10 +224,10 @@ class _LibraryTypeChecker extends TypeChecker {
 
   @override
   bool isExactly(Element element) =>
-      element is ClassElement && element == _type.element;
+      element is ClassElement && element == _type.element2;
 
   @override
-  String toString() => urlOfElement(_type.element!);
+  String toString() => urlOfElement(_type.element2!);
 }
 
 // Checks a runtime type against a static type.

--- a/packages/riverpod_lint/lib/src/utils.dart
+++ b/packages/riverpod_lint/lib/src/utils.dart
@@ -2,13 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:path/path.dart' as p;
-import 'package:yaml/yaml.dart';
 
 /// Returns a non-null name for the provided [type].
 ///
@@ -75,9 +72,11 @@ Uri _normalizeDartUrl(Uri url) => url.pathSegments.isNotEmpty
 
 Uri _fileToAssetUrl(Uri url) {
   if (!p.isWithin(p.url.current, url.path)) return url;
+
   return Uri(
     scheme: 'asset',
-    path: p.join(_rootPackageName, p.relative(url.path)),
+    // TODO is it safe to use empty url?
+    path: p.join('', p.relative(url.path)),
   );
 }
 
@@ -120,15 +119,3 @@ Uri assetToPackageUrl(Uri url) => url.scheme == 'asset' &&
         ],
       )
     : url;
-
-final String _rootPackageName = () {
-  final name = (loadYaml(File('pubspec.yaml').readAsStringSync())
-      as Map<Object?, Object?>)['name'];
-  if (name is! String) {
-    throw StateError(
-      "Your pubspec.yaml file is missing a `name` field or it isn't "
-      'a String.',
-    );
-  }
-  return name;
-}();

--- a/packages/riverpod_lint/lib/src/utils.dart
+++ b/packages/riverpod_lint/lib/src/utils.dart
@@ -42,10 +42,12 @@ bool hasExpectedPartDirective(CompilationUnit unit, String part) =>
 /// Returns a URL representing [element].
 String urlOfElement(Element element) => element.kind == ElementKind.DYNAMIC
     ? 'dart:core#dynamic'
-    // using librarySource.uri – in case the element is in a part
-    : normalizeUrl(element.librarySource!.uri)
-        .replace(fragment: element.name)
-        .toString();
+    : element.kind == ElementKind.NEVER
+        ? 'dart:core#Never'
+        // using librarySource.uri – in case the element is in a part
+        : normalizeUrl(element.librarySource!.uri)
+            .replace(fragment: element.name)
+            .toString();
 
 Uri normalizeUrl(Uri url) {
   switch (url.scheme) {

--- a/packages/riverpod_lint/lib/src/utils.dart
+++ b/packages/riverpod_lint/lib/src/utils.dart
@@ -26,10 +26,10 @@ String typeNameOf(DartType type) {
     return 'dynamic';
   }
   if (type is InterfaceType) {
-    return type.element.name;
+    return type.element2.name;
   }
   if (type is TypeParameterType) {
-    return type.element.name;
+    return type.element2.name;
   }
   throw UnimplementedError('(${type.runtimeType}) $type');
 }

--- a/packages/riverpod_lint/lib/src/utils.dart
+++ b/packages/riverpod_lint/lib/src/utils.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// Returns a non-null name for the provided [type].
+///
+/// In newer versions of the Dart analyzer, a `typedef` does not keep the
+/// existing `name`, because it is used an alias:
+/// ```
+/// // Used to return `VoidFunc` for name, is now `null`.
+/// typedef VoidFunc = void Function();
+/// ```
+///
+/// This function will return `'VoidFunc'`, unlike [DartType.element.name].
+String typeNameOf(DartType type) {
+  final aliasElement = type.alias?.element;
+  if (aliasElement != null) {
+    return aliasElement.name;
+  }
+  if (type is DynamicType) {
+    return 'dynamic';
+  }
+  if (type is InterfaceType) {
+    return type.element.name;
+  }
+  if (type is TypeParameterType) {
+    return type.element.name;
+  }
+  throw UnimplementedError('(${type.runtimeType}) $type');
+}
+
+bool hasExpectedPartDirective(CompilationUnit unit, String part) =>
+    unit.directives
+        .whereType<PartDirective>()
+        .any((e) => e.uri.stringValue == part);
+
+/// Returns a URL representing [element].
+String urlOfElement(Element element) => element.kind == ElementKind.DYNAMIC
+    ? 'dart:core#dynamic'
+    // using librarySource.uri – in case the element is in a part
+    : normalizeUrl(element.librarySource!.uri)
+        .replace(fragment: element.name)
+        .toString();
+
+Uri normalizeUrl(Uri url) {
+  switch (url.scheme) {
+    case 'dart':
+      return _normalizeDartUrl(url);
+    case 'package':
+      return packageToAssetUrl(url);
+    case 'file':
+      return _fileToAssetUrl(url);
+    default:
+      return url;
+  }
+}
+
+/// Make `dart:`-type URLs look like a user-knowable path.
+///
+/// Some internal dart: URLs are something like `dart:core/map.dart`.
+///
+/// This isn't a user-knowable path, so we strip out extra path segments
+/// and only expose `dart:core`.
+Uri _normalizeDartUrl(Uri url) => url.pathSegments.isNotEmpty
+    ? url.replace(pathSegments: url.pathSegments.take(1))
+    : url;
+
+Uri _fileToAssetUrl(Uri url) {
+  if (!p.isWithin(p.url.current, url.path)) return url;
+  return Uri(
+    scheme: 'asset',
+    path: p.join(_rootPackageName, p.relative(url.path)),
+  );
+}
+
+/// Returns a `package:` URL converted to a `asset:` URL.
+///
+/// This makes internal comparison logic much easier, but still allows users
+/// to define assets in terms of `package:`, which is something that makes more
+/// sense to most.
+///
+/// For example, this transforms `package:source_gen/source_gen.dart` into:
+/// `asset:source_gen/lib/source_gen.dart`.
+Uri packageToAssetUrl(Uri url) => url.scheme == 'package'
+    ? url.replace(
+        scheme: 'asset',
+        pathSegments: <String>[
+          url.pathSegments.first,
+          'lib',
+          ...url.pathSegments.skip(1),
+        ],
+      )
+    : url;
+
+/// Returns a `asset:` URL converted to a `package:` URL.
+///
+/// For example, this transformers `asset:source_gen/lib/source_gen.dart' into:
+/// `package:source_gen/source_gen.dart`. Asset URLs that aren't pointing to a
+/// file in the 'lib' folder are not modified.
+///
+/// Asset URLs come from `package:build`, as they are able to describe URLs that
+/// are not describable using `package:...`, such as files in the `bin`, `tool`,
+/// `web`, or even root directory of a package - `asset:some_lib/web/main.dart`.
+Uri assetToPackageUrl(Uri url) => url.scheme == 'asset' &&
+        url.pathSegments.isNotEmpty &&
+        url.pathSegments[1] == 'lib'
+    ? url.replace(
+        scheme: 'package',
+        pathSegments: [
+          url.pathSegments.first,
+          ...url.pathSegments.skip(2),
+        ],
+      )
+    : url;
+
+final String _rootPackageName = () {
+  final name = (loadYaml(File('pubspec.yaml').readAsStringSync())
+      as Map<Object?, Object?>)['name'];
+  if (name is! String) {
+    throw StateError(
+      "Your pubspec.yaml file is missing a `name` field or it isn't "
+      'a String.',
+    );
+  }
+  return name;
+}();

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=3.0.0 <5.0.0"
-  collection:
+  analyzer: ^4.0.0
+  collection: ^1.16.0
   custom_lint_builder: ^0.0.3
   meta: ^1.7.0
   path: ^1.8.1
@@ -19,6 +19,3 @@ dependencies:
 dev_dependencies:
   mockito: ^5.0.0
   test: ^1.21.1
-
-dependency_overrides:
-  analyzer: ^4.0.0

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -1,0 +1,24 @@
+name: riverpod_lint
+version: 0.0.1
+homepage: https://riverpod.dev
+repository: https://github.com/rrousselGit/river_pod
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  analyzer: ">=3.0.0 <5.0.0"
+  collection:
+  custom_lint_builder: ^0.0.3
+  meta: ^1.7.0
+  path: ^1.8.1
+  riverpod: ^2.0.0-dev.9
+  source_span: ^1.8.0
+  yaml: ^3.1.1
+
+dev_dependencies:
+  mockito: ^5.0.0
+  test: ^1.21.1
+
+dependency_overrides:
+  analyzer: ^4.0.0

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   analyzer: ^4.0.0
   collection: ^1.16.0
-  custom_lint_builder: ^0.0.6
+  custom_lint_builder: ^0.0.7
   meta: ^1.7.0
   path: ^1.8.1
   riverpod: ^2.0.0-dev.9

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   analyzer: ^4.0.0
   collection: ^1.16.0
-  custom_lint_builder: 0.0.5
+  custom_lint_builder: ^0.0.6
   meta: ^1.7.0
   path: ^1.8.1
   riverpod: ^2.0.0-dev.9

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -18,5 +18,7 @@ dependencies:
   yaml: ^3.1.1
 
 dev_dependencies:
+  hotreloader: ^3.0.5
   mockito: ^5.0.0
   test: ^1.21.1
+  watcher: ^1.0.1

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   analyzer: ^4.0.0
   collection: ^1.16.0
   custom_lint_builder: 0.0.5
-  meta: ^1.8.0
+  meta: ^1.7.0
   path: ^1.8.1
   riverpod: ^2.0.0-dev.9
   source_span: ^1.8.0

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   analyzer: ^4.0.0
   collection: ^1.16.0
-  custom_lint_builder: ^0.0.3
-  meta: ^1.7.0
+  custom_lint_builder: 0.0.5
+  meta: ^1.8.0
   path: ^1.8.1
   riverpod: ^2.0.0-dev.9
   source_span: ^1.8.0

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -8,8 +8,9 @@ environment:
 
 dependencies:
   analyzer: ^4.0.0
+  analyzer_plugin: ^0.10.0
   collection: ^1.16.0
-  custom_lint_builder: ^0.0.7
+  custom_lint_builder: ^0.0.8
   meta: ^1.7.0
   path: ^1.8.1
   riverpod: ^2.0.0-dev.9

--- a/packages/riverpod_lint_flutter_test/analysis_options.yaml
+++ b/packages/riverpod_lint_flutter_test/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  plugins:
+    - custom_lint

--- a/packages/riverpod_lint_flutter_test/pubspec.yaml
+++ b/packages/riverpod_lint_flutter_test/pubspec.yaml
@@ -1,0 +1,19 @@
+name: riverpod_lint_flutter_test
+version: 0.0.0
+publish_to: none
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
+
+dependencies:
+  hooks_riverpod:
+    path: ../hooks_riverpod
+
+dev_dependencies:
+  custom_lint: ^0.0.3
+  custom_lint_builder: ^0.0.3
+  flutter_test:
+    sdk: flutter
+  riverpod_lint:
+    path: ../riverpod_lint

--- a/packages/riverpod_lint_flutter_test/pubspec.yaml
+++ b/packages/riverpod_lint_flutter_test/pubspec.yaml
@@ -1,6 +1,5 @@
 name: riverpod_lint_flutter_test
 version: 0.0.0
-publish_to: none
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
@@ -10,8 +9,8 @@ dependencies:
   hooks_riverpod: ^2.0.0-dev.9
 
 dev_dependencies:
-  custom_lint: ^0.0.6
-  custom_lint_builder: ^0.0.6
+  custom_lint: ^0.0.7
+  custom_lint_builder: ^0.0.7
   flutter_test:
     sdk: flutter
   riverpod_lint:

--- a/packages/riverpod_lint_flutter_test/pubspec.yaml
+++ b/packages/riverpod_lint_flutter_test/pubspec.yaml
@@ -7,12 +7,11 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  hooks_riverpod:
-    path: ../hooks_riverpod
+  hooks_riverpod: ^2.0.0-dev.9
 
 dev_dependencies:
-  custom_lint: ^0.0.3
-  custom_lint_builder: ^0.0.3
+  custom_lint: 0.0.5
+  custom_lint_builder: 0.0.5
   flutter_test:
     sdk: flutter
   riverpod_lint:

--- a/packages/riverpod_lint_flutter_test/pubspec.yaml
+++ b/packages/riverpod_lint_flutter_test/pubspec.yaml
@@ -9,8 +9,8 @@ dependencies:
   hooks_riverpod: ^2.0.0-dev.9
 
 dev_dependencies:
-  custom_lint: ^0.0.7
-  custom_lint_builder: ^0.0.7
+  custom_lint: ^0.0.8
+  custom_lint_builder: ^0.0.8
   flutter_test:
     sdk: flutter
   riverpod_lint:

--- a/packages/riverpod_lint_flutter_test/pubspec.yaml
+++ b/packages/riverpod_lint_flutter_test/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   hooks_riverpod: ^2.0.0-dev.9
 
 dev_dependencies:
-  custom_lint: 0.0.5
-  custom_lint_builder: 0.0.5
+  custom_lint: ^0.0.6
+  custom_lint_builder: ^0.0.6
   flutter_test:
     sdk: flutter
   riverpod_lint:

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-void main() {
+Future<void> main() async {
   test('goldens', () async {
     final result = await Process.run(
       'flutter',
@@ -16,6 +16,11 @@ void main() {
   test/goldens/avoid_dynamic_provider.dart:14:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
   test/goldens/avoid_dynamic_provider.dart:15:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
   test/goldens/avoid_dynamic_provider.dart:16:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
+  test/goldens/dependencies.dart:20:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
+  test/goldens/dependencies.dart:25:22 • This provider specifies that it depends on "b" yet it never uses that provider. • riverpod_extra_dependency
+  test/goldens/dependencies.dart:42:7 • This provider does not specifies `dependencies`, yet depends on "c" which did specify its dependencies. • riverpod_unspecified_dependencies
+  test/goldens/dependencies.dart:62:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
+  test/goldens/dependencies.dart:79:19 • This provider specifies that it depends on "a" yet it never uses that provider. • riverpod_extra_dependency
   test/goldens/final_provider.dart:5:14 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:6:51 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:11:5 • Providers should always be declared as final • riverpod_final_provider

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -24,7 +24,7 @@ Future<void> main() async {
   test/goldens/dependencies.dart:93:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
   test/goldens/dependencies.dart:110:48 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
   test/goldens/dependencies.dart:122:60 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
-  test/goldens/dependencies.dart:136:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
+  test/goldens/dependencies.dart:127:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
   test/goldens/final_provider.dart:5:14 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:6:51 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:11:5 • Providers should always be declared as final • riverpod_final_provider
@@ -48,6 +48,9 @@ Future<void> main() async {
   test/goldens/read_vs_watch.dart:104:9 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
   test/goldens/read_vs_watch.dart:114:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
   test/goldens/read_vs_watch.dart:128:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/ref_escape_scope.dart:7:12 • Ref escaped the scope via a function or return expression. • riverpod_ref_escape_scope
+  test/goldens/ref_escape_scope.dart:33:32 • Ref escaped its scope to another widget. • riverpod_ref_escape_scope
+  test/goldens/ref_escape_scope.dart:42:32 • Ref escaped its scope to another widget. • riverpod_ref_escape_scope
 ''');
   });
 }

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -38,7 +38,6 @@ void main() {
   test/goldens/read_vs_watch.dart:98:7 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
   test/goldens/read_vs_watch.dart:104:9 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
   test/goldens/read_vs_watch.dart:114:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
-  test/goldens/read_vs_watch.dart:121:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
   test/goldens/read_vs_watch.dart:128:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
 ''');
   });

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -17,10 +17,10 @@ Future<void> main() async {
   test/goldens/avoid_dynamic_provider.dart:15:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
   test/goldens/avoid_dynamic_provider.dart:16:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
   test/goldens/dependencies.dart:20:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
-  test/goldens/dependencies.dart:25:22 • This provider specifies that it depends on "b" yet it never uses that provider. • riverpod_extra_dependency
+  test/goldens/dependencies.dart:25:22 • This provider specifies that it depends on "b" yet it never uses that provider. • riverpod_unused_dependency
   test/goldens/dependencies.dart:42:7 • This provider does not specifies `dependencies`, yet depends on "c" which did specify its dependencies. • riverpod_unspecified_dependencies
   test/goldens/dependencies.dart:62:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
-  test/goldens/dependencies.dart:79:19 • This provider specifies that it depends on "a" yet it never uses that provider. • riverpod_extra_dependency
+  test/goldens/dependencies.dart:79:19 • This provider specifies that it depends on "a" yet it never uses that provider. • riverpod_unused_dependency
   test/goldens/final_provider.dart:5:14 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:6:51 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:11:5 • Providers should always be declared as final • riverpod_final_provider

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('goldens', () async {
+    final result = await Process.run(
+      'flutter',
+      ['pub', 'run', 'custom_lint'],
+      stdoutEncoding: utf8,
+    );
+
+    expect(result.stdout, '''
+  test/goldens/avoid_dynamic_provider.dart:10:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
+  test/goldens/avoid_dynamic_provider.dart:14:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
+  test/goldens/avoid_dynamic_provider.dart:15:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
+  test/goldens/avoid_dynamic_provider.dart:16:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
+  test/goldens/final_provider.dart:5:14 • Providers should always be declared as final • riverpod_final_provider
+  test/goldens/final_provider.dart:6:51 • Providers should always be declared as final • riverpod_final_provider
+  test/goldens/final_provider.dart:11:5 • Providers should always be declared as final • riverpod_final_provider
+  test/goldens/final_provider.dart:13:5 • Providers should always be declared as final • riverpod_final_provider
+  test/goldens/final_provider.dart:15:42 • Providers should always be declared as final • riverpod_final_provider
+  test/goldens/read_vs_watch.dart:10:3 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
+  test/goldens/read_vs_watch.dart:13:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:18:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:26:5 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
+  test/goldens/read_vs_watch.dart:29:7 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:34:7 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:45:5 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
+  test/goldens/read_vs_watch.dart:48:7 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:53:7 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:65:5 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
+  test/goldens/read_vs_watch.dart:69:7 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
+  test/goldens/read_vs_watch.dart:75:9 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:85:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:94:5 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
+  test/goldens/read_vs_watch.dart:98:7 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
+  test/goldens/read_vs_watch.dart:104:9 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:114:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:121:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+  test/goldens/read_vs_watch.dart:128:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
+''');
+  });
+}

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -18,9 +18,13 @@ Future<void> main() async {
   test/goldens/avoid_dynamic_provider.dart:16:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
   test/goldens/dependencies.dart:20:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
   test/goldens/dependencies.dart:25:22 • This provider specifies that it depends on "b" yet it never uses that provider. • riverpod_unused_dependency
-  test/goldens/dependencies.dart:42:7 • This provider does not specifies `dependencies`, yet depends on "c" which did specify its dependencies. • riverpod_unspecified_dependencies
-  test/goldens/dependencies.dart:62:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
-  test/goldens/dependencies.dart:79:19 • This provider specifies that it depends on "a" yet it never uses that provider. • riverpod_unused_dependency
+  test/goldens/dependencies.dart:42:7 • This provider does not specify `dependencies`, yet depends on "c" which did specify its dependencies. • riverpod_unspecified_dependencies
+  test/goldens/dependencies.dart:64:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
+  test/goldens/dependencies.dart:82:19 • This provider specifies that it depends on "a" yet it never uses that provider. • riverpod_unused_dependency
+  test/goldens/dependencies.dart:93:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
+  test/goldens/dependencies.dart:110:48 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
+  test/goldens/dependencies.dart:122:60 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
+  test/goldens/dependencies.dart:136:4 • This provider depends on "a" yet "a" isn't listed in the dependencies. • riverpod_missing_dependency
   test/goldens/final_provider.dart:5:14 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:6:51 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:11:5 • Providers should always be declared as final • riverpod_final_provider

--- a/packages/riverpod_lint_flutter_test/test/goldens/avoid_dynamic_provider.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/avoid_dynamic_provider.dart
@@ -1,0 +1,17 @@
+// ignore_for_file: unused_element, unused_local_variable
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final global = Provider((ref) => 0);
+
+class Class {
+  static final topLevel = Provider((ref) => 0);
+
+  final local = Provider((ref) => 0);
+}
+
+void fn() {
+  final shouldBeTopLevel = Provider((ref) => 0);
+  final shouldBeTopLevelFamily = Provider.family<int, int>((ref, id) => 0);
+  final shouldBeTopLevelAutoDispose = Provider.autoDispose((ref) => 0);
+}

--- a/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
@@ -72,7 +72,7 @@ class K extends StateNotifier<int> {
 
 final l = StateProvider.autoDispose((ref) {
   return 0;
-}, dependencies: [a]);
+}, dependencies: []);
 
 final m = StateProvider.autoDispose.family((ref, param) {
   return 0;

--- a/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
@@ -57,4 +57,26 @@ class J extends StateNotifier<int> {
   }
 }
 
-// TODO check .autoDispose/family definition and family/select dependencies
+final k = StateNotifierProvider<K, int>((ref) {
+  return K(ref);
+}, dependencies: []);
+
+class K extends StateNotifier<int> {
+  K(this.ref) : super(0);
+  final Ref ref;
+
+  void fn() {
+    ref.read(a);
+  }
+}
+
+final l = StateProvider.autoDispose((ref) {
+  return 0;
+}, dependencies: [a]);
+
+final m = StateProvider.autoDispose.family((ref, param) {
+  return 0;
+}, dependencies: [a]);
+
+// TODO check random Service
+// TODO test passing ref to a function/method

--- a/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
@@ -1,0 +1,60 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final a = StateProvider<int>((ref) {
+  return 0;
+});
+
+final b = StateProvider<int>((ref) {
+  ref.watch(a);
+  return 0;
+});
+
+final c = StateProvider<int>((ref) {
+  ref.watch(a);
+  return 0;
+}, dependencies: [a]);
+
+final d = StateProvider<int>((ref) {
+  ref.watch(a);
+  return 0;
+}, dependencies: []);
+
+final e = StateProvider<int>((ref) {
+  ref.watch(a);
+  return 0;
+}, dependencies: [a, b]);
+
+final f = StateProvider<int>((ref) {
+  ref.watch(a.notifier);
+  return 0;
+}, dependencies: [a]);
+
+final g = StateProvider<int>((ref) {
+  ref.watch(b);
+  return 0;
+}, dependencies: [b]);
+
+final h = StateProvider<int>((ref) {
+  ref.watch(c);
+  return 0;
+}, dependencies: [c]);
+
+final i = StateProvider<int>((ref) {
+  ref.watch(c);
+  return 0;
+});
+
+final j = StateNotifierProvider<J, int>((ref) {
+  return J(ref);
+});
+
+class J extends StateNotifier<int> {
+  J(this.ref) : super(0);
+  final Ref ref;
+
+  void fn() {
+    ref.read(a);
+  }
+}
+
+// TODO check .autoDispose/family definition and family/select dependencies

--- a/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
@@ -78,5 +78,19 @@ final m = StateProvider.autoDispose.family((ref, param) {
   return 0;
 }, dependencies: [a]);
 
-// TODO check random Service
-// TODO test passing ref to a function/method
+final n = StateProvider((ref) {
+  fn(ref);
+  return 0;
+}, dependencies: [a]);
+
+final o = StateProvider((ref) {
+  fn(ref);
+  return 0;
+}, dependencies: []);
+
+void fn(Ref ref) {
+  ref.watch(a);
+}
+
+// TODO handle Provider(Service.new);
+// TODO check dynamic ref invocation

--- a/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
@@ -44,6 +44,7 @@ final i = StateProvider<int>((ref) {
   return 0;
 });
 
+// Notifier without specified dependencies
 final j = StateNotifierProvider<J, int>((ref) {
   return J(ref);
 });
@@ -57,6 +58,7 @@ class J extends StateNotifier<int> {
   }
 }
 
+// Notifier with dependency
 final k = StateNotifierProvider<K, int>((ref) {
   return K(ref);
 }, dependencies: []);
@@ -70,6 +72,7 @@ class K extends StateNotifier<int> {
   }
 }
 
+// Provider variants (autoDispose / family)
 final l = StateProvider.autoDispose((ref) {
   return 0;
 }, dependencies: []);
@@ -78,6 +81,7 @@ final m = StateProvider.autoDispose.family((ref, param) {
   return 0;
 }, dependencies: [a]);
 
+// Passing ref to a function
 final n = StateProvider((ref) {
   fn(ref);
   return 0;
@@ -92,5 +96,58 @@ void fn(Ref ref) {
   ref.watch(a);
 }
 
-// TODO handle Provider(Service.new);
+final p = StateNotifierProvider<P, int>(P.new);
+
+class P extends StateNotifier<int> {
+  P(this.ref) : super(0);
+  final Ref ref;
+
+  void fn() {
+    ref.read(a);
+  }
+}
+
+final q = StateNotifierProvider<Q, int>(Q.new, dependencies: []);
+
+class Q extends StateNotifier<int> {
+  Q(this.ref) : super(0);
+  final Ref ref;
+
+  void fn() {
+    ref.read(a);
+  }
+}
+
+final r =
+    StateNotifierProvider<R, int>((ref) => R()..ref = ref, dependencies: []);
+
+class R extends StateNotifier<int> {
+  R() : super(0);
+  late final Ref ref;
+
+  void fn() {
+    ref.read(a);
+  }
+}
+
+final s = StateProvider((ref) {
+  get() => ref;
+  get().watch(a);
+}, dependencies: []);
+
+// TODO: Ref escape analysis
+final t = StateNotifierProvider<T, int>((ref) {
+  get() => ref;
+  return T(get);
+}, dependencies: []);
+
+class T extends StateNotifier<int> {
+  T(this.get) : super(0);
+  final Ref Function() get;
+
+  void fn() {
+    get().read(a);
+  }
+}
+
 // TODO check dynamic ref invocation

--- a/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/dependencies.dart
@@ -118,8 +118,13 @@ class Q extends StateNotifier<int> {
   }
 }
 
-final r =
+final r1 =
     StateNotifierProvider<R, int>((ref) => R()..ref = ref, dependencies: []);
+final r2 = StateNotifierProvider<R, int>((ref) {
+  final r = R();
+  r.ref = ref;
+  return r;
+}, dependencies: []);
 
 class R extends StateNotifier<int> {
   R() : super(0);
@@ -127,26 +132,6 @@ class R extends StateNotifier<int> {
 
   void fn() {
     ref.read(a);
-  }
-}
-
-final s = StateProvider((ref) {
-  get() => ref;
-  get().watch(a);
-}, dependencies: []);
-
-// TODO: Ref escape analysis
-final t = StateNotifierProvider<T, int>((ref) {
-  get() => ref;
-  return T(get);
-}, dependencies: []);
-
-class T extends StateNotifier<int> {
-  T(this.get) : super(0);
-  final Ref Function() get;
-
-  void fn() {
-    get().read(a);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/goldens/final_provider.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/final_provider.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class Class {
+  static final ok = Provider((ref) => 0);
+  static var staticShouldBeFinal = Provider((ref) => 0);
+  static Provider<int> get shouldBeFinalGetter => Provider((ref) => 0);
+}
+
+final ok = StateProvider((ref) => 0);
+
+var shouldBeFinal = StateProvider.autoDispose((ref) => 0);
+
+var shouldBeFinalFamily = StateProvider.autoDispose.family((ref, value) => 0);
+
+Provider<int> get shouldBeFinalGetter => Provider((ref) => 0);

--- a/packages/riverpod_lint_flutter_test/test/goldens/mutate_in_create.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/mutate_in_create.dart
@@ -1,0 +1,42 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final a = StateProvider((ref) => 'String');
+
+final b = Provider<bool>((ref) {
+  ref.watch(a.notifier).state = '';
+  return false;
+});
+
+final c = StateNotifierProvider<C, int>((ref) {
+  return C(ref);
+});
+
+class C extends StateNotifier<int> {
+  C(this.ref) : super(0) {
+    ref.read(a.notifier).state = '';
+    Future.delayed(Duration(milliseconds: 10), () {
+      ref.read(a.notifier).state = '';
+    });
+    ref.read(a.notifier).state = '';
+    fn();
+    fn2();
+    fn3();
+  }
+  final Ref ref;
+
+  void fn() {
+    ref.read(a.notifier).state = '';
+  }
+
+  // Not okay
+  Future<void> fn2() async {
+    ref.read(a.notifier).state = '';
+    await Future.delayed(Duration(seconds: 1));
+  }
+
+  // Okay
+  Future<void> fn3() async {
+    await Future.delayed(Duration(seconds: 1));
+    ref.read(a.notifier).state = '';
+  }
+}

--- a/packages/riverpod_lint_flutter_test/test/goldens/read_vs_watch.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/read_vs_watch.dart
@@ -1,0 +1,131 @@
+// ignore_for_file: unused_element, unused_local_variable
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final provider = Provider((ref) => 0);
+
+final another = Provider((ref) {
+  ref.watch(provider);
+  ref.read(provider);
+
+  void fn() {
+    ref.watch(provider);
+    ref.read(provider);
+  }
+
+  final fn2 = () {
+    ref.watch(provider);
+    ref.read(provider);
+  };
+});
+
+final foo = Consumer(
+  builder: (context, ref, child) {
+    ref.watch(provider);
+    ref.read(provider);
+
+    void fn() {
+      ref.watch(provider);
+      ref.read(provider);
+    }
+
+    final fn2 = () {
+      ref.watch(provider);
+      ref.read(provider);
+    };
+
+    return Container();
+  },
+);
+
+final bar = HookConsumer(
+  builder: (context, ref, child) {
+    ref.watch(provider);
+    ref.read(provider);
+
+    void fn() {
+      ref.watch(provider);
+      ref.read(provider);
+    }
+
+    final fn2 = () {
+      ref.watch(provider);
+      ref.read(provider);
+    };
+
+    return Container();
+  },
+);
+
+class Home extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(provider);
+    ref.read(provider);
+
+    Builder(builder: (context) {
+      ref.watch(provider);
+      ref.read(provider);
+      return Container();
+    });
+
+    FloatingActionButton(
+      onPressed: () {
+        ref.watch(provider);
+        ref.read(provider);
+      },
+      child: const Icon(Icons.add),
+    );
+
+    return Container();
+  }
+
+  void fn(WidgetRef ref) {
+    ref.watch(provider);
+    ref.read(provider);
+  }
+}
+
+class HookHome extends HookConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(provider);
+    ref.read(provider);
+
+    Builder(builder: (context) {
+      ref.watch(provider);
+      ref.read(provider);
+      return Container();
+    });
+
+    FloatingActionButton(
+      onPressed: () {
+        ref.watch(provider);
+        ref.read(provider);
+      },
+      child: const Icon(Icons.add),
+    );
+
+    return Container();
+  }
+
+  void fn(WidgetRef ref) {
+    ref.watch(provider);
+    ref.read(provider);
+  }
+}
+
+class Counter extends StateNotifier<int> {
+  Counter(this.ref) : super(0) {
+    ref.watch(provider);
+    ref.read(provider);
+  }
+
+  final Ref ref;
+
+  void increment() {
+    ref.watch(provider);
+    ref.read(provider);
+  }
+}

--- a/packages/riverpod_lint_flutter_test/test/goldens/ref_escape_scope.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/ref_escape_scope.dart
@@ -1,0 +1,56 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter/material.dart';
+
+final a = StateProvider((ref) => '');
+
+final b = StateNotifierProvider<B, int>((ref) {
+  get() => ref;
+  return B(get);
+});
+
+class B extends StateNotifier<int> {
+  B(this.get) : super(0);
+  final Ref Function() get;
+
+  void fn() {
+    get().read(a);
+  }
+}
+
+class C extends ConsumerWidget {
+  const C({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(children: [
+      BadWidgetA(ref: ref),
+      BadWidgetB(ref: ref),
+    ]);
+  }
+}
+
+class BadWidgetA extends StatelessWidget {
+  const BadWidgetA({super.key, this.ref});
+  final WidgetRef? ref;
+  @override
+  Widget build(BuildContext context) {
+    throw UnimplementedError();
+  }
+}
+
+class BadWidgetB extends StatefulWidget {
+  const BadWidgetB({super.key, this.ref});
+  final WidgetRef? ref;
+
+  @override
+  State<StatefulWidget> createState() {
+    return BadWidgetBState();
+  }
+}
+
+class BadWidgetBState extends State<BadWidgetB> {
+  @override
+  Widget build(BuildContext context) {
+    throw UnimplementedError();
+  }
+}


### PR DESCRIPTION
Migrated a few deprecated analyzer apis. Handle dependencies for constructor tearoffs and assignment of ref to objects using cascades.

Still not handling escape of ref via functions. Will work on that next.