### PR TITLE
add pubspec overrides

### DIFF
--- a/examples/counter/pubspec_overrides.yaml
+++ b/examples/counter/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: flutter_riverpod,hooks_riverpod,riverpod
+# melos_managed_dependency_overrides: flutter_riverpod,hooks_riverpod,riverpod,riverpod_lint
 dependency_overrides:
   flutter_riverpod:
     path: ../../packages/flutter_riverpod
@@ -6,3 +6,5 @@ dependency_overrides:
     path: ../../packages/hooks_riverpod
   riverpod:
     path: ../../packages/riverpod
+  riverpod_lint:
+    path: ../../packages/riverpod_lint

--- a/examples/pub/pubspec_overrides.yaml
+++ b/examples/pub/pubspec_overrides.yaml
@@ -1,3 +1,4 @@
+# melos_managed_dependency_overrides: flutter_riverpod,hooks_riverpod,riverpod,riverpod_annotation,riverpod_generator
 dependency_overrides:
   flutter_riverpod:
     path: ../../packages/flutter_riverpod

--- a/examples/random_number/pubspec_overrides.yaml
+++ b/examples/random_number/pubspec_overrides.yaml
@@ -1,0 +1,6 @@
+# melos_managed_dependency_overrides: flutter_riverpod,riverpod
+dependency_overrides:
+  flutter_riverpod:
+    path: ../../packages/flutter_riverpod
+  riverpod:
+    path: ../../packages/riverpod

--- a/examples/stackoverflow/pubspec_overrides.yaml
+++ b/examples/stackoverflow/pubspec_overrides.yaml
@@ -1,3 +1,4 @@
+# melos_managed_dependency_overrides: flutter_riverpod,hooks_riverpod,riverpod,riverpod_annotation,riverpod_generator
 dependency_overrides:
   flutter_riverpod:
     path: ../../packages/flutter_riverpod

--- a/examples/todos/pubspec_overrides.yaml
+++ b/examples/todos/pubspec_overrides.yaml
@@ -1,3 +1,4 @@
+# melos_managed_dependency_overrides: flutter_riverpod,hooks_riverpod,riverpod
 dependency_overrides:
   flutter_riverpod:
     path: ../../packages/flutter_riverpod
@@ -5,7 +6,3 @@ dependency_overrides:
     path: ../../packages/hooks_riverpod
   riverpod:
     path: ../../packages/riverpod
-  riverpod_annotation:
-    path: ../../packages/riverpod_annotation
-  riverpod_generator:
-    path: ../../packages/riverpod_generator

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,5 +1,9 @@
 name: my_project
 
+command:
+  bootstrap:
+    usePubspecOverrides: true
+
 packages:
   - website/**
   - packages/**

--- a/packages/flutter_riverpod/example/pubspec_overrides.yaml
+++ b/packages/flutter_riverpod/example/pubspec_overrides.yaml
@@ -1,8 +1,8 @@
 # melos_managed_dependency_overrides: flutter_riverpod,hooks_riverpod,riverpod
 dependency_overrides:
   flutter_riverpod:
-    path: ../../packages/flutter_riverpod
+    path: ../../flutter_riverpod
   hooks_riverpod:
-    path: ../../packages/hooks_riverpod
+    path: ../../hooks_riverpod
   riverpod:
-    path: ../../packages/riverpod
+    path: ../../riverpod

--- a/packages/flutter_riverpod/pubspec_overrides.yaml
+++ b/packages/flutter_riverpod/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: riverpod
+dependency_overrides:
+  riverpod:
+    path: ../riverpod

--- a/packages/hooks_riverpod/example/pubspec_overrides.yaml
+++ b/packages/hooks_riverpod/example/pubspec_overrides.yaml
@@ -1,8 +1,8 @@
 # melos_managed_dependency_overrides: flutter_riverpod,hooks_riverpod,riverpod
 dependency_overrides:
   flutter_riverpod:
-    path: ../../packages/flutter_riverpod
+    path: ../../flutter_riverpod
   hooks_riverpod:
-    path: ../../packages/hooks_riverpod
+    path: ..
   riverpod:
-    path: ../../packages/riverpod
+    path: ../../riverpod

--- a/packages/hooks_riverpod/pubspec_overrides.yaml
+++ b/packages/hooks_riverpod/pubspec_overrides.yaml
@@ -1,0 +1,6 @@
+# melos_managed_dependency_overrides: flutter_riverpod,riverpod
+dependency_overrides:
+  flutter_riverpod:
+    path: ../flutter_riverpod
+  riverpod:
+    path: ../riverpod

--- a/packages/riverpod/example/pubspec_overrides.yaml
+++ b/packages/riverpod/example/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: riverpod
+dependency_overrides:
+  riverpod:
+    path: ..

--- a/packages/riverpod_annotation/pubspec_overrides.yaml
+++ b/packages/riverpod_annotation/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: riverpod
+dependency_overrides:
+  riverpod:
+    path: ../riverpod

--- a/packages/riverpod_cli/fixtures/unified_syntax/golden/pubspec.yaml
+++ b/packages/riverpod_cli/fixtures/unified_syntax/golden/pubspec.yaml
@@ -10,6 +10,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks:
-  flutter_riverpod: ^1.0.0-dev.10
-  hooks_riverpod: ^1.0.0-dev.10
-  riverpod: ^1.0.0-dev.10
+  flutter_riverpod: ^1.0.4
+  hooks_riverpod: ^1.0.4
+  riverpod: ^1.0.3+1

--- a/packages/riverpod_cli/fixtures/unified_syntax/golden/pubspec_overrides.yaml
+++ b/packages/riverpod_cli/fixtures/unified_syntax/golden/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+dependency_overrides:
+  flutter_riverpod: ^1.0.4
+  hooks_riverpod: ^1.0.4
+  riverpod: ^1.0.3+1

--- a/packages/riverpod_generator/pubspec_overrides.yaml
+++ b/packages/riverpod_generator/pubspec_overrides.yaml
@@ -1,5 +1,6 @@
+# melos_managed_dependency_overrides: riverpod,riverpod_annotation
 dependency_overrides:
-  riverpod_annotation:
-    path: ../riverpod_annotation
   riverpod:
     path: ../riverpod
+  riverpod_annotation:
+    path: ../riverpod_annotation

--- a/packages/riverpod_graph/test/integration/addition/golden/pubspec_overrides.yaml
+++ b/packages/riverpod_graph/test/integration/addition/golden/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: riverpod
+dependency_overrides:
+  riverpod:
+    path: ../../../../../riverpod

--- a/packages/riverpod_graph/test/integration/consumer_widget/golden/pubspec_overrides.yaml
+++ b/packages/riverpod_graph/test/integration/consumer_widget/golden/pubspec_overrides.yaml
@@ -1,0 +1,6 @@
+# melos_managed_dependency_overrides: flutter_riverpod,riverpod
+dependency_overrides:
+  flutter_riverpod:
+    path: ../../../../../../packages/flutter_riverpod
+  riverpod:
+    path: ../../../../../../packages/riverpod

--- a/packages/riverpod_graph/test/integration/generated/golden/pubspec_overrides.yaml
+++ b/packages/riverpod_graph/test/integration/generated/golden/pubspec_overrides.yaml
@@ -1,0 +1,10 @@
+# melos_managed_dependency_overrides: flutter_riverpod,riverpod,riverpod_annotation,riverpod_generator
+dependency_overrides:
+  flutter_riverpod:
+    path: ../../../../../../packages/flutter_riverpod
+  riverpod:
+    path: ../../../../../../packages/riverpod
+  riverpod_annotation:
+    path: ../../../../../../packages/riverpod_annotation
+  riverpod_generator:
+    path: ../../../../../../packages/riverpod_generator

--- a/packages/riverpod_lint/pubspec_overrides.yaml
+++ b/packages/riverpod_lint/pubspec_overrides.yaml
@@ -1,0 +1,4 @@
+# melos_managed_dependency_overrides: riverpod
+dependency_overrides:
+  riverpod:
+    path: ../riverpod

--- a/packages/riverpod_lint_flutter_test/pubspec_overrides.yaml
+++ b/packages/riverpod_lint_flutter_test/pubspec_overrides.yaml
@@ -1,0 +1,14 @@
+# melos_managed_dependency_overrides: riverpod_generator,riverpod,flutter_riverpod,hooks_riverpod,riverpod_annotation,riverpod_lint
+dependency_overrides:
+  riverpod_generator:
+    path: ../riverpod_generator
+  riverpod:
+    path: ../riverpod
+  flutter_riverpod:
+    path: ../flutter_riverpod
+  hooks_riverpod:
+    path: ../hooks_riverpod
+  riverpod_annotation:
+    path: ../riverpod_annotation
+  riverpod_lint:
+    path: ../riverpod_lint

--- a/website/pubspec_overrides.yaml
+++ b/website/pubspec_overrides.yaml
@@ -1,8 +1,8 @@
 # melos_managed_dependency_overrides: flutter_riverpod,hooks_riverpod,riverpod
 dependency_overrides:
   flutter_riverpod:
-    path: ../../packages/flutter_riverpod
+    path: ../packages/flutter_riverpod
   hooks_riverpod:
-    path: ../../packages/hooks_riverpod
+    path: ../packages/hooks_riverpod
   riverpod:
-    path: ../../packages/riverpod
+    path: ../packages/riverpod


### PR DESCRIPTION
Most of these are managed by melos (with a melos config option) since we want path dependencies.

There are a few in the migration tool tests that are managed manually, since we want to control the version there.

This makes it easier to make sure local repos use the right versions for development / test (without the IDE automatically downloading packages that override melos's version). My understanding is that these overrides are ignored for publishing, but if not I think we can also add a .gitignore to prevent them from being published.