### PR TITLE
Expose mounted property in Ref

### DIFF
--- a/packages/riverpod/lib/src/framework/element.dart
+++ b/packages/riverpod/lib/src/framework/element.dart
@@ -113,7 +113,7 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
   bool _mounted = false;
 
   /// Whether the element was disposed or not
-  @internal
+  @override
   bool get mounted => _mounted;
 
   /// Whether the assert that prevents [requireState] from returning

--- a/packages/riverpod/lib/src/framework/ref.dart
+++ b/packages/riverpod/lib/src/framework/ref.dart
@@ -14,6 +14,9 @@ abstract class Ref<State extends Object?> {
   /// The [ProviderContainer] that this provider is associated with.
   ProviderContainer get container;
 
+  ///
+  bool get mounted;
+
   /// {@template riverpod.refresh}
   /// Forces a provider to re-evaluate its state immediately, and return the created value.
   ///


### PR DESCRIPTION
There are several issues about how to determine the mounted status of providers after asynchronous operations. I am aware that you do not agree with `mounted` being a public property, but the solution you recommend is no further than that. As you suggested in this comment (https://github.com/rrousselGit/riverpod/issues/1879#issuecomment-1303189191), the `Ref.onDisposed` method can be used to determine the `mounted` state. As I looked under the hood, the `mounted` property is always consistent with the disposed status and is set to false before the `Ref.onDisposed` call. I don't understand why it is a problem to make this property public, thus reducing the boilerplate code. If someone writes a variable that is set to true by `onDisposed`, it is practically the same as reading `mounted`.
I use it in many places, mainly because a new lint rule (`use_build_context_synchronously`) keeps warning me about this. Unfortunately, due to Riverpod's implementation, this cannot be done with a simple mixin or extension function, so I have to fill most of my providers with a `bool disposed + onDispose(() => mounted = false)` combo, which makes it quite dirty. I have now replaced it with this solution and it works without problems. Since only `Ref` declares this property, it is not available in `WidgetRef` outside of a provider

https://github.com/rrousselGit/riverpod/issues/1879
https://github.com/rrousselGit/riverpod/issues/1908
https://github.com/rrousselGit/riverpod/issues/1579