### PR TITLE
Add BaseRef as base class for Ref and WidgetRef

### DIFF
--- a/packages/flutter_riverpod/lib/src/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/consumer.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 import 'internals.dart';
 
 /// An object that allows widgets to interact with providers.
-abstract class WidgetRef {
+abstract class WidgetRef extends BaseRef {
   /// The [BuildContext] of the widget associated to this [WidgetRef].
   ///
   /// This is strictly identical to the [BuildContext] passed to [ConsumerWidget.build].
@@ -18,6 +18,7 @@ abstract class WidgetRef {
   /// - [ProviderListenable.select], which allows a widget to filter rebuilds by
   ///   observing only the selected properties.
   /// - [listen], to react to changes on a provider, such as for showing modals.
+  @override
   T watch<T>(ProviderListenable<T> provider);
 
   /// Determines whether a provider is initialized or not.
@@ -51,6 +52,7 @@ abstract class WidgetRef {
   ///   return Item.fromJson(json);
   /// });
   /// ```
+  @override
   bool exists(ProviderBase<Object?> provider);
 
   /// Listen to a provider and call `listener` whenever its value changes,
@@ -169,6 +171,7 @@ abstract class WidgetRef {
   /// While more verbose than [read], using [Provider]/`select` is a lot safer.
   /// It does not rely on implementation details on `Model`, and it makes
   /// impossible to have a bug where our UI does not refresh.
+  @override
   T read<T>(ProviderListenable<T> provider);
 
   /// Forces a provider to re-evaluate its state immediately, and return the created value.

--- a/packages/riverpod/lib/src/framework/ref.dart
+++ b/packages/riverpod/lib/src/framework/ref.dart
@@ -11,7 +11,7 @@ abstract class BaseRef {
 
   /// Returns the value exposed by a provider and rebuild the widget when that
   /// value changes.
-  T watch<T>(covariant ProviderListenable<T> provider);
+  T watch<T>(AlwaysAliveProviderListenable<T> provider);
 }
 
 /// {@template riverpod.providerrefbase}

--- a/packages/riverpod/lib/src/framework/ref.dart
+++ b/packages/riverpod/lib/src/framework/ref.dart
@@ -1,5 +1,19 @@
 part of '../framework.dart';
 
+/// Base class for [Ref]
+@optionalTypeArgs
+abstract class BaseRef {
+  /// Read the state associated with a provider, without listening to that provider.
+  T read<T>(ProviderListenable<T> provider);
+
+  /// Determines whether a provider is initialized or not.
+  bool exists(ProviderBase<Object?> provider);
+
+  /// Returns the value exposed by a provider and rebuild the widget when that
+  /// value changes.
+  T watch<T>(covariant ProviderListenable<T> provider);
+}
+
 /// {@template riverpod.providerrefbase}
 /// An object used by providers to interact with other providers and the life-cycles
 /// of the application.
@@ -10,7 +24,7 @@ part of '../framework.dart';
 /// - [onDispose], a method that allows performing a task when the provider is destroyed.
 /// {@endtemplate}
 @optionalTypeArgs
-abstract class Ref<State extends Object?> {
+abstract class Ref<State extends Object?> extends BaseRef {
   /// The [ProviderContainer] that this provider is associated with.
   ProviderContainer get container;
 
@@ -189,6 +203,7 @@ abstract class Ref<State extends Object?> {
   ///
   /// If possible, avoid using [read] and prefer [watch], which is generally
   /// safer to use.
+  @override
   T read<T>(ProviderListenable<T> provider);
 
   /// {@template riverpod.exists}
@@ -224,6 +239,7 @@ abstract class Ref<State extends Object?> {
   /// });
   /// ```
   /// {@endtemplate}
+  @override
   bool exists(ProviderBase<Object?> provider);
 
   /// Obtains the state of a provider and causes the state to be re-evaluated
@@ -276,6 +292,7 @@ abstract class Ref<State extends Object?> {
   /// - if multiple widgets depends on `sortedTodosProvider` the list will be
   ///   sorted only once.
   /// - if nothing is listening to `sortedTodosProvider`, then no sort is performed.
+  @override
   T watch<T>(AlwaysAliveProviderListenable<T> provider);
 
   /// {@template riverpod.listen}


### PR DESCRIPTION
Both classes (WidgetRef and Ref) has common methods that could've been extracted into a base class. It also makes it a lot easier when you want to pass a Ref to another function which can be called from a Widget/State or Provider.

example:
```dart
Foo createFoo(BaseRef ref) {
  final bar = ref.watch(barProvider);
  return Foo(bar);
}
```