### PR TITLE
Adding the link to Amplify Storage example

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -140,6 +140,11 @@ module.exports = {
           label: "Movies API App with Caching & Pagination",
           href: "https://github.com/Roaa94/movies_app",
         },
+        {
+          type: "link",
+          label: "AWS Amplify Storage Gallery App with Riverpod & Freezed",
+          href: "https://github.com/offlineprogrammer/amplify_storage_app",
+        },        
       ],
     },
     {


### PR DESCRIPTION
A link to an example that uses Riverpod, Freezed and AWS Amplify