### PR TITLE
doc: fix minor typo

### DIFF
--- a/packages/flutter_riverpod/lib/src/framework.dart
+++ b/packages/flutter_riverpod/lib/src/framework.dart
@@ -366,7 +366,7 @@ To fix this problem, you have one of two solutions:
 
 - Delay your modification, such as by encasuplating the modification
   in a `Future(() {...})`.
-  This will perform your upddate after the widget tree is done building.
+  This will perform your update after the widget tree is done building.
 ''',
         ),
       ]);


### PR DESCRIPTION
Fix a minor typo when an error is thrown.