### PR TITLE
Add MutationState to riverpod

### DIFF
--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -12,9 +12,7 @@ export 'src/async_notifier.dart'
         BuildlessAsyncNotifier,
         BuildlessAutoDisposeAsyncNotifier,
         FutureHandlerProviderElementMixin;
-
 export 'src/common.dart' hide AsyncTransition;
-
 export 'src/framework.dart'
     hide
         debugCanModifyProviders,
@@ -44,9 +42,8 @@ export 'src/framework.dart'
         Node,
         ProviderElementProxy,
         OnError;
-
 export 'src/future_provider.dart';
-
+export 'src/mutation_state.dart';
 export 'src/notifier.dart'
     hide
         NotifierBase,
@@ -57,7 +54,6 @@ export 'src/notifier.dart'
         NotifierProviderImpl,
         BuildlessAutoDisposeNotifier,
         BuildlessNotifier;
-
 export 'src/provider.dart' hide InternalProvider;
 export 'src/state_controller.dart';
 export 'src/state_notifier_provider.dart';

--- a/packages/riverpod/lib/src/listenable.dart
+++ b/packages/riverpod/lib/src/listenable.dart
@@ -18,7 +18,7 @@ class _Listener<T> {
 /// to subsets of the state exposed by a provider.
 @internal
 class ProxyElementValueNotifier<T> extends _ValueListenable<T> {
-  /// Directly obtain the value exposed, grafully handling cases where
+  /// Directly obtain the value exposed, gracefully handling cases where
   /// [result] is null or in error state.
   T get value {
     final result = _result;

--- a/packages/riverpod/lib/src/mutation_state.dart
+++ b/packages/riverpod/lib/src/mutation_state.dart
@@ -87,11 +87,15 @@ abstract class MutationState<Result, Param> {
   //   _setState.state = state.copyWithPrevious(_setState.state);
   // }
 
+  void _mutateState(MutationState<Result, Param> state) {
+    _setState(state.copyWithPrevious(this));
+  }
+
   Future<MutationState<Result, Param>> call(Param parameter) async {
-    _setState(MutationState<Result, Param>.loading(_setState, _fn));
+    _mutateState(MutationState<Result, Param>.loading(_setState, _fn));
     final result =
         await MutationState.guard<Result, Param>(_setState, _fn, parameter);
-    _setState(result);
+    _mutateState(result);
     return result;
   }
 

--- a/packages/riverpod/lib/src/mutation_state.dart
+++ b/packages/riverpod/lib/src/mutation_state.dart
@@ -1,0 +1,528 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import 'provider.dart';
+import 'stack_trace.dart';
+
+/// AsyncValue-like data class, but includes a ref and callback
+/// strictly for use in providers
+/// `_fn` is the handler for whatever parameter gets passed in (a call to a notifier function, for example)
+/// Param is the type of the value that gets passed in by the front end
+/// T is the type of the created data from the call (equivalent to AsyncValue's T)
+/// (the type of the `value`)
+@immutable
+abstract class MutationState<Result, Param> {
+  const MutationState._(this._ref, this._fn);
+
+  /// Use to initialize your own mutation provider
+  ///
+  /// [ref] is the provider reference
+  ///
+  /// [fn] is the function that will be called when the mutation is called
+  /// with the parameter passed in by the front end
+  ///
+  /// Here's an example for a generic mutation:
+  /// ```dart
+  /// @riverpod
+  /// MutationState<void, Future<void> Function()> genericMutation(GenericMutationRef ref, Object mutationKey) {
+  ///   // simply calls the function provided by the user
+  ///   return MutationState.create(ref, (fn) => fn());
+  /// }
+  /// ```
+  factory MutationState.create(
+    ProviderRef<MutationState<Result, Param>> ref,
+    FutureOr<Result> Function(Param p) fn,
+  ) =>
+      MutationState<Result, Param>._initial(ref, fn);
+
+  const factory MutationState._initial(
+    ProviderRef<MutationState<Result, Param>> ref,
+    FutureOr<Result> Function(Param p) fn,
+  ) = MutationInitial<Result, Param>._;
+
+  const factory MutationState._error(
+    ProviderRef<MutationState<Result, Param>> ref,
+    FutureOr<Result> Function(Param p) fn,
+    Object error, {
+    required StackTrace stackTrace,
+  }) = MutationError<Result, Param>._;
+
+  const factory MutationState._data(
+    ProviderRef<MutationState<Result, Param>> ref,
+    FutureOr<Result> Function(Param p) fn,
+    Result value,
+  ) = MutationData<Result, Param>._;
+
+  const factory MutationState._loading(
+    ProviderRef<MutationState<Result, Param>> ref,
+    FutureOr<Result> Function(Param p) fn,
+  ) = MutationLoading<Result, Param>._;
+
+  static Future<MutationState<Result, P>> _guard<Result, P>(
+    ProviderRef<MutationState<Result, P>> ref,
+    FutureOr<Result> Function(P p) cb,
+    P parameter,
+  ) async {
+    try {
+      return MutationState<Result, P>._data(ref, cb, await cb(parameter));
+    } catch (e, s) {
+      return MutationState<Result, P>._error(ref, cb, e, stackTrace: s);
+    }
+  }
+
+  final ProviderRef<MutationState<Result, Param>> _ref;
+  bool get isLoading;
+  bool get hasValue;
+  Result? get value;
+  Object? get error;
+  StackTrace? get stackTrace;
+  final FutureOr<Result> Function(Param p) _fn;
+
+  void _setState(MutationState<Result, Param> state) {
+    _ref.state = state.copyWithPrevious(_ref.state);
+  }
+
+  Future<MutationState<Result, Param>> call(Param parameter) async {
+    final cb = this._fn;
+    _setState(MutationState<Result, Param>._loading(_ref, cb));
+    final result =
+        await MutationState._guard<Result, Param>(_ref, cb, parameter);
+    _setState(result);
+    return result;
+  }
+
+  R map<R>({
+    required R Function(MutationInitial<Result, Param> initial) initial,
+    required R Function(MutationData<Result, Param> data) data,
+    required R Function(MutationError<Result, Param> error) error,
+    required R Function(MutationLoading<Result, Param> loading) loading,
+  });
+
+  MutationState<Result, Param> copyWithPrevious(
+    MutationState<Result, Param> previous,
+  );
+
+  MutationState<Result, Param> unwrapPrevious() {
+    return map(
+      initial: (i) => MutationInitial<Result, Param>._(_ref, _fn),
+      data: (d) {
+        if (d.isLoading) return MutationLoading<Result, Param>._(_ref, _fn);
+        return MutationData._(_ref, _fn, d.value!);
+      },
+      error: (e) {
+        if (e.isLoading) return MutationLoading._(_ref, _fn);
+        return MutationError._(_ref, _fn, e.error, stackTrace: e.stackTrace);
+      },
+      loading: (l) => MutationLoading<Result, Param>._(_ref, _fn),
+    );
+  }
+
+  @override
+  String toString() {
+    final content = [
+      if (isLoading && this is! MutationLoading) 'isLoading: $isLoading',
+      if (hasValue) 'value: $value',
+      if (hasError) ...[
+        'error: $error',
+        'stackTrace: $stackTrace',
+      ],
+      if (stackTrace != null) 'stackTrace: $stackTrace',
+    ].join(', ');
+    return '$runtimeType($content)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return runtimeType == other.runtimeType &&
+        other is MutationState<Result, Param> &&
+        other.isInitial == isInitial &&
+        other.isLoading == isLoading &&
+        other.hasValue == hasValue &&
+        other.error == error &&
+        other.stackTrace == stackTrace &&
+        other.valueOrNull == valueOrNull;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        runtimeType,
+        isLoading,
+        hasValue,
+        // Fallback null values to 0, making sure Object.hash hashes all values
+        valueOrNull ?? 0,
+        error ?? 0,
+        stackTrace ?? 0,
+      );
+}
+
+class MutationInitial<Result, Param> extends MutationState<Result, Param> {
+  const MutationInitial._(super._ref, super._fn) : super._();
+
+  @override
+  Result? get value => null;
+
+  @override
+  bool get hasValue => false;
+
+  @override
+  bool get isLoading => false;
+
+  @override
+  StackTrace? get stackTrace => null;
+
+  @override
+  Object? get error => null;
+
+  @override
+  R map<R>({
+    required R Function(MutationInitial<Result, Param> initial) initial,
+    required R Function(MutationData<Result, Param> data) data,
+    required R Function(MutationError<Result, Param> error) error,
+    required R Function(MutationLoading<Result, Param> loading) loading,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  MutationState<Result, Param> copyWithPrevious(
+    MutationState<Result, Param> previous,
+  ) {
+    // We shouldn't even have a previous value if we are initial
+    return this;
+  }
+}
+
+class MutationLoading<Result, Param> extends MutationState<Result, Param> {
+  const MutationLoading._(super._ref, super._fn)
+      : hasValue = false,
+        value = null,
+        error = null,
+        stackTrace = null,
+        super._();
+
+  const MutationLoading.__(
+    super._ref,
+    super._fn, {
+    required this.hasValue,
+    required this.value,
+    required this.error,
+    required this.stackTrace,
+  }) : super._();
+
+  @override
+  bool get isLoading => true;
+
+  @override
+  final bool hasValue;
+
+  @override
+  final Result? value;
+
+  @override
+  final Object? error;
+
+  @override
+  final StackTrace? stackTrace;
+
+  @override
+  R map<R>({
+    required R Function(MutationInitial<Result, Param> initial) initial,
+    required R Function(MutationData<Result, Param> data) data,
+    required R Function(MutationError<Result, Param> error) error,
+    required R Function(MutationLoading<Result, Param> loading) loading,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  MutationState<Result, Param> copyWithPrevious(
+    MutationState<Result, Param> previous, {
+    bool isRefresh = true,
+  }) {
+    if (isRefresh) {
+      return previous.map(
+        initial: (_) => this,
+        data: (d) => MutationData.__(
+          _ref,
+          _fn,
+          d.value,
+          isLoading: true,
+          error: d.error,
+          stackTrace: d.stackTrace,
+        ),
+        error: (e) => MutationError.__(
+          _ref,
+          _fn,
+          e.error,
+          isLoading: true,
+          value: e.valueOrNull,
+          stackTrace: e.stackTrace,
+          hasValue: e.hasValue,
+        ),
+        loading: (_) => this,
+      );
+    } else {
+      return previous.map(
+        initial: (_) => this,
+        data: (e) => MutationLoading.__(
+          _ref,
+          _fn,
+          hasValue: true,
+          value: e.valueOrNull,
+          error: e.error,
+          stackTrace: e.stackTrace,
+        ),
+        error: (e) => MutationLoading.__(
+          _ref,
+          _fn,
+          hasValue: e.hasValue,
+          value: e.valueOrNull,
+          error: e.error,
+          stackTrace: e.stackTrace,
+        ),
+        loading: (e) => e,
+      );
+    }
+  }
+}
+
+class MutationData<Result, Param> extends MutationState<Result, Param> {
+  const MutationData._(super._ref, super._fn, this.value)
+      : isLoading = false,
+        error = null,
+        stackTrace = null,
+        super._();
+
+  const MutationData.__(
+    super._ref,
+    super._fn,
+    this.value, {
+    required this.isLoading,
+    required this.error,
+    required this.stackTrace,
+  }) : super._();
+
+  @override
+  final Result value;
+
+  @override
+  bool get hasValue => true;
+
+  @override
+  final bool isLoading;
+
+  @override
+  final Object? error;
+
+  @override
+  final StackTrace? stackTrace;
+
+  @override
+  R map<R>({
+    required R Function(MutationInitial<Result, Param> initial) initial,
+    required R Function(MutationData<Result, Param> data) data,
+    required R Function(MutationError<Result, Param> error) error,
+    required R Function(MutationLoading<Result, Param> loading) loading,
+  }) {
+    return data(this);
+  }
+
+  @override
+  MutationState<Result, Param> copyWithPrevious(
+    MutationState<Result, Param> previous,
+  ) =>
+      this;
+}
+
+class MutationError<Result, Param> extends MutationState<Result, Param> {
+  const MutationError.__(
+    super._ref,
+    super._fn,
+    this.error, {
+    required this.stackTrace,
+    required this.isLoading,
+    required Result? value,
+    required this.hasValue,
+  })  : _value = value,
+        super._();
+
+  const MutationError._(
+    super._ref,
+    super._fn,
+    this.error, {
+    required this.stackTrace,
+  })  : isLoading = false,
+        hasValue = false,
+        _value = null,
+        super._();
+
+  @override
+  final bool isLoading;
+
+  @override
+  final bool hasValue;
+
+  @override
+  Result? get value {
+    if (!hasValue) {
+      throwErrorWithCombinedStackTrace(error, stackTrace);
+    }
+    return _value;
+  }
+
+  final Result? _value;
+
+  @override
+  final Object error;
+  @override
+  final StackTrace stackTrace;
+
+  @override
+  R map<R>({
+    required R Function(MutationInitial<Result, Param> initial) initial,
+    required R Function(MutationData<Result, Param> data) data,
+    required R Function(MutationError<Result, Param> error) error,
+    required R Function(MutationLoading<Result, Param> loading) loading,
+  }) {
+    return error(this);
+  }
+
+  @override
+  MutationState<Result, Param> copyWithPrevious(
+    MutationState<Result, Param> previous,
+  ) {
+    return MutationError.__(
+      _ref,
+      _fn,
+      error,
+      stackTrace: stackTrace,
+      isLoading: isLoading,
+      value: previous.valueOrNull,
+      hasValue: previous.hasValue,
+    );
+  }
+}
+
+extension MutationValueX<Result, Param> on MutationState<Result, Param> {
+  bool get isInitial => this is MutationInitial;
+  Result get requireValue {
+    if (hasValue) return value as Result;
+    if (hasError) throwErrorWithCombinedStackTrace(error!, stackTrace!);
+    throw StateError(
+      'Tried to call `requireValue` on a `MutationValue`'
+      ' that has no value: $this',
+    );
+  }
+
+  Result? get valueOrNull => hasValue ? value : null;
+
+  bool get isRerunning =>
+      isLoading && (hasValue || hasError) && this is! MutationLoading;
+
+  bool get hasError => error != null;
+  MutationData<Result, Param>? get asData =>
+      maybeMap(data: (d) => d, orElse: () => null);
+
+  MutationError<Result, Param>? get asError =>
+      maybeMap(error: (e) => e, orElse: () => null);
+
+  R maybeWhen<R>({
+    bool skipLoadingOnRerun = false,
+    bool skipError = false,
+    R Function()? initial,
+    R Function(Result value)? data,
+    R Function(Object error, StackTrace stackTrace)? error,
+    R Function()? loading,
+    required R Function() orElse,
+  }) {
+    return when(
+      skipError: skipError,
+      skipLoadingOnRerun: skipLoadingOnRerun,
+      initial: initial ?? orElse,
+      loading: loading ?? orElse,
+      data: (d) {
+        if (data != null) return data(d);
+        return orElse();
+      },
+      error: (e, s) {
+        if (error != null) return error(e, s);
+        return orElse();
+      },
+    );
+  }
+
+  R when<R>({
+    bool skipLoadingOnRerun = false,
+    bool skipError = false,
+    required R Function() initial,
+    required R Function(Result data) data,
+    required R Function(Object error, StackTrace stackTrace) error,
+    required R Function() loading,
+  }) {
+    if (isInitial) {
+      return initial();
+    }
+
+    if (isLoading) {
+      bool skip;
+      if (isRerunning) {
+        skip = skipLoadingOnRerun;
+      } else {
+        skip = false;
+      }
+      if (!skip) return loading();
+    }
+
+    if (hasError && (!hasValue || !skipError)) {
+      return error(this.error!, stackTrace!);
+    }
+
+    return data(requireValue);
+  }
+
+  R? whenOrNull<R>({
+    bool skipLoadingOnRerun = false,
+    bool skipError = false,
+    R? Function()? initial,
+    R? Function(Result data)? data,
+    R? Function(Object error, StackTrace stackTrace)? error,
+    R? Function()? loading,
+  }) {
+    return when(
+      skipError: skipError,
+      skipLoadingOnRerun: skipLoadingOnRerun,
+      initial: initial ?? () => null,
+      data: data ?? (_) => null,
+      error: error ?? (err, stack) => null,
+      loading: loading ?? () => null,
+    );
+  }
+
+  R maybeMap<R>({
+    R Function(MutationInitial<Result, Param> initial)? initial,
+    R Function(MutationData<Result, Param> data)? data,
+    R Function(MutationError<Result, Param> error)? error,
+    R Function(MutationLoading<Result, Param> loading)? loading,
+    required R Function() orElse,
+  }) {
+    return map(
+      initial: (i) {
+        if (initial != null) return initial(i);
+        return orElse();
+      },
+      data: (d) {
+        if (data != null) return data(d);
+        return orElse();
+      },
+      error: (e) {
+        if (error != null) return error(e);
+        return orElse();
+      },
+      loading: (l) {
+        if (loading != null) return loading(l);
+        return orElse();
+      },
+    );
+  }
+}

--- a/packages/riverpod/lib/src/notifier.dart
+++ b/packages/riverpod/lib/src/notifier.dart
@@ -120,7 +120,7 @@ abstract class NotifierProviderBase<NotifierT extends NotifierBase<T>, T>
   /// )
   /// ```
   ///
-  /// This listenable will notify its notifiers if the [Notifier] instance
+  /// This listenable will notify its listeners if the [Notifier] instance
   /// changes.
   /// This may happen if the provider is refreshed or one of its dependencies
   /// has changes.

--- a/packages/riverpod/test/framework/mutation_state_test.dart
+++ b/packages/riverpod/test/framework/mutation_state_test.dart
@@ -6,12 +6,12 @@ import 'package:test/test.dart';
 /// generic mutation. pass a function into `call` to execute the mutation
 final genericMutationProvider =
     Provider<MutationState<void, Future<void> Function()>>((ref) {
-  return MutationState.create(ref, (fn) => fn());
+  return MutationState.create((newState) => ref.state = newState, (fn) => fn());
 });
 
 /// mutation that converts a string to a double
 final stringToDoubleProvider = Provider<MutationState<double, String>>((ref) {
-  return MutationState.create(ref, double.parse);
+  return MutationState.create((newState) => ref.state = newState, double.parse);
 });
 
 void main() {

--- a/packages/riverpod/test/framework/mutation_state_test.dart
+++ b/packages/riverpod/test/framework/mutation_state_test.dart
@@ -1,0 +1,231 @@
+import 'dart:async';
+
+import 'package:riverpod/riverpod.dart';
+import 'package:test/test.dart';
+
+/// generic mutation. pass a function into `call` to execute the mutation
+final genericMutationProvider =
+    Provider<MutationState<void, Future<void> Function()>>((ref) {
+  return MutationState.create(ref, (fn) => fn());
+});
+
+/// mutation that converts a string to a double
+final stringToDoubleProvider = Provider<MutationState<double, String>>((ref) {
+  return MutationState.create(ref, double.parse);
+});
+
+void main() {
+  late ProviderContainer container;
+
+  setUpAll(() {
+    container = ProviderContainer();
+  });
+
+  tearDownAll(() {
+    container.dispose();
+  });
+
+  group('Custom Mutation Tests', () {
+    late Provider<MutationState<double, String>> provider;
+
+    setUp(() {
+      provider = stringToDoubleProvider;
+    });
+
+    test('Custom mutation with parameter', () async {
+      var exampleMutation = container.read(provider);
+      expect(exampleMutation, isA<MutationInitial<double, String>>());
+
+      // final expectedException = Exception('Mutation failed');
+      final mutationFuture = exampleMutation('1');
+
+      exampleMutation = container.read(provider);
+
+      expect(
+        exampleMutation,
+        isA<MutationLoading<double, String>>(),
+        reason: 'Mutation is not loading',
+      );
+
+      await mutationFuture;
+
+      exampleMutation = container.read(provider);
+
+      expect(
+        exampleMutation,
+        isA<MutationData<double, String>>(),
+        reason: 'Mutation did not succeed',
+      );
+
+      expect(
+        exampleMutation.valueOrNull,
+        isNotNull,
+        reason: 'Mutation does not have a value',
+      );
+
+      expect(
+        exampleMutation.valueOrNull,
+        1,
+        reason: 'Mutation value is not correct',
+      );
+
+      // lets give it another go, this time it will fail. same provider.
+      exampleMutation = container.read(provider);
+
+      expect(exampleMutation, isA<MutationData<double, String>>());
+
+      final mutationFuture2 = exampleMutation('Invalid input');
+
+      exampleMutation = container.read(provider);
+
+      expect(
+        exampleMutation.isLoading,
+        isTrue,
+        reason: 'Mutation is not loading again',
+      );
+
+      // previous value should still be there
+      expect(
+        exampleMutation.valueOrNull,
+        1,
+        reason: 'Mutation value should not have changed',
+      );
+
+      await mutationFuture2;
+
+      exampleMutation = container.read(provider);
+
+      expect(
+        exampleMutation.hasError,
+        isTrue,
+        reason: 'Mutation does not have an error',
+      );
+
+      expect(
+        exampleMutation,
+        isA<MutationError<double, String>>(),
+        reason: 'Mutation did not fail',
+      );
+
+      expect(
+        exampleMutation.error,
+        isNotNull,
+        reason: 'Mutation does not have an error',
+      );
+
+      expect(
+        exampleMutation.error,
+        isA<FormatException>(),
+        reason: 'Mutation error should be a FormatException',
+      );
+
+      // mutation value should still be there
+      expect(
+        exampleMutation.valueOrNull,
+        1,
+        reason: 'Mutation value should STILL not have changed',
+      );
+    });
+  });
+
+  group('Mutation Tests', () {
+    late Provider<MutationState<void, Future<void> Function()>> provider;
+    // ignore: no_leading_underscores_for_local_identifiers
+    setUp(() {
+      provider = genericMutationProvider;
+    });
+
+    tearDown(() {
+      container.invalidate(provider);
+    });
+
+    test('Mutation is initial', () {
+      final exampleMutation = container.read(provider);
+      expect(
+        exampleMutation,
+        isA<MutationInitial<void, Future<void> Function()>>(),
+        reason: 'Mutation is not initial',
+      );
+      expect(
+        exampleMutation.maybeMap(
+          orElse: () => false,
+          initial: (_) => true,
+        ),
+        isTrue,
+        reason: 'Mutation is not initial',
+      );
+    });
+
+    test('Mutation succeeds', () async {
+      var exampleMutation = container.read(provider);
+      expect(
+        exampleMutation,
+        isA<MutationInitial<void, Future<void> Function()>>(),
+      );
+
+      final completer = Completer<void>();
+      final f = exampleMutation(() async {
+        await Future<void>.delayed(const Duration(microseconds: 100));
+        return completer.future;
+      });
+
+      exampleMutation = container.read(provider);
+      expect(
+        exampleMutation,
+        isA<MutationLoading<void, Future<void> Function()>>(),
+        reason: 'Mutation is not loading',
+      );
+
+      completer.complete();
+      await f;
+
+      exampleMutation = container.read(provider);
+      expect(
+        exampleMutation,
+        isA<MutationData<void, Future<void> Function()>>(),
+        reason: 'Mutation has not succeeded',
+      );
+    });
+
+    test('Mutation fails', () async {
+      var exampleMutation = container.read(provider);
+      expect(
+        exampleMutation,
+        isA<MutationInitial<void, Future<void> Function()>>(),
+      );
+
+      final expectedException = Exception('Mutation failed');
+
+      final completer = Completer<void>();
+      final f = exampleMutation.call(() async {
+        await Future<void>.delayed(const Duration(microseconds: 10));
+        await completer.future;
+        throw expectedException;
+      });
+
+      exampleMutation = container.read(provider);
+
+      expect(
+        exampleMutation,
+        isA<MutationLoading<void, Future<void> Function()>>(),
+        reason: 'Mutation is not loading',
+      );
+
+      completer.complete();
+      await f;
+
+      exampleMutation = container.read(provider);
+      expect(
+        exampleMutation,
+        isA<MutationError<void, Future<void> Function()>>(),
+        reason: 'Mutation did not fail',
+      );
+
+      expect(
+        exampleMutation.error,
+        expectedException,
+        reason: 'Mutation did not fail with expected exception',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Adds non-generator mutations for #1660 

-- from [TekExplorer/riverpod_mutations](https://github.com/TekExplorer/riverpod_mutations) which is available in the meantime as `riverpod_mutations` on pub.dev

Tests could be better, but the model does work.