### PR TITLE
hook code snippets in getting started page

### DIFF
--- a/website/docs/getting_started/hello_world/index.tsx
+++ b/website/docs/getting_started/hello_world/index.tsx
@@ -1,9 +1,11 @@
 import raw from "!!raw-loader!./raw.dart";
+import raw_hooks from "!!raw-loader!./raw_hooks.dart";
 import codegen from "!!raw-loader!./main.dart";
+import codegen_hooks from "!!raw-loader!./main_hooks.dart";
 
 export default {
   raw,
-  hooks: raw,
+  hooks: raw_hooks,
   codegen,
-  hooksCodegen: codegen,
+  hooksCodegen: codegen_hooks,
 };

--- a/website/docs/getting_started/hello_world/main_hooks.dart
+++ b/website/docs/getting_started/hello_world/main_hooks.dart
@@ -39,7 +39,7 @@ class MyApp extends HookConsumerWidget {
       home: Scaffold(
         appBar: AppBar(title: const Text('Example')),
         body: Center(
-          child: Text(value),
+          child: Text('$value ${counter.value}'),
         ),
       ),
     );

--- a/website/docs/getting_started/hello_world/main_hooks.dart
+++ b/website/docs/getting_started/hello_world/main_hooks.dart
@@ -1,0 +1,44 @@
+// ignore_for_file: use_key_in_widget_constructors, omit_local_variable_types
+
+/* SNIPPET START */
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'main_hooks.g.dart';
+
+// We create a "provider", which will store a value (here "Hello world").
+// By using a provider, this allows us to mock/override the value exposed.
+@riverpod
+String helloWorld(HelloWorldRef ref) {
+  return 'Hello world';
+}
+
+void main() {
+  runApp(
+    // For widgets to be able to read providers, we need to wrap the entire
+    // application in a "ProviderScope" widget.
+    // This is where the state of our providers will be stored.
+    ProviderScope(
+      child: MyApp(),
+    ),
+  );
+}
+
+// Extend HookConsumerWidget instead of HookWidget, which is exposed by Riverpod
+class MyApp extends HookConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final String value = ref.watch(helloWorldProvider);
+
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Example')),
+        body: Center(
+          child: Text(value),
+        ),
+      ),
+    );
+  }
+}

--- a/website/docs/getting_started/hello_world/main_hooks.dart
+++ b/website/docs/getting_started/hello_world/main_hooks.dart
@@ -3,6 +3,7 @@
 /* SNIPPET START */
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 

--- a/website/docs/getting_started/hello_world/main_hooks.dart
+++ b/website/docs/getting_started/hello_world/main_hooks.dart
@@ -30,6 +30,9 @@ void main() {
 class MyApp extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // We can use hooks inside HookConsumerWidget
+    final counter = useState(0);
+
     final String value = ref.watch(helloWorldProvider);
 
     return MaterialApp(

--- a/website/docs/getting_started/hello_world/main_hooks.g.dart
+++ b/website/docs/getting_started/hello_world/main_hooks.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'main.dart';
+part of 'main_hooks.dart';
 
 // **************************************************************************
 // RiverpodGenerator

--- a/website/docs/getting_started/hello_world/raw_hooks.dart
+++ b/website/docs/getting_started/hello_world/raw_hooks.dart
@@ -24,6 +24,9 @@ void main() {
 class MyApp extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // We can use hooks inside HookConsumerWidget
+    final counter = useState(0);
+
     final String value = ref.watch(helloWorldProvider);
 
     return MaterialApp(

--- a/website/docs/getting_started/hello_world/raw_hooks.dart
+++ b/website/docs/getting_started/hello_world/raw_hooks.dart
@@ -3,6 +3,7 @@
 /* SNIPPET START */
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 // We create a "provider", which will store a value (here "Hello world").

--- a/website/docs/getting_started/hello_world/raw_hooks.dart
+++ b/website/docs/getting_started/hello_world/raw_hooks.dart
@@ -33,7 +33,7 @@ class MyApp extends HookConsumerWidget {
       home: Scaffold(
         appBar: AppBar(title: const Text('Example')),
         body: Center(
-          child: Text(value),
+          child: Text('$value ${counter.value}'),
         ),
       ),
     );

--- a/website/docs/getting_started/hello_world/raw_hooks.dart
+++ b/website/docs/getting_started/hello_world/raw_hooks.dart
@@ -1,0 +1,38 @@
+// ignore_for_file: use_key_in_widget_constructors, omit_local_variable_types
+
+/* SNIPPET START */
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// We create a "provider", which will store a value (here "Hello world").
+// By using a provider, this allows us to mock/override the value exposed.
+final helloWorldProvider = Provider((_) => 'Hello world');
+
+void main() {
+  runApp(
+    // For widgets to be able to read providers, we need to wrap the entire
+    // application in a "ProviderScope" widget.
+    // This is where the state of our providers will be stored.
+    ProviderScope(
+      child: MyApp(),
+    ),
+  );
+}
+
+// Extend HookConsumerWidget instead of HookWidget, which is exposed by Riverpod
+class MyApp extends HookConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final String value = ref.watch(helloWorldProvider);
+
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Example')),
+        body: Center(
+          child: Text(value),
+        ),
+      ),
+    );
+  }
+}

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/about_codegen/main.g.dart
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/about_codegen/main.g.dart
@@ -29,7 +29,7 @@ class _SystemHash {
   }
 }
 
-String $fetchUserHash() => r'ff427bbb4130a8a6994fa623ae70997f7b0f6bdb';
+String _$fetchUserHash() => r'ff427bbb4130a8a6994fa623ae70997f7b0f6bdb';
 
 /// See also [fetchUser].
 class FetchUserProvider extends AutoDisposeFutureProvider<User> {
@@ -45,7 +45,7 @@ class FetchUserProvider extends AutoDisposeFutureProvider<User> {
           debugGetCreateSourceHash:
               const bool.fromEnvironment('dart.vm.product')
                   ? null
-                  : $fetchUserHash,
+                  : _$fetchUserHash,
         );
 
   final int userId;

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/getting_started/hello_world/main.g.dart
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/getting_started/hello_world/main.g.dart
@@ -29,13 +29,13 @@ class _SystemHash {
   }
 }
 
-String $helloWorldHash() => r'8bbe6cff2b7b1f4e1f7be3d1820da793259f7bfc';
+String _$helloWorldHash() => r'8bbe6cff2b7b1f4e1f7be3d1820da793259f7bfc';
 
 /// See also [helloWorld].
 final helloWorldProvider = AutoDisposeProvider<String>(
   helloWorld,
   name: r'helloWorldProvider',
   debugGetCreateSourceHash:
-      const bool.fromEnvironment('dart.vm.product') ? null : $helloWorldHash,
+      const bool.fromEnvironment('dart.vm.product') ? null : _$helloWorldHash,
 );
 typedef HelloWorldRef = AutoDisposeProviderRef<String>;


### PR DESCRIPTION
This adds snippets on the Getting started page that show when the hooks switch is toggled to true. It's using the same examples that had already been made with the change being HookConsumerWidget in place of ConsumerWidget