### PR TITLE
Make hashFunctionName private in generator

### DIFF
--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased patch]
+
+- The generated hash function of providers is now correctluy private (thanks to @westito)
+
 ## 1.0.6
 
 Upgrade Riverpod to latest

--- a/packages/riverpod_generator/lib/src/models.dart
+++ b/packages/riverpod_generator/lib/src/models.dart
@@ -58,7 +58,7 @@ class Data {
   final bool keepAlive;
   final String providerDoc;
 
-  String get hashFunctionName => '\$${rawName}Hash';
+  String get hashFunctionName => '_\$${rawName}Hash';
 
   String get hashFn => "const bool.fromEnvironment('dart.vm.product') ? "
       'null : $hashFunctionName';

--- a/packages/riverpod_generator/test/integration/async.g.dart
+++ b/packages/riverpod_generator/test/integration/async.g.dart
@@ -29,7 +29,7 @@ class _SystemHash {
   }
 }
 
-String $PublicClassHash() => r'98f7b5a2478814264c0a70d066ecabfddc58c577';
+String _$PublicClassHash() => r'98f7b5a2478814264c0a70d066ecabfddc58c577';
 
 /// See also [PublicClass].
 final publicClassProvider =
@@ -37,7 +37,7 @@ final publicClassProvider =
   PublicClass.new,
   name: r'publicClassProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $PublicClassHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$PublicClassHash,
 );
 typedef PublicClassRef = AutoDisposeAsyncNotifierProviderRef<String>;
 
@@ -46,15 +46,16 @@ abstract class _$PublicClass extends AutoDisposeAsyncNotifier<String> {
   FutureOr<String> build();
 }
 
-String $_PrivateClassHash() => r'7e69cffe8315999710e4cb6bb3de9f179d3f2f5d';
+String _$_PrivateClassHash() => r'7e69cffe8315999710e4cb6bb3de9f179d3f2f5d';
 
 /// See also [_PrivateClass].
 final _privateClassProvider =
     AutoDisposeAsyncNotifierProvider<_PrivateClass, String>(
   _PrivateClass.new,
   name: r'_privateClassProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $_PrivateClassHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$_PrivateClassHash,
 );
 typedef _PrivateClassRef = AutoDisposeAsyncNotifierProviderRef<String>;
 
@@ -63,7 +64,7 @@ abstract class _$PrivateClass extends AutoDisposeAsyncNotifier<String> {
   FutureOr<String> build();
 }
 
-String $FamilyClassHash() => r'7b31f94e49dff1aa8b2f88d41b8a94e9a6434408';
+String _$FamilyClassHash() => r'7b31f94e49dff1aa8b2f88d41b8a94e9a6434408';
 
 /// See also [FamilyClass].
 class FamilyClassProvider
@@ -86,7 +87,7 @@ class FamilyClassProvider
           debugGetCreateSourceHash:
               const bool.fromEnvironment('dart.vm.product')
                   ? null
-                  : $FamilyClassHash,
+                  : _$FamilyClassHash,
         );
 
   final int first;
@@ -194,27 +195,27 @@ abstract class _$FamilyClass extends BuildlessAutoDisposeAsyncNotifier<String> {
   });
 }
 
-String $publicHash() => r'9d99b79c013da13926d4ad89c72ebca4fc1cc257';
+String _$publicHash() => r'9d99b79c013da13926d4ad89c72ebca4fc1cc257';
 
 /// See also [public].
 final publicProvider = AutoDisposeFutureProvider<String>(
   public,
   name: r'publicProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $publicHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$publicHash,
 );
 typedef PublicRef = AutoDisposeFutureProviderRef<String>;
-String $_privateHash() => r'bc0469a9315de114a0ccd82c7db4980844d0009f';
+String _$_privateHash() => r'bc0469a9315de114a0ccd82c7db4980844d0009f';
 
 /// See also [_private].
 final _privateProvider = AutoDisposeFutureProvider<String>(
   _private,
   name: r'_privateProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $_privateHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$_privateHash,
 );
 typedef _PrivateRef = AutoDisposeFutureProviderRef<String>;
