### PR TITLE
Remove the old pre 1.x dart docs comments

### DIFF
--- a/packages/riverpod/lib/src/framework/foundation.dart
+++ b/packages/riverpod/lib/src/framework/foundation.dart
@@ -85,9 +85,6 @@ mixin ProviderListenable<State> {
 
   /// Partially listen to a provider.
   ///
-  /// Note: This method of listening to an object is currently only supported
-  /// by `ref.watch(` from `hooks_riverpod` and [ProviderContainer.listen].
-  ///
   /// The [select] function allows filtering unwanted rebuilds of a Widget
   /// by reading only the properties that we care about.
   ///


### PR DESCRIPTION
I know this is the smallest PR ever made, but I noticed that the docs onto `select` still mention the fact that this works only within `hooks_riverpod` and `ProviderContainer.listen`.

But this is not true since version 1.0.

