### PR TITLE
Update counter example

### DIFF
--- a/examples/counter/analysis_options.yaml
+++ b/examples/counter/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../analysis_options.yaml
+# enable riverpod_lint
+analyzer:
+  plugins:
+    - custom_lint

--- a/examples/counter/lib/main.dart
+++ b/examples/counter/lib/main.dart
@@ -44,13 +44,7 @@ class Home extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Counter example')),
       body: Center(
-        // Consumer is a widget that allows you reading providers.
-        child: Consumer(
-          builder: (context, ref, _) {
-            final count = ref.watch(counterProvider);
-            return Text('$count');
-          },
-        ),
+        child: Text('${ref.watch(counterProvider)}'),
       ),
       floatingActionButton: FloatingActionButton(
         // The read method is a utility to read a provider without listening to it


### PR DESCRIPTION
## enable riverpod_lint
There was riverpod_lint in dev_dependencies, but since custom_lint was not added in analysis_options, I modified analysis_options.yaml.

## remove  unnecessary Consumer
After checking the History, there was a Consumer added when the example was using StatelessWidget, but it seemed unnecessary now since it has been replaced with ConsumerWidget, so I removed it.
https://github.com/rrousselGit/riverpod/commit/c44d952eb78d9c13ff9ba864b4f00d8500fd3465