### PR TITLE
[riverpod_lint] Fix to `dart run custom_lint`

### DIFF
--- a/packages/riverpod_lint/README.md
+++ b/packages/riverpod_lint/README.md
@@ -150,7 +150,7 @@ Since your project should already have custom_lint installed
 able to run:
 
 ```sh
-dart pub custom_lint
+dart run custom_lint
 ```
 
 Alternatively, you can globally install `custom_lint`:


### PR DESCRIPTION
`dart pub custom_lint` isn't valid command, and `dart run custom_lint` is right.