### PR TITLE
Update fr migration docs

### DIFF
--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/migration/0.14.0_to_1.0.0.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/migration/0.14.0_to_1.0.0.mdx
@@ -10,7 +10,7 @@ utilisant Riverpod version 0.14.x vers la version 1.0.0.
 
 ## Utiliser l'outil de migration pour automatiquement migrer votre projet
 
-Avant d'expliquer les différents changeemnts, il est important de noter que Riverpod
+Avant d'expliquer les différents changements, il est important de noter que Riverpod
 vient avec une application terminale permettant de mettre à jour votre projet pour vous.
 
 ### Installer l'outil
@@ -31,7 +31,7 @@ riverpod --help
 
 Maintenant que la ligne de commande est installé, nous pouvons l'utiliser.
 
-- Premièrement, ouvrez votre projt dans votre terminal.
+- Premièrement, ouvrez votre projet dans votre terminal.
 - **Ne pas** mettre à jour Riverpod.  
   L'outil de migration va automatiquement changer la version de Riverpod pour vous.
   :::danger
@@ -46,7 +46,7 @@ Maintenant que la ligne de commande est installé, nous pouvons l'utiliser.
   riverpod migrate
   ```
 
-L'outil va ensuite analyser votre projet et suggérer des changements. Comme par example:
+L'outil va ensuite analyser votre projet et suggérer des changements. Comme par exemple:
 
 ```diff
 -Widget build(BuildContext context, ScopedReader watch) {
@@ -67,9 +67,9 @@ notre projet, voyons en detail ces changements.
 
 ### Unification de syntaxe
 
-La version 1.0.0 de Riverpod de concentre sur l'unification de la syntaxe pour
+La version 1.0.0 de Riverpod se concentre sur l'unification de la syntaxe pour
 interagir avec les providers.  
-Avant, Riverpod avait de nombreuses similaire mais différentes syntaxes pour
+Avant, Riverpod avait de nombreuses syntaxes similaires mais différentes pour
 lire un provider, tel que `ref.watch(provider)` vs `useProvider(provider)` vs `watch(provider)`.  
 Avec la version 1.0.0, seule une syntaxe reste: `ref.watch(provider)`. Les autres
 sont quant-à elles supprimés.
@@ -103,7 +103,7 @@ Ce qui veut dire que:
   }
   ```
 
-- Le prototype de la méthode `build` de `ConsumerWidget` et `Consumer` est changée.
+- Le prototype de la méthode `build` de `ConsumerWidget` et `Consumer` est changé.
   Avant:
 
   ```dart


### PR DESCRIPTION
This PR corrects spelling mistakes in the French version of 0.14 to 1.0 migration document.