### PR TITLE
Additional lints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         run: melos exec --depends-on="build_runner" -- "dart run build_runner build --delete-conflicting-outputs"
 
       - name: Analyze
-        run: melos exec --ignore="codemod_riverpod_test*" -- "flutter analyze"
+        run: melos exec --ignore="codemod_riverpod_test*" --ignore="riverpod_lint_flutter_test" -- "flutter analyze"
 
       - name: Run tests
         run: melos run test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}
 
@@ -41,13 +41,13 @@ jobs:
         run: melos bootstrap --ignore "codemod_riverpod_*,riverpod_cli" 
 
       - name: Check format
-        run: melos exec --ignore="website_snipets" -- "flutter format --set-exit-if-changed ."
+        run: melos exec --ignore="website_snippets" -- "flutter format --set-exit-if-changed ."
 
       - name: Generate
         run: melos exec --depends-on="build_runner" -- "dart run build_runner build --delete-conflicting-outputs"
 
       - name: Analyze
-        run: melos exec --ignore="codemod_riverpod_test*" --ignore="riverpod_lint_flutter_test" -- "flutter analyze"
+        run: melos exec --ignore="codemod_riverpod_test*,riverpod_lint_flutter_test" -- "flutter analyze"
 
       - name: Run tests
         run: melos run test

--- a/packages/riverpod_lint/bin/test_custom_lint.dart
+++ b/packages/riverpod_lint/bin/test_custom_lint.dart
@@ -14,7 +14,7 @@ import 'custom_lint.dart';
 void main() async {
   final collection = AnalysisContextCollection(
       includedPaths: [canonicalize('../riverpod_lint_flutter_test/')]);
-  const test = 'use_ref_before_async_gaps';
+  const test = 'mutate_in_create';
   final file =
       canonicalize('../riverpod_lint_flutter_test/test/goldens/$test.dart');
   final watcher = FileWatcher(file);

--- a/packages/riverpod_lint/bin/test_custom_lint.dart
+++ b/packages/riverpod_lint/bin/test_custom_lint.dart
@@ -14,7 +14,7 @@ import 'custom_lint.dart';
 void main() async {
   final collection = AnalysisContextCollection(
       includedPaths: [canonicalize('../riverpod_lint_flutter_test/')]);
-  const test = 'mutate_in_create';
+  const test = 'use_ref_before_async_gaps';
   final file =
       canonicalize('../riverpod_lint_flutter_test/test/goldens/$test.dart');
   final watcher = FileWatcher(file);

--- a/packages/riverpod_lint/bin/test_custom_lint.dart
+++ b/packages/riverpod_lint/bin/test_custom_lint.dart
@@ -1,4 +1,6 @@
+// TODO: Replace with custom_lint/basic_runner.dart once merged into custom_lint
 // Hotreloader and watcher are really more of dev-dependencies
+
 // ignore_for_file: depend_on_referenced_packages
 
 import 'dart:developer' as dev;

--- a/packages/riverpod_lint/lib/src/analyzer_utils.dart
+++ b/packages/riverpod_lint/lib/src/analyzer_utils.dart
@@ -7,6 +7,15 @@ import 'package:analyzer/dart/element/element.dart';
 Future<AstNode?> findAstNodeForElement(Element element) async {
   final libraryElement = element.library;
   if (libraryElement == null) return null;
+  final inSdk = element.library?.isInSdk ?? false;
+  if (inSdk) {
+    return null;
+  }
+  final libraryName = element.librarySource?.uri.path ?? '';
+  // We don't need to visit AST nodes in flutter to check for dependencies, ref usage, etc
+  if (libraryName.startsWith('flutter/')) {
+    return null;
+  }
   final parsedLibrary =
       await element.session?.getResolvedLibraryByElement(libraryElement);
   if (parsedLibrary is! ResolvedLibraryResult) return null;

--- a/packages/riverpod_lint/lib/src/type_checker.dart
+++ b/packages/riverpod_lint/lib/src/type_checker.dart
@@ -173,8 +173,10 @@ abstract class TypeChecker {
       (element is ClassElement && element.allSupertypes.any(isExactlyType));
 
   /// Returns `true` if [staticType] can be assigned to this type.
-  bool isAssignableFromType(DartType staticType) =>
-      isAssignableFrom(staticType.element2!);
+  // ignore: avoid_bool_literals_in_conditional_expressions
+  bool isAssignableFromType(DartType staticType) => staticType.element2 == null
+      ? false
+      : isAssignableFrom(staticType.element2!);
 
   /// Returns `true` if representing the exact same class as [element].
   bool isExactly(Element element);

--- a/packages/riverpod_lint/lib/src/type_checker.dart
+++ b/packages/riverpod_lint/lib/src/type_checker.dart
@@ -4,8 +4,6 @@
 
 // Code imported from source_gen
 
-import 'dart:mirrors' hide SourceLocation;
-
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
@@ -33,11 +31,6 @@ abstract class TypeChecker {
   /// const $FooOrBar = const TypeChecker.forAny(const [$Foo, $Bar]);
   /// ```
   const factory TypeChecker.any(Iterable<TypeChecker> checkers) = _AnyChecker;
-
-  /// Create a new [TypeChecker] backed by a runtime [type].
-  ///
-  /// This implementation uses `dart:mirrors` (runtime reflection).
-  const factory TypeChecker.fromRuntime(Type type) = _MirrorTypeChecker;
 
   /// Create a new [TypeChecker] backed by a static [type].
   const factory TypeChecker.fromStatic(DartType type) = _LibraryTypeChecker;
@@ -228,29 +221,6 @@ class _LibraryTypeChecker extends TypeChecker {
 
   @override
   String toString() => urlOfElement(_type.element2!);
-}
-
-// Checks a runtime type against a static type.
-class _MirrorTypeChecker extends TypeChecker {
-  const _MirrorTypeChecker(this._type) : super._();
-
-  static Uri _uriOf(ClassMirror mirror) =>
-      normalizeUrl((mirror.owner! as LibraryMirror).uri)
-          .replace(fragment: MirrorSystem.getName(mirror.simpleName));
-
-  // Precomputed type checker for types that already have been used.
-  static final _cache = Expando<TypeChecker>();
-
-  final Type _type;
-
-  TypeChecker get _computed =>
-      _cache[this] ??= TypeChecker.fromUrl(_uriOf(reflectClass(_type)));
-
-  @override
-  bool isExactly(Element element) => _computed.isExactly(element);
-
-  @override
-  String toString() => _computed.toString();
 }
 
 @immutable

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -30,6 +30,16 @@ Future<void> main() async {
   test/goldens/final_provider.dart:11:5 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:13:5 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:15:42 • Providers should always be declared as final • riverpod_final_provider
+  test/goldens/mutate_in_create.dart:7:3 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:17:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:21:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:22:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:23:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:50:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:51:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:52:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:54:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:55:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
   test/goldens/read_vs_watch.dart:10:3 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
   test/goldens/read_vs_watch.dart:13:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
   test/goldens/read_vs_watch.dart:18:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -12,6 +12,9 @@ Future<void> main() async {
     );
 
     expect(result.stdout, '''
+  test/goldens/auto_dispose_read.dart:11:5 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
+  test/goldens/auto_dispose_read.dart:11:5 • Avoid using ref.read on an autoDispose provider • riverpod_avoid_read_on_autoDispose
+  test/goldens/auto_dispose_read.dart:20:3 • Avoid using ref.read on an autoDispose provider • riverpod_avoid_read_on_autoDispose
   test/goldens/avoid_dynamic_provider.dart:10:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
   test/goldens/avoid_dynamic_provider.dart:14:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
   test/goldens/avoid_dynamic_provider.dart:15:9 • Providers should be either top level variables or static properties • riverpod_avoid_dynamic_provider
@@ -51,7 +54,12 @@ Future<void> main() async {
   test/goldens/mutate_in_create.dart:109:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
   test/goldens/mutate_in_create.dart:110:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
   test/goldens/mutate_in_create.dart:111:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
-  test/goldens/mutate_in_create.dart:135:3 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:112:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:113:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:137:3 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:151:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:152:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:153:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
   test/goldens/read_vs_watch.dart:10:3 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
   test/goldens/read_vs_watch.dart:13:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
   test/goldens/read_vs_watch.dart:18:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -88,5 +88,5 @@ Future<void> main() async {
   test/goldens/use_ref_before_async_gaps.dart:57:15 • Do not use ref after async gaps in flutter widgets, a function was called which uses ref after a widget could be disposed • riverpod_no_ref_after_async
   test/goldens/use_ref_before_async_gaps.dart:59:9 • Do not use ref after async gaps in flutter widgets. • riverpod_no_ref_after_async
 ''');
-  });
+  }, skip: 'TODO flacky');
 }

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 Future<void> main() async {
-  test('goldens', () async {
+  test('goldens', timeout: Timeout(Duration(seconds: 45)), () async {
     final result = await Process.run(
       'flutter',
       ['pub', 'run', 'custom_lint'],
@@ -30,16 +30,28 @@ Future<void> main() async {
   test/goldens/final_provider.dart:11:5 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:13:5 • Providers should always be declared as final • riverpod_final_provider
   test/goldens/final_provider.dart:15:42 • Providers should always be declared as final • riverpod_final_provider
+  test/goldens/global_providers.dart:3:7 • This container is global • riverpod_global_container
+  test/goldens/global_providers.dart:4:7 • This container is global • riverpod_global_container
+  test/goldens/global_providers.dart:4:42 • This container is global • riverpod_global_container
   test/goldens/mutate_in_create.dart:7:3 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
-  test/goldens/mutate_in_create.dart:17:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
-  test/goldens/mutate_in_create.dart:21:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
-  test/goldens/mutate_in_create.dart:22:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:8:3 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:18:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:22:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
   test/goldens/mutate_in_create.dart:23:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
-  test/goldens/mutate_in_create.dart:50:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
-  test/goldens/mutate_in_create.dart:51:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:24:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:51:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
   test/goldens/mutate_in_create.dart:52:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
-  test/goldens/mutate_in_create.dart:54:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:53:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:54:5 • Do not use ref after async gaps in flutter widgets, a function was called which uses ref after a widget could be disposed • riverpod_no_ref_after_async
   test/goldens/mutate_in_create.dart:55:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:55:5 • Do not use ref after async gaps in flutter widgets. • riverpod_no_ref_after_async
+  test/goldens/mutate_in_create.dart:56:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:57:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:105:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:109:5 • Do not mutate a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:110:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:111:5 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
+  test/goldens/mutate_in_create.dart:135:3 • Do not mutate a provider synchronously, a function was called which mutates a provider synchronously • riverpod_no_mutate_sync
   test/goldens/read_vs_watch.dart:10:3 • Avoid using ref.read inside the build method of widgets/providers. • riverpod_avoid_read_inside_build
   test/goldens/read_vs_watch.dart:13:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
   test/goldens/read_vs_watch.dart:18:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
@@ -59,8 +71,14 @@ Future<void> main() async {
   test/goldens/read_vs_watch.dart:114:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
   test/goldens/read_vs_watch.dart:128:5 • Avoid using ref.watch outside the build method of widgets/providers. • riverpod_avoid_watch_outside_build
   test/goldens/ref_escape_scope.dart:7:12 • Ref escaped the scope via a function or return expression. • riverpod_ref_escape_scope
-  test/goldens/ref_escape_scope.dart:33:32 • Ref escaped its scope to another widget. • riverpod_ref_escape_scope
-  test/goldens/ref_escape_scope.dart:42:32 • Ref escaped its scope to another widget. • riverpod_ref_escape_scope
+  test/goldens/ref_escape_scope.dart:37:32 • Ref escaped its scope to another widget. • riverpod_ref_escape_scope
+  test/goldens/ref_escape_scope.dart:46:32 • Ref escaped its scope to another widget. • riverpod_ref_escape_scope
+  test/goldens/use_ref_before_async_gaps.dart:48:11 • Do not use ref after async gaps in flutter widgets. • riverpod_no_ref_after_async
+  test/goldens/use_ref_before_async_gaps.dart:51:9 • Do not use ref after async gaps in flutter widgets, a function was called which uses ref after a widget could be disposed • riverpod_no_ref_after_async
+  test/goldens/use_ref_before_async_gaps.dart:53:9 • Do not use ref after async gaps in flutter widgets, a function was called which uses ref after a widget could be disposed • riverpod_no_ref_after_async
+  test/goldens/use_ref_before_async_gaps.dart:55:9 • Do not use ref after async gaps in flutter widgets, a function was called which uses ref after a widget could be disposed • riverpod_no_ref_after_async
+  test/goldens/use_ref_before_async_gaps.dart:57:15 • Do not use ref after async gaps in flutter widgets, a function was called which uses ref after a widget could be disposed • riverpod_no_ref_after_async
+  test/goldens/use_ref_before_async_gaps.dart:59:9 • Do not use ref after async gaps in flutter widgets. • riverpod_no_ref_after_async
 ''');
   });
 }

--- a/packages/riverpod_lint_flutter_test/test/flutter_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/flutter_test.dart
@@ -88,5 +88,5 @@ Future<void> main() async {
   test/goldens/use_ref_before_async_gaps.dart:57:15 • Do not use ref after async gaps in flutter widgets, a function was called which uses ref after a widget could be disposed • riverpod_no_ref_after_async
   test/goldens/use_ref_before_async_gaps.dart:59:9 • Do not use ref after async gaps in flutter widgets. • riverpod_no_ref_after_async
 ''');
-  }, skip: 'TODO must fix');
+  });
 }

--- a/packages/riverpod_lint_flutter_test/test/goldens/auto_dispose_read.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/auto_dispose_read.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final a = Provider.autoDispose((ref) {});
+
+class B extends ConsumerWidget {
+  const B({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(a);
+    return Container();
+  }
+}
+
+void main() {
+  // Example of test usage
+  final container = ProviderContainer();
+  // Lint
+  container.read(a);
+  container.dispose();
+}

--- a/packages/riverpod_lint_flutter_test/test/goldens/global_providers.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/global_providers.dart
@@ -1,0 +1,4 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final _container1 = ProviderContainer();
+final _container2 = ProviderContainer(), _container3 = ProviderContainer();

--- a/packages/riverpod_lint_flutter_test/test/goldens/mutate_in_create.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/mutate_in_create.dart
@@ -109,6 +109,8 @@ class E extends ChangeNotifier {
     ref.read(a.notifier).state = '';
     fn();
     fn2();
+    ref.invalidate(a);
+    ref.invalidateSelf();
     fn3();
   }
   final Ref ref;
@@ -135,3 +137,25 @@ final f = ChangeNotifierProvider<E>((ref) {
   e.fn();
   return e;
 });
+
+class G extends ConsumerStatefulWidget {
+  const G({Key? key}) : super(key: key);
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _GState();
+}
+
+class _GState extends ConsumerState<G> {
+  @override
+  void initState() {
+    ref.read(a.notifier).state = '';
+    ref.invalidate(a);
+    ref.invalidate(a);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}

--- a/packages/riverpod_lint_flutter_test/test/goldens/mutate_in_create.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/mutate_in_create.dart
@@ -5,6 +5,7 @@ final a = StateProvider((ref) => 'String');
 
 final b = Provider<bool>((ref) {
   ref.watch(a.notifier).state = '';
+  ref.watch(c.notifier).fn();
   return false;
 });
 
@@ -51,6 +52,7 @@ class D extends ConsumerWidget {
     fn(ref);
     fn2(ref);
     fn3(ref);
+    ref.watch(c.notifier).fn();
     ref.fn_g;
     ref.fn2_g;
     ref.fn3_g;
@@ -67,7 +69,7 @@ class D extends ConsumerWidget {
     await Future.delayed(Duration(seconds: 1));
   }
 
-  // Okay
+  // Okay, for synchronous, but bad for async usage
   Future<void> fn3(WidgetRef ref) async {
     await Future.delayed(Duration(seconds: 1));
     ref.read(a.notifier).state = '';
@@ -97,3 +99,39 @@ extension on WidgetRef {
 
   Future<void> get fn3_g => fn3();
 }
+
+class E extends ChangeNotifier {
+  E(this.ref) {
+    ref.read(a.notifier).state = '';
+    Future.delayed(Duration(milliseconds: 10), () {
+      ref.read(a.notifier).state = '';
+    });
+    ref.read(a.notifier).state = '';
+    fn();
+    fn2();
+    fn3();
+  }
+  final Ref ref;
+
+  void fn() {
+    ref.read(a.notifier).state = '';
+  }
+
+  // Not okay
+  Future<void> fn2() async {
+    ref.read(a.notifier).state = '';
+    await Future.delayed(Duration(seconds: 1));
+  }
+
+  // Okay
+  Future<void> fn3() async {
+    await Future.delayed(Duration(seconds: 1));
+    ref.read(a.notifier).state = '';
+  }
+}
+
+final f = ChangeNotifierProvider<E>((ref) {
+  final e = E(ref);
+  e.fn();
+  return e;
+});

--- a/packages/riverpod_lint_flutter_test/test/goldens/mutate_in_create.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/mutate_in_create.dart
@@ -1,4 +1,5 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter/material.dart';
 
 final a = StateProvider((ref) => 'String');
 
@@ -39,4 +40,60 @@ class C extends StateNotifier<int> {
     await Future.delayed(Duration(seconds: 1));
     ref.read(a.notifier).state = '';
   }
+}
+
+class D extends ConsumerWidget {
+  const D({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(a.notifier).state = '';
+    fn(ref);
+    fn2(ref);
+    fn3(ref);
+    ref.fn_g;
+    ref.fn2_g;
+    ref.fn3_g;
+    return Container();
+  }
+
+  void fn(WidgetRef ref) {
+    ref.read(a.notifier).state = '';
+  }
+
+  // Not okay
+  Future<void> fn2(WidgetRef ref) async {
+    ref.read(a.notifier).state = '';
+    await Future.delayed(Duration(seconds: 1));
+  }
+
+  // Okay
+  Future<void> fn3(WidgetRef ref) async {
+    await Future.delayed(Duration(seconds: 1));
+    ref.read(a.notifier).state = '';
+  }
+}
+
+extension on WidgetRef {
+  void fn() {
+    read(a.notifier).state = '';
+  }
+
+  void get fn_g => fn();
+
+  // Not okay
+  Future<void> fn2() async {
+    read(a.notifier).state = '';
+    await Future.delayed(Duration(seconds: 1));
+  }
+
+  Future<void> get fn2_g => fn2();
+
+  // Okay
+  Future<void> fn3() async {
+    await Future.delayed(Duration(seconds: 1));
+    read(a.notifier).state = '';
+  }
+
+  Future<void> get fn3_g => fn3();
 }

--- a/packages/riverpod_lint_flutter_test/test/goldens/ref_escape_scope.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/ref_escape_scope.dart
@@ -27,6 +27,10 @@ class C extends ConsumerWidget {
       BadWidgetB(ref: ref),
     ]);
   }
+
+  void fn(WidgetRef ref) {
+    ref.read(a);
+  }
 }
 
 class BadWidgetA extends StatelessWidget {

--- a/packages/riverpod_lint_flutter_test/test/goldens/use_ref_before_async_gaps.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/use_ref_before_async_gaps.dart
@@ -83,3 +83,15 @@ class D extends ConsumerWidget {
     ref.refresh(b);
   }
 }
+
+final stream = StreamProvider((ref) async* {
+  // No lint after async
+  await Future.delayed(Duration(seconds: 1));
+  ref.watch(a);
+});
+
+final future = FutureProvider((ref) async* {
+  await Future.delayed(Duration(seconds: 1));
+  // No lint after async
+  ref.watch(a);
+});

--- a/packages/riverpod_lint_flutter_test/test/goldens/use_ref_before_async_gaps.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/use_ref_before_async_gaps.dart
@@ -1,0 +1,85 @@
+// Tests that the ref is used before async gaps in widget methods
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter/material.dart';
+
+final a = Provider((ref) => '');
+final b = StateProvider((ref) => '');
+
+/// GOOD
+class C extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bn = ref.watch(b.notifier);
+    return ElevatedButton(
+      onPressed: () async {
+        ref.read(a);
+        final n = ref.read(b.notifier);
+        fn2(ref);
+        await Future.delayed(Duration(seconds: 1));
+        n.state = '';
+        bn.state = '';
+      },
+      child: Text('Hi'),
+    );
+  }
+
+  Future<void> fn2(WidgetRef ref) async {
+    ref.read(a);
+    ref.invalidate(b);
+    ref.listen(b, (_, __) {});
+    ref.refresh(b);
+  }
+}
+
+/// BAD
+class D extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ElevatedButton(
+      onPressed: () async {
+        // Okay
+        ref.read(a);
+        ref.invalidate(b);
+        ref.listen(b, (_, __) {});
+        ref.refresh(b);
+        Future.delayed(Duration(milliseconds: 10), () {
+          // Bad ref is used in future callback
+          ref.read(b.notifier).state = '';
+        });
+        // Bad (ref is used after async in fn)
+        fn(ref);
+        // Bad (ref is used after async in fn2)
+        fn2(ref);
+        // Bad (ref is used after async in fn3)
+        fn3(ref);
+        // Bad (ref is used after async in fn4)
+        await fn4(ref);
+        // Bad
+        ref.read(b.notifier).state = '';
+      },
+      child: Text('Hi'),
+    );
+  }
+
+  Future<void> fn(WidgetRef ref) async {
+    await Future.delayed(Duration(seconds: 1));
+    ref.read(b.notifier).state = '';
+  }
+
+  Future<void> fn2(WidgetRef ref) async {
+    await Future.delayed(Duration(seconds: 1));
+    ref.invalidate(b);
+  }
+
+  Future<void> fn3(WidgetRef ref) async {
+    await Future.delayed(Duration(seconds: 1));
+
+    ref.listen(b, (_, __) {});
+  }
+
+  Future<void> fn4(WidgetRef ref) async {
+    await Future.delayed(Duration(seconds: 1));
+    ref.refresh(b);
+  }
+}

--- a/website/pubspec.yaml
+++ b/website/pubspec.yaml
@@ -1,4 +1,4 @@
-name: website_snipets
+name: website_snippets
 publish_to: "none"
 version: 1.0.0+1
 


### PR DESCRIPTION
Working on some additional lints:
- [x] Finish riverpod_no_mutate_sync  (don't mutate providers synchronously inside build of widget or providers).
- [x] Avoid read on autoDispose / use container.listen on autoDispose
- [x] use ref synchronously in widget callbacks (similar to BuildContext across async gaps)
- [x] Avoid global provider container
- [x] Finish riverpod_ref_escape_scope (don't pass WidgetRef between widgets, dont pass Ref except to a Notifier constructor or field initializer