-String $familyHash() => r'f46defb7b007c76254058e9e8bc868260bcfe0f1';
+String _$familyHash() => r'f46defb7b007c76254058e9e8bc868260bcfe0f1';
 
 /// See also [family].
 class FamilyProvider extends AutoDisposeFutureProvider<String> {
@@ -238,7 +239,7 @@ class FamilyProvider extends AutoDisposeFutureProvider<String> {
           debugGetCreateSourceHash:
               const bool.fromEnvironment('dart.vm.product')
                   ? null
-                  : $familyHash,
+                  : _$familyHash,
         );
 
   final int first;

--- a/packages/riverpod_generator/test/integration/auto_dispose.g.dart
+++ b/packages/riverpod_generator/test/integration/auto_dispose.g.dart
@@ -29,23 +29,23 @@ class _SystemHash {
   }
 }
 
-String $keepAliveHash() => r'72dd192676126d487c24c7695a91d59410c62696';
+String _$keepAliveHash() => r'72dd192676126d487c24c7695a91d59410c62696';
 
 /// See also [keepAlive].
 final keepAliveProvider = Provider<int>(
   keepAlive,
   name: r'keepAliveProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $keepAliveHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$keepAliveHash,
 );
 typedef KeepAliveRef = ProviderRef<int>;
-String $notKeepAliveHash() => r'1ccc497d7c651f8e730ec1bcecf271ffe9615d83';
+String _$notKeepAliveHash() => r'1ccc497d7c651f8e730ec1bcecf271ffe9615d83';
 
 /// See also [notKeepAlive].
 final notKeepAliveProvider = AutoDisposeProvider<int>(
   notKeepAlive,
   name: r'notKeepAliveProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $notKeepAliveHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$notKeepAliveHash,
 );
 typedef NotKeepAliveRef = AutoDisposeProviderRef<int>;

--- a/packages/riverpod_generator/test/integration/hash/hash1.g.dart
+++ b/packages/riverpod_generator/test/integration/hash/hash1.g.dart
@@ -29,14 +29,14 @@ class _SystemHash {
   }
 }
 
-String $SimpleClassHash() => r'958123cd6179c5b88da040cfeb71eb3061765277';
+String _$SimpleClassHash() => r'958123cd6179c5b88da040cfeb71eb3061765277';
 
 /// See also [SimpleClass].
 final simpleClassProvider = AutoDisposeNotifierProvider<SimpleClass, String>(
   SimpleClass.new,
   name: r'simpleClassProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $SimpleClassHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$SimpleClassHash,
 );
 typedef SimpleClassRef = AutoDisposeNotifierProviderRef<String>;
 
@@ -45,23 +45,23 @@ abstract class _$SimpleClass extends AutoDisposeNotifier<String> {
   String build();
 }
 
-String $simpleHash() => r'ff9f7451526aef5b3af6646814631a502ad76a5f';
+String _$simpleHash() => r'ff9f7451526aef5b3af6646814631a502ad76a5f';
 
 /// See also [simple].
 final simpleProvider = AutoDisposeProvider<String>(
   simple,
   name: r'simpleProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $simpleHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$simpleHash,
 );
 typedef SimpleRef = AutoDisposeProviderRef<String>;
-String $simple2Hash() => r'06327442776394c5c9cbb33b048d7a42e709e7fd';
+String _$simple2Hash() => r'06327442776394c5c9cbb33b048d7a42e709e7fd';
 
 /// See also [simple2].
 final simple2Provider = AutoDisposeProvider<String>(
   simple2,
   name: r'simple2Provider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $simple2Hash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$simple2Hash,
 );
 typedef Simple2Ref = AutoDisposeProviderRef<String>;

--- a/packages/riverpod_generator/test/integration/sync.g.dart
+++ b/packages/riverpod_generator/test/integration/sync.g.dart
@@ -29,7 +29,7 @@ class _SystemHash {
   }
 }
 
-String $PublicClassHash() => r'f04884c039e6200ad3537feeecfc6e83828b5eb5';
+String _$PublicClassHash() => r'f04884c039e6200ad3537feeecfc6e83828b5eb5';
 
 /// This is some documentation
 ///
@@ -38,7 +38,7 @@ final publicClassProvider = AutoDisposeNotifierProvider<PublicClass, String>(
   PublicClass.new,
   name: r'publicClassProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $PublicClassHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$PublicClassHash,
 );
 typedef PublicClassRef = AutoDisposeNotifierProviderRef<String>;
 
@@ -47,15 +47,16 @@ abstract class _$PublicClass extends AutoDisposeNotifier<String> {
   String build();
 }
 
-String $_PrivateClassHash() => r'6d41def3ffdc1f79e593beaefb3304ce4b211a77';
+String _$_PrivateClassHash() => r'6d41def3ffdc1f79e593beaefb3304ce4b211a77';
 
 /// See also [_PrivateClass].
 final _privateClassProvider =
     AutoDisposeNotifierProvider<_PrivateClass, String>(
   _PrivateClass.new,
   name: r'_privateClassProvider',
-  debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $_PrivateClassHash,
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$_PrivateClassHash,
 );
 typedef _PrivateClassRef = AutoDisposeNotifierProviderRef<String>;
 
@@ -64,7 +65,7 @@ abstract class _$PrivateClass extends AutoDisposeNotifier<String> {
   String build();
 }
 
-String $FamilyClassHash() => r'7dd0013dba8f45e82e8e39fbb2635e5a7f4b9cac';
+String _$FamilyClassHash() => r'7dd0013dba8f45e82e8e39fbb2635e5a7f4b9cac';
 
 /// This is some documentation
 ///
@@ -89,7 +90,7 @@ class FamilyClassProvider
           debugGetCreateSourceHash:
               const bool.fromEnvironment('dart.vm.product')
                   ? null
-                  : $FamilyClassHash,
+                  : _$FamilyClassHash,
         );
 
   final int first;
@@ -199,7 +200,7 @@ abstract class _$FamilyClass extends BuildlessAutoDisposeNotifier<String> {
   });
 }
 
-String $Supports$InClassNameHash() =>
+String _$Supports$InClassNameHash() =>
     r'4e99f433d9cb3598faaf4d172edf9f28b9e68091';
 
 /// See also [Supports$InClassName].
@@ -209,7 +210,7 @@ final supports$InClassNameProvider =
   name: r'supports$InClassNameProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : $Supports$InClassNameHash,
+      : _$Supports$InClassNameHash,
 );
 typedef Supports$InClassNameRef = AutoDisposeNotifierProviderRef<String>;
 
@@ -218,7 +219,7 @@ abstract class _$Supports$InClassName extends AutoDisposeNotifier<String> {
   String build();
 }
 
-String $publicHash() => r'138be35943899793ab085e711fe3f3d22696a3ba';
+String _$publicHash() => r'138be35943899793ab085e711fe3f3d22696a3ba';
 
 /// This is some documentation
 ///
@@ -227,10 +228,10 @@ final publicProvider = AutoDisposeProvider<String>(
   public,
   name: r'publicProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $publicHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$publicHash,
 );
 typedef PublicRef = AutoDisposeProviderRef<String>;
-String $supports$inNamesHash() => r'cbf929802fcbd0aa949ad72743d096fb3ef5f28f';
+String _$supports$inNamesHash() => r'cbf929802fcbd0aa949ad72743d096fb3ef5f28f';
 
 /// See also [supports$inNames].
 final supports$inNamesProvider = AutoDisposeProvider<String>(
@@ -238,10 +239,10 @@ final supports$inNamesProvider = AutoDisposeProvider<String>(
   name: r'supports$inNamesProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : $supports$inNamesHash,
+      : _$supports$inNamesHash,
 );
 typedef Supports$inNamesRef = AutoDisposeProviderRef<String>;
-String $familyHash() => r'14d1ee238ca608d547630d0e222ef4c5866e9e61';
+String _$familyHash() => r'14d1ee238ca608d547630d0e222ef4c5866e9e61';
 
 /// This is some documentation
 ///
@@ -267,7 +268,7 @@ class FamilyProvider extends AutoDisposeProvider<String> {
           debugGetCreateSourceHash:
               const bool.fromEnvironment('dart.vm.product')
                   ? null
-                  : $familyHash,
+                  : _$familyHash,
         );
 
   final int first;
@@ -348,13 +349,13 @@ class FamilyFamily extends Family<String> {
   String? get name => r'familyProvider';
 }
 
-String $_privateHash() => r'519561bc7e88e394d7f75ca2102a5c0acc832c66';
+String _$_privateHash() => r'519561bc7e88e394d7f75ca2102a5c0acc832c66';
 
 /// See also [_private].
 final _privateProvider = AutoDisposeProvider<String>(
   _private,
   name: r'_privateProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $_privateHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$_privateHash,
 );
 typedef _PrivateRef = AutoDisposeProviderRef<String>;


### PR DESCRIPTION
The `hashFunctionName` in generated code is unnecessarily has public access. This fix prevents importing and listing this variable in code completition