### PR TITLE
add provider family name suffix option

### DIFF
--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -1,7 +1,9 @@
-## Unreleased patch
+## Unreleased minor
 
-Deprecate the (new) shorthand syntax for scoping provider using the `external`
-keyword. That syntax unfortunately does not work on web and therefore will be removed.
+- Added support for configuring the name of providers with parameters ("families") (thanks to @K9i-0)
+
+- Deprecate the (new) shorthand syntax for scoping provider using the `external`
+  keyword. That syntax unfortunately does not work on web and therefore will be removed.
 
 ## 2.0.0
 

--- a/packages/riverpod_generator/README.md
+++ b/packages/riverpod_generator/README.md
@@ -169,6 +169,11 @@ targets:
           # Could be changed to "Pod", such that riverpod_generator
           # would generate "countPod" instead of "countProvider"
           provider_name_suffix: "Provider" # (default)
+          # Could be changed to "ProviderFamily", such that riverpod_generator
+          # would generate "countProviderFamily" instead of "countProvider"
+          # This option only affects the Family Provider
+          # and takes precedence over provider_name_suffix.
+          provider_family_name_suffix: "Provider" # (default)
 ```
 
 [family]: https://riverpod.dev/docs/concepts/modifiers/family

--- a/packages/riverpod_generator/README.md
+++ b/packages/riverpod_generator/README.md
@@ -169,10 +169,9 @@ targets:
           # Could be changed to "Pod", such that riverpod_generator
           # would generate "countPod" instead of "countProvider"
           provider_name_suffix: "Provider" # (default)
-          # Could be changed to "ProviderFamily", such that riverpod_generator
-          # would generate "countProviderFamily" instead of "countProvider"
-          # This option only affects the Family Provider
-          # and takes precedence over provider_name_suffix.
+          # Similar to provider_name_sufix, this is an option for renaming
+          # providers with parameters ("families").
+          # This takes precedence over provider_name_suffix.
           provider_family_name_suffix: "Provider" # (default)
 ```
 

--- a/packages/riverpod_generator/integration/build_yaml/build.yaml
+++ b/packages/riverpod_generator/integration/build_yaml/build.yaml
@@ -4,3 +4,4 @@ targets:
       riverpod_generator:
         options:
           provider_name_suffix: 'Pod'
+          provider_family_name_suffix: 'ProviderFamily'

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.dart
@@ -13,6 +13,11 @@ FutureOr<int> countFuture(CountFutureRef ref) {
 }
 
 @riverpod
+Stream<int> countStream(CountStreamRef ref) {
+  return Stream.value(1);
+}
+
+@riverpod
 class CountNotifier extends _$CountNotifier {
   @override
   int build() {
@@ -29,6 +34,14 @@ class CountAsyncNotifier extends _$CountAsyncNotifier {
 }
 
 @riverpod
+class CountStreamNotifier extends _$CountStreamNotifier {
+  @override
+  Stream<int> build() {
+    return Stream.value(1);
+  }
+}
+
+@riverpod
 int count2(Count2Ref ref, int a) {
   return 1;
 }
@@ -36,6 +49,11 @@ int count2(Count2Ref ref, int a) {
 @riverpod
 FutureOr<int> countFuture2(CountFuture2Ref ref, int a) {
   return 1;
+}
+
+@riverpod
+Stream<int> countStream2(CountStream2Ref ref, int a) {
+  return Stream.value(1);
 }
 
 @riverpod
@@ -51,5 +69,13 @@ class CountAsyncNotifier2 extends _$CountAsyncNotifier2 {
   @override
   FutureOr<int> build(int a) {
     return 1;
+  }
+}
+
+@riverpod
+class CountStreamNotifier2 extends _$CountStreamNotifier2 {
+  @override
+  Stream<int> build(int a) {
+    return Stream.value(1);
   }
 }

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.dart
@@ -27,3 +27,29 @@ class CountAsyncNotifier extends _$CountAsyncNotifier {
     return 1;
   }
 }
+
+@riverpod
+int count2(Count2Ref ref, int a) {
+  return 1;
+}
+
+@riverpod
+FutureOr<int> countFuture2(CountFuture2Ref ref, int a) {
+  return 1;
+}
+
+@riverpod
+class CountNotifier2 extends _$CountNotifier2 {
+  @override
+  int build(int a) {
+    return 1;
+  }
+}
+
+@riverpod
+class CountAsyncNotifier2 extends _$CountAsyncNotifier2 {
+  @override
+  FutureOr<int> build(int a) {
+    return 1;
+  }
+}

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
@@ -34,6 +34,20 @@ final countFuturePod = AutoDisposeFutureProvider<int>.internal(
 );
 
 typedef CountFutureRef = AutoDisposeFutureProviderRef<int>;
+String _$countStreamHash() => r'1dbe49244ea19e8dbc3af0534429bb323720c07a';
+
+/// See also [countStream].
+@ProviderFor(countStream)
+final countStreamPod = AutoDisposeStreamProvider<int>.internal(
+  countStream,
+  name: r'countStreamPod',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$countStreamHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef CountStreamRef = AutoDisposeStreamProviderRef<int>;
 String _$count2Hash() => r'6256825480d83bb13acde282cf3c9d9524cc3a6c';
 
 /// Copied from Dart SDK
@@ -219,6 +233,88 @@ class CountFuture2Provider extends AutoDisposeFutureProvider<int> {
   }
 }
 
+String _$countStream2Hash() => r'051264dd685ebc0a57e454bb676957c93cb4ae20';
+typedef CountStream2Ref = AutoDisposeStreamProviderRef<int>;
+
+/// See also [countStream2].
+@ProviderFor(countStream2)
+const countStream2ProviderFamily = CountStream2Family();
+
+/// See also [countStream2].
+class CountStream2Family extends Family<AsyncValue<int>> {
+  /// See also [countStream2].
+  const CountStream2Family();
+
+  /// See also [countStream2].
+  CountStream2Provider call(
+    int a,
+  ) {
+    return CountStream2Provider(
+      a,
+    );
+  }
+
+  @override
+  CountStream2Provider getProviderOverride(
+    covariant CountStream2Provider provider,
+  ) {
+    return call(
+      provider.a,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'countStream2ProviderFamily';
+}
+
+/// See also [countStream2].
+class CountStream2Provider extends AutoDisposeStreamProvider<int> {
+  /// See also [countStream2].
+  CountStream2Provider(
+    this.a,
+  ) : super.internal(
+          (ref) => countStream2(
+            ref,
+            a,
+          ),
+          from: countStream2ProviderFamily,
+          name: r'countStream2ProviderFamily',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$countStream2Hash,
+          dependencies: CountStream2Family._dependencies,
+          allTransitiveDependencies:
+              CountStream2Family._allTransitiveDependencies,
+        );
+
+  final int a;
+
+  @override
+  bool operator ==(Object other) {
+    return other is CountStream2Provider && other.a == a;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, a.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
 String _$countNotifierHash() => r'a8dd7a66ee0002b8af657245c4affaa206fd99ec';
 
 /// See also [CountNotifier].
@@ -252,6 +348,23 @@ final countAsyncNotifierPod =
 );
 
 typedef _$CountAsyncNotifier = AutoDisposeAsyncNotifier<int>;
+String _$countStreamNotifierHash() =>
+    r'61d2cd311c4808f8d7e8b2d67f5c7b85337666c6';
+
+/// See also [CountStreamNotifier].
+@ProviderFor(CountStreamNotifier)
+final countStreamNotifierPod =
+    AutoDisposeStreamNotifierProvider<CountStreamNotifier, int>.internal(
+  CountStreamNotifier.new,
+  name: r'countStreamNotifierPod',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$countStreamNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$CountStreamNotifier = AutoDisposeStreamNotifier<int>;
 String _$countNotifier2Hash() => r'ef12bb4f94add336804ae43bcdbcd8e9b0bec420';
 
 abstract class _$CountNotifier2 extends BuildlessAutoDisposeNotifier<int> {
@@ -439,6 +552,104 @@ class CountAsyncNotifier2Provider
   @override
   FutureOr<int> runNotifierBuild(
     covariant CountAsyncNotifier2 notifier,
+  ) {
+    return notifier.build(
+      a,
+    );
+  }
+}
+
+String _$countStreamNotifier2Hash() =>
+    r'13be1b7aa32801b33c68f2a228851d2fb6a4a9ee';
+
+abstract class _$CountStreamNotifier2
+    extends BuildlessAutoDisposeStreamNotifier<int> {
+  late final int a;
+
+  Stream<int> build(
+    int a,
+  );
+}
+
+/// See also [CountStreamNotifier2].
+@ProviderFor(CountStreamNotifier2)
+const countStreamNotifier2ProviderFamily = CountStreamNotifier2Family();
+
+/// See also [CountStreamNotifier2].
+class CountStreamNotifier2Family extends Family<AsyncValue<int>> {
+  /// See also [CountStreamNotifier2].
+  const CountStreamNotifier2Family();
+
+  /// See also [CountStreamNotifier2].
+  CountStreamNotifier2Provider call(
+    int a,
+  ) {
+    return CountStreamNotifier2Provider(
+      a,
+    );
+  }
+
+  @override
+  CountStreamNotifier2Provider getProviderOverride(
+    covariant CountStreamNotifier2Provider provider,
+  ) {
+    return call(
+      provider.a,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'countStreamNotifier2ProviderFamily';
+}
+
+/// See also [CountStreamNotifier2].
+class CountStreamNotifier2Provider
+    extends AutoDisposeStreamNotifierProviderImpl<CountStreamNotifier2, int> {
+  /// See also [CountStreamNotifier2].
+  CountStreamNotifier2Provider(
+    this.a,
+  ) : super.internal(
+          () => CountStreamNotifier2()..a = a,
+          from: countStreamNotifier2ProviderFamily,
+          name: r'countStreamNotifier2ProviderFamily',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$countStreamNotifier2Hash,
+          dependencies: CountStreamNotifier2Family._dependencies,
+          allTransitiveDependencies:
+              CountStreamNotifier2Family._allTransitiveDependencies,
+        );
+
+  final int a;
+
+  @override
+  bool operator ==(Object other) {
+    return other is CountStreamNotifier2Provider && other.a == a;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, a.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+
+  @override
+  Stream<int> runNotifierBuild(
+    covariant CountStreamNotifier2 notifier,
   ) {
     return notifier.build(
       a,

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
@@ -34,6 +34,191 @@ final countFuturePod = AutoDisposeFutureProvider<int>.internal(
 );
 
 typedef CountFutureRef = AutoDisposeFutureProviderRef<int>;
+String _$count2Hash() => r'6256825480d83bb13acde282cf3c9d9524cc3a6c';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+typedef Count2Ref = AutoDisposeProviderRef<int>;
+
+/// See also [count2].
+@ProviderFor(count2)
+const count2ProviderFamily = Count2Family();
+
+/// See also [count2].
+class Count2Family extends Family<int> {
+  /// See also [count2].
+  const Count2Family();
+
+  /// See also [count2].
+  Count2Provider call(
+    int a,
+  ) {
+    return Count2Provider(
+      a,
+    );
+  }
+
+  @override
+  Count2Provider getProviderOverride(
+    covariant Count2Provider provider,
+  ) {
+    return call(
+      provider.a,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'count2ProviderFamily';
+}
+
+/// See also [count2].
+class Count2Provider extends AutoDisposeProvider<int> {
+  /// See also [count2].
+  Count2Provider(
+    this.a,
+  ) : super.internal(
+          (ref) => count2(
+            ref,
+            a,
+          ),
+          from: count2ProviderFamily,
+          name: r'count2ProviderFamily',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$count2Hash,
+          dependencies: Count2Family._dependencies,
+          allTransitiveDependencies: Count2Family._allTransitiveDependencies,
+        );
+
+  final int a;
+
+  @override
+  bool operator ==(Object other) {
+    return other is Count2Provider && other.a == a;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, a.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+String _$countFuture2Hash() => r'096675b70a267f5d7c62ac7d3e7dd231ef529034';
+typedef CountFuture2Ref = AutoDisposeFutureProviderRef<int>;
+
+/// See also [countFuture2].
+@ProviderFor(countFuture2)
+const countFuture2ProviderFamily = CountFuture2Family();
+
+/// See also [countFuture2].
+class CountFuture2Family extends Family<AsyncValue<int>> {
+  /// See also [countFuture2].
+  const CountFuture2Family();
+
+  /// See also [countFuture2].
+  CountFuture2Provider call(
+    int a,
+  ) {
+    return CountFuture2Provider(
+      a,
+    );
+  }
+
+  @override
+  CountFuture2Provider getProviderOverride(
+    covariant CountFuture2Provider provider,
+  ) {
+    return call(
+      provider.a,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'countFuture2ProviderFamily';
+}
+
+/// See also [countFuture2].
+class CountFuture2Provider extends AutoDisposeFutureProvider<int> {
+  /// See also [countFuture2].
+  CountFuture2Provider(
+    this.a,
+  ) : super.internal(
+          (ref) => countFuture2(
+            ref,
+            a,
+          ),
+          from: countFuture2ProviderFamily,
+          name: r'countFuture2ProviderFamily',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$countFuture2Hash,
+          dependencies: CountFuture2Family._dependencies,
+          allTransitiveDependencies:
+              CountFuture2Family._allTransitiveDependencies,
+        );
+
+  final int a;
+
+  @override
+  bool operator ==(Object other) {
+    return other is CountFuture2Provider && other.a == a;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, a.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
 String _$countNotifierHash() => r'a8dd7a66ee0002b8af657245c4affaa206fd99ec';
 
 /// See also [CountNotifier].
@@ -67,4 +252,197 @@ final countAsyncNotifierPod =
 );
 
 typedef _$CountAsyncNotifier = AutoDisposeAsyncNotifier<int>;
+String _$countNotifier2Hash() => r'ef12bb4f94add336804ae43bcdbcd8e9b0bec420';
+
+abstract class _$CountNotifier2 extends BuildlessAutoDisposeNotifier<int> {
+  late final int a;
+
+  int build(
+    int a,
+  );
+}
+
+/// See also [CountNotifier2].
+@ProviderFor(CountNotifier2)
+const countNotifier2ProviderFamily = CountNotifier2Family();
+
+/// See also [CountNotifier2].
+class CountNotifier2Family extends Family<int> {
+  /// See also [CountNotifier2].
+  const CountNotifier2Family();
+
+  /// See also [CountNotifier2].
+  CountNotifier2Provider call(
+    int a,
+  ) {
+    return CountNotifier2Provider(
+      a,
+    );
+  }
+
+  @override
+  CountNotifier2Provider getProviderOverride(
+    covariant CountNotifier2Provider provider,
+  ) {
+    return call(
+      provider.a,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'countNotifier2ProviderFamily';
+}
+
+/// See also [CountNotifier2].
+class CountNotifier2Provider
+    extends AutoDisposeNotifierProviderImpl<CountNotifier2, int> {
+  /// See also [CountNotifier2].
+  CountNotifier2Provider(
+    this.a,
+  ) : super.internal(
+          () => CountNotifier2()..a = a,
+          from: countNotifier2ProviderFamily,
+          name: r'countNotifier2ProviderFamily',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$countNotifier2Hash,
+          dependencies: CountNotifier2Family._dependencies,
+          allTransitiveDependencies:
+              CountNotifier2Family._allTransitiveDependencies,
+        );
+
+  final int a;
+
+  @override
+  bool operator ==(Object other) {
+    return other is CountNotifier2Provider && other.a == a;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, a.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+
+  @override
+  int runNotifierBuild(
+    covariant CountNotifier2 notifier,
+  ) {
+    return notifier.build(
+      a,
+    );
+  }
+}
+
+String _$countAsyncNotifier2Hash() =>
+    r'e4bd4d858edbb47fa0d7581f3cfa72e13c914d3d';
+
+abstract class _$CountAsyncNotifier2
+    extends BuildlessAutoDisposeAsyncNotifier<int> {
+  late final int a;
+
+  FutureOr<int> build(
+    int a,
+  );
+}
+
+/// See also [CountAsyncNotifier2].
+@ProviderFor(CountAsyncNotifier2)
+const countAsyncNotifier2ProviderFamily = CountAsyncNotifier2Family();
+
+/// See also [CountAsyncNotifier2].
+class CountAsyncNotifier2Family extends Family<AsyncValue<int>> {
+  /// See also [CountAsyncNotifier2].
+  const CountAsyncNotifier2Family();
+
+  /// See also [CountAsyncNotifier2].
+  CountAsyncNotifier2Provider call(
+    int a,
+  ) {
+    return CountAsyncNotifier2Provider(
+      a,
+    );
+  }
+
+  @override
+  CountAsyncNotifier2Provider getProviderOverride(
+    covariant CountAsyncNotifier2Provider provider,
+  ) {
+    return call(
+      provider.a,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'countAsyncNotifier2ProviderFamily';
+}
+
+/// See also [CountAsyncNotifier2].
+class CountAsyncNotifier2Provider
+    extends AutoDisposeAsyncNotifierProviderImpl<CountAsyncNotifier2, int> {
+  /// See also [CountAsyncNotifier2].
+  CountAsyncNotifier2Provider(
+    this.a,
+  ) : super.internal(
+          () => CountAsyncNotifier2()..a = a,
+          from: countAsyncNotifier2ProviderFamily,
+          name: r'countAsyncNotifier2ProviderFamily',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$countAsyncNotifier2Hash,
+          dependencies: CountAsyncNotifier2Family._dependencies,
+          allTransitiveDependencies:
+              CountAsyncNotifier2Family._allTransitiveDependencies,
+        );
+
+  final int a;
+
+  @override
+  bool operator ==(Object other) {
+    return other is CountAsyncNotifier2Provider && other.a == a;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, a.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+
+  @override
+  FutureOr<int> runNotifierBuild(
+    covariant CountAsyncNotifier2 notifier,
+  ) {
+    return notifier.build(
+      a,
+    );
+  }
+}
 // ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/packages/riverpod_generator/integration/build_yaml/test/build_yaml_test.dart
+++ b/packages/riverpod_generator/integration/build_yaml/test/build_yaml_test.dart
@@ -18,4 +18,14 @@ void main() {
     expect(countNotifierPod.name, 'countNotifierPod');
     expect(countAsyncNotifierPod.name, 'countAsyncNotifierPod');
   });
+
+  test('provider family names', () {
+    expect(count2ProviderFamily.name, 'count2ProviderFamily');
+    expect(countFuture2ProviderFamily.name, 'countFuture2ProviderFamily');
+    expect(countNotifier2ProviderFamily.name, 'countNotifier2ProviderFamily');
+    expect(
+      countAsyncNotifier2ProviderFamily.name,
+      'countAsyncNotifier2ProviderFamily',
+    );
+  });
 }

--- a/packages/riverpod_generator/integration/build_yaml/test/build_yaml_test.dart
+++ b/packages/riverpod_generator/integration/build_yaml/test/build_yaml_test.dart
@@ -15,17 +15,24 @@ void main() {
   test('provider names', () {
     expect(countPod.name, 'countPod');
     expect(countFuturePod.name, 'countFuturePod');
+    expect(countStreamPod.name, 'countStreamPod');
     expect(countNotifierPod.name, 'countNotifierPod');
     expect(countAsyncNotifierPod.name, 'countAsyncNotifierPod');
+    expect(countStreamNotifierPod.name, 'countStreamNotifierPod');
   });
 
   test('provider family names', () {
     expect(count2ProviderFamily.name, 'count2ProviderFamily');
     expect(countFuture2ProviderFamily.name, 'countFuture2ProviderFamily');
+    expect(countStream2ProviderFamily.name, 'countStream2ProviderFamily');
     expect(countNotifier2ProviderFamily.name, 'countNotifier2ProviderFamily');
     expect(
       countAsyncNotifier2ProviderFamily.name,
       'countAsyncNotifier2ProviderFamily',
+    );
+    expect(
+      countStreamNotifier2ProviderFamily.name,
+      'countStreamNotifier2ProviderFamily',
     );
   });
 }

--- a/packages/riverpod_generator/lib/src/models.dart
+++ b/packages/riverpod_generator/lib/src/models.dart
@@ -1,15 +1,18 @@
 class BuildYamlOptions {
   BuildYamlOptions({
     this.providerNameSuffix,
+    this.providerFamilyNameSuffix,
   });
 
   factory BuildYamlOptions.fromMap(Map<String, dynamic> map) {
     return BuildYamlOptions(
       providerNameSuffix: map['provider_name_suffix'] as String?,
+      providerFamilyNameSuffix: map['provider_family_name_suffix'] as String?,
     );
   }
 
   final String? providerNameSuffix;
+  final String? providerFamilyNameSuffix;
 }
 
 extension CaseChangeExtension on String {

--- a/packages/riverpod_generator/lib/src/riverpod_generator.dart
+++ b/packages/riverpod_generator/lib/src/riverpod_generator.dart
@@ -96,6 +96,7 @@ class _RiverpodGeneratorVisitor extends RecursiveRiverpodAstVisitor {
   final BuildYamlOptions options;
 
   String get suffix => options.providerNameSuffix ?? _defaultProviderNameSuffix;
+  String get familySuffix => options.providerFamilyNameSuffix ?? suffix;
 
   var _didEmitHashUtils = false;
   void maybeEmitHashUtils() {
@@ -132,11 +133,6 @@ class _SystemHash {
   ) {
     super.visitStatefulProviderDeclaration(provider);
 
-    final providerName = '${provider.providerElement.name.lowerFirst}$suffix';
-    final notifierTypedefName = providerName.startsWith('_')
-        ? '_\$${provider.providerElement.name.substring(1)}'
-        : '_\$${provider.providerElement.name}';
-
     final parameters = provider.buildMethod.parameters?.parameters;
     if (parameters == null) return;
 
@@ -145,6 +141,11 @@ class _SystemHash {
     buffer.write(_hashFn(provider, hashFunctionName));
 
     if (parameters.isEmpty) {
+      final providerName = '${provider.providerElement.name.lowerFirst}$suffix';
+      final notifierTypedefName = providerName.startsWith('_')
+          ? '_\$${provider.providerElement.name.substring(1)}'
+          : '_\$${provider.providerElement.name}';
+
       StatefulProviderTemplate(
         provider,
         options: options,
@@ -152,6 +153,12 @@ class _SystemHash {
         hashFn: hashFn,
       ).run(buffer);
     } else {
+      final providerName =
+          '${provider.providerElement.name.lowerFirst}$familySuffix';
+      final notifierTypedefName = providerName.startsWith('_')
+          ? '_\$${provider.providerElement.name.substring(1)}'
+          : '_\$${provider.providerElement.name}';
+
       maybeEmitHashUtils();
       FamilyTemplate.stateful(
         provider,

--- a/packages/riverpod_generator/lib/src/templates/family.dart
+++ b/packages/riverpod_generator/lib/src/templates/family.dart
@@ -1,11 +1,19 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:collection/collection.dart';
 import 'package:riverpod_analyzer_utils/riverpod_analyzer_utils.dart';
+
 import '../models.dart';
 import '../riverpod_generator.dart';
 import 'parameters.dart';
 import 'stateful_provider.dart';
 import 'template.dart';
+
+String providerFamilyNameFor(
+  ProviderDeclarationElement provider,
+  BuildYamlOptions options,
+) {
+  return '${provider.name.lowerFirst}${options.providerFamilyNameSuffix ?? options.providerNameSuffix ?? 'Provider'}';
+}
 
 class FamilyTemplate extends Template {
   FamilyTemplate._(
@@ -166,7 +174,8 @@ abstract class $notifierTypedefName extends $notifierBaseType<${provider.valueTy
     });
 
     final docs = providerDocFor(provider.providerElement.element);
-    final providerName = providerNameFor(provider.providerElement, options);
+    final providerName =
+        providerFamilyNameFor(provider.providerElement, options);
 
     final dependenciesKeyword =
         provider.providerElement.annotation.dependencies == null

--- a/packages/riverpod_generator/test/build_yaml_config_test.dart
+++ b/packages/riverpod_generator/test/build_yaml_config_test.dart
@@ -7,4 +7,10 @@ void main() {
     final options = BuildYamlOptions.fromMap(map);
     expect(options.providerNameSuffix, 'Pod');
   });
+
+  test('custom family suffix', () async {
+    const map = {'provider_family_name_suffix': 'ProviderFamily'};
+    final options = BuildYamlOptions.fromMap(map);
+    expect(options.providerFamilyNameSuffix, 'ProviderFamily');
+  });
 }


### PR DESCRIPTION
I wanted to differentiate the Family Provider from other providers, so I implemented an option to change only the suffix of the Family Provider, referring to the option added in #1898 to change the suffix of providers.