### PR TITLE
fix: #2003

### DIFF
--- a/packages/riverpod/lib/src/devtool.dart
+++ b/packages/riverpod/lib/src/devtool.dart
@@ -16,10 +16,12 @@ void debugPostEvent(
   String eventKind, [
   Map<Object?, Object?> event = const {},
 ]) {
+  // HACK: https://github.com/rrousselGit/riverpod/issues/2003
+  final _event = {...event};
   if (_debugPostEventOverride != null) {
-    _debugPostEventOverride!(eventKind, event);
+    _debugPostEventOverride!(eventKind, _event);
   } else {
-    developer.postEvent(eventKind, event);
+    developer.postEvent(eventKind, _event);
   }
 }
 


### PR DESCRIPTION
works around #2003 by copying input event map

this is a hack, that must be removed once https://github.com/dart-lang/sdk/issues/50713 is solved