### PR TITLE
Fix typo

### DIFF
--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -167,7 +167,7 @@ void main() {
 
 Comme vous pouvez le voir, bien que `counterProvider` soit global, aucun état n'est
 partagé entre test.
-Nous n'avons donc pas à nous inquiéter de poentiels problème survenant si
+Nous n'avons donc pas à nous inquiéter de potentiels problèmes survenant si
 l'ordre de nos tests changent, car ils s'executent en complète isolation.
 
 ## Surcharger le comportement d'un provider durant un test


### PR DESCRIPTION
The word "potentiels" is missing a t and the plural for "problèmes"