### PR TITLE
If dependencies is empty, add const

### DIFF
--- a/examples/pub/lib/pub_repository.freezed.dart
+++ b/examples/pub/lib/pub_repository.freezed.dart
@@ -150,7 +150,9 @@ class __$$_PackageMetricsScoreCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_PackageMetricsScore implements _PackageMetricsScore {
+class _$_PackageMetricsScore
+    with DiagnosticableTreeMixin
+    implements _PackageMetricsScore {
   _$_PackageMetricsScore(
       {required this.grantedPoints,
       required this.maxPoints,
@@ -179,8 +181,20 @@ class _$_PackageMetricsScore implements _PackageMetricsScore {
   }
 
   @override
-  String toString() {
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'PackageMetricsScore(grantedPoints: $grantedPoints, maxPoints: $maxPoints, likeCount: $likeCount, popularityScore: $popularityScore, tags: $tags)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'PackageMetricsScore'))
+      ..add(DiagnosticsProperty('grantedPoints', grantedPoints))
+      ..add(DiagnosticsProperty('maxPoints', maxPoints))
+      ..add(DiagnosticsProperty('likeCount', likeCount))
+      ..add(DiagnosticsProperty('popularityScore', popularityScore))
+      ..add(DiagnosticsProperty('tags', tags));
   }
 
   @override
@@ -344,7 +358,9 @@ class __$$_PackageMetricsResponseCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_PackageMetricsResponse implements _PackageMetricsResponse {
+class _$_PackageMetricsResponse
+    with DiagnosticableTreeMixin
+    implements _PackageMetricsResponse {
   _$_PackageMetricsResponse({required this.score});
 
   factory _$_PackageMetricsResponse.fromJson(Map<String, dynamic> json) =>
@@ -354,8 +370,16 @@ class _$_PackageMetricsResponse implements _PackageMetricsResponse {
   final PackageMetricsScore score;
 
   @override
-  String toString() {
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'PackageMetricsResponse(score: $score)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'PackageMetricsResponse'))
+      ..add(DiagnosticsProperty('score', score));
   }
 
   @override
@@ -493,7 +517,9 @@ class __$$_PackageDetailsCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_PackageDetails implements _PackageDetails {
+class _$_PackageDetails
+    with DiagnosticableTreeMixin
+    implements _PackageDetails {
   _$_PackageDetails({required this.version, required this.pubspec});
 
   factory _$_PackageDetails.fromJson(Map<String, dynamic> json) =>
@@ -505,8 +531,17 @@ class _$_PackageDetails implements _PackageDetails {
   final Pubspec pubspec;
 
   @override
-  String toString() {
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'PackageDetails(version: $version, pubspec: $pubspec)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'PackageDetails'))
+      ..add(DiagnosticsProperty('version', version))
+      ..add(DiagnosticsProperty('pubspec', pubspec));
   }
 
   @override
@@ -656,7 +691,7 @@ class __$$_PackageCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_Package implements _Package {
+class _$_Package with DiagnosticableTreeMixin implements _Package {
   _$_Package({required this.name, required this.latest});
 
   factory _$_Package.fromJson(Map<String, dynamic> json) =>
@@ -668,8 +703,17 @@ class _$_Package implements _Package {
   final PackageDetails latest;
 
   @override
-  String toString() {
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'Package(name: $name, latest: $latest)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'Package'))
+      ..add(DiagnosticsProperty('name', name))
+      ..add(DiagnosticsProperty('latest', latest));
   }
 
   @override
@@ -809,7 +853,7 @@ class __$$_LikedPackageCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_LikedPackage implements _LikedPackage {
+class _$_LikedPackage with DiagnosticableTreeMixin implements _LikedPackage {
   _$_LikedPackage({required this.package, required this.liked});
 
   factory _$_LikedPackage.fromJson(Map<String, dynamic> json) =>
@@ -821,8 +865,17 @@ class _$_LikedPackage implements _LikedPackage {
   final bool liked;
 
   @override
-  String toString() {
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'LikedPackage(package: $package, liked: $liked)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'LikedPackage'))
+      ..add(DiagnosticsProperty('package', package))
+      ..add(DiagnosticsProperty('liked', liked));
   }
 
   @override
@@ -954,7 +1007,9 @@ class __$$_LikesPackagesResponseCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_LikesPackagesResponse implements _LikesPackagesResponse {
+class _$_LikesPackagesResponse
+    with DiagnosticableTreeMixin
+    implements _LikesPackagesResponse {
   _$_LikesPackagesResponse({required final List<LikedPackage> likedPackages})
       : _likedPackages = likedPackages;
 
@@ -970,8 +1025,16 @@ class _$_LikesPackagesResponse implements _LikesPackagesResponse {
   }
 
   @override
-  String toString() {
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'LikedPackagesResponse(likedPackages: $likedPackages)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'LikedPackagesResponse'))
+      ..add(DiagnosticsProperty('likedPackages', likedPackages));
   }
 
   @override
@@ -1101,7 +1164,9 @@ class __$$_PubPackagesResponseCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_PubPackagesResponse implements _PubPackagesResponse {
+class _$_PubPackagesResponse
+    with DiagnosticableTreeMixin
+    implements _PubPackagesResponse {
   _$_PubPackagesResponse({required final List<Package> packages})
       : _packages = packages;
 
@@ -1117,8 +1182,16 @@ class _$_PubPackagesResponse implements _PubPackagesResponse {
   }
 
   @override
-  String toString() {
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'PubPackagesResponse(packages: $packages)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'PubPackagesResponse'))
+      ..add(DiagnosticsProperty('packages', packages));
   }
 
   @override
@@ -1246,7 +1319,7 @@ class __$$_SearchPackageCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_SearchPackage implements _SearchPackage {
+class _$_SearchPackage with DiagnosticableTreeMixin implements _SearchPackage {
   _$_SearchPackage({required this.package});
 
   factory _$_SearchPackage.fromJson(Map<String, dynamic> json) =>
@@ -1256,8 +1329,16 @@ class _$_SearchPackage implements _SearchPackage {
   final String package;
 
   @override
-  String toString() {
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'SearchPackage(package: $package)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'SearchPackage'))
+      ..add(DiagnosticsProperty('package', package));
   }
 
   @override
@@ -1382,7 +1463,9 @@ class __$$_PubSearchResponseCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_PubSearchResponse implements _PubSearchResponse {
+class _$_PubSearchResponse
+    with DiagnosticableTreeMixin
+    implements _PubSearchResponse {
   _$_PubSearchResponse({required final List<SearchPackage> packages})
       : _packages = packages;
 
@@ -1398,8 +1481,16 @@ class _$_PubSearchResponse implements _PubSearchResponse {
   }
 
   @override
-  String toString() {
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
     return 'PubSearchResponse(packages: $packages)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'PubSearchResponse'))
+      ..add(DiagnosticsProperty('packages', packages));
   }
 
   @override

--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased patch
+
+- If a provider has an empty list of dependencies, the generated list is now `const`
+  (thanks to @K9i-0)
+
 ## 2.1.3 - 2023-03-10
 
 - Fixed InconsistentAnalysisException

--- a/packages/riverpod_generator/lib/src/templates/stateful_provider.dart
+++ b/packages/riverpod_generator/lib/src/templates/stateful_provider.dart
@@ -16,7 +16,9 @@ String? serializeDependencies(
 ) {
   if (dependencies == null) return 'null';
 
-  final buffer = StringBuffer('<ProviderOrFamily>');
+  final buffer = StringBuffer(
+    '${dependencies.isEmpty ? 'const ' : ''}<ProviderOrFamily>',
+  );
   // Use list vs set based on the number of dependencies to optimize "contains" call
   if (dependencies.length < 4) {
     buffer.write('[');

--- a/packages/riverpod_generator/test/dependencies_test.dart
+++ b/packages/riverpod_generator/test/dependencies_test.dart
@@ -1,3 +1,4 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:test/test.dart';
 
 import 'integration/dependencies.dart';
@@ -27,6 +28,16 @@ void main() {
     );
 
     expect(transitiveDependenciesProvider.dependencies, [providerProvider]);
+
+    expect(
+      emptyDependenciesStatelessProvider.dependencies,
+      const <ProviderOrFamily>[],
+    );
+
+    expect(
+      emptyDependenciesStatefulProvider.dependencies,
+      const <ProviderOrFamily>[],
+    );
   });
 
   test('Generates transitive dependencies', () {
@@ -61,6 +72,16 @@ void main() {
         dep2Provider,
         family2Provider,
       ],
+    );
+
+    expect(
+      emptyDependenciesStatelessProvider.allTransitiveDependencies,
+      const <ProviderOrFamily>[],
+    );
+
+    expect(
+      emptyDependenciesStatefulProvider.allTransitiveDependencies,
+      const <ProviderOrFamily>[],
     );
   });
 

--- a/packages/riverpod_generator/test/dependencies_test.dart
+++ b/packages/riverpod_generator/test/dependencies_test.dart
@@ -31,12 +31,12 @@ void main() {
 
     expect(
       emptyDependenciesStatelessProvider.dependencies,
-      const <ProviderOrFamily>[],
+      same(const <ProviderOrFamily>[]),
     );
 
     expect(
       emptyDependenciesStatefulProvider.dependencies,
-      const <ProviderOrFamily>[],
+      same(const <ProviderOrFamily>[]),
     );
   });
 
@@ -76,12 +76,12 @@ void main() {
 
     expect(
       emptyDependenciesStatelessProvider.allTransitiveDependencies,
-      const <ProviderOrFamily>[],
+      same(const <ProviderOrFamily>[]),
     );
 
     expect(
       emptyDependenciesStatefulProvider.allTransitiveDependencies,
-      const <ProviderOrFamily>[],
+      same(const <ProviderOrFamily>[]),
     );
   });
 

--- a/packages/riverpod_generator/test/dependencies_test.dart
+++ b/packages/riverpod_generator/test/dependencies_test.dart
@@ -106,6 +106,18 @@ void main() {
       transitiveDependenciesProvider.dependencies,
       same(transitiveDependenciesProvider.dependencies),
     );
+    expect(
+      smallTransitiveDependencyCountProvider.dependencies,
+      same(smallTransitiveDependencyCountProvider.dependencies),
+    );
+    expect(
+      emptyDependenciesStatelessProvider.dependencies,
+      same(emptyDependenciesStatelessProvider.dependencies),
+    );
+    expect(
+      emptyDependenciesStatefulProvider.dependencies,
+      same(emptyDependenciesStatefulProvider.dependencies),
+    );
 
     expect(
       provider3Provider.allTransitiveDependencies,
@@ -118,6 +130,10 @@ void main() {
     expect(
       transitiveDependenciesProvider.allTransitiveDependencies,
       same(transitiveDependenciesProvider.allTransitiveDependencies),
+    );
+    expect(
+      smallTransitiveDependencyCountProvider.allTransitiveDependencies,
+      same(smallTransitiveDependencyCountProvider.allTransitiveDependencies),
     );
   });
 }

--- a/packages/riverpod_generator/test/integration/dependencies.dart
+++ b/packages/riverpod_generator/test/integration/dependencies.dart
@@ -43,3 +43,13 @@ int transitiveDependencies(TransitiveDependenciesRef ref) => 0;
 
 @Riverpod(dependencies: [dep, family, Dep2])
 int smallTransitiveDependencyCount(SmallTransitiveDependencyCountRef ref) => 0;
+
+@Riverpod(dependencies: [])
+int emptyDependenciesStateless(EmptyDependenciesStatelessRef ref) =>
+    throw UnimplementedError();
+
+@Riverpod(dependencies: [])
+class EmptyDependenciesStateful extends _$EmptyDependenciesStateful {
+  @override
+  int build() => throw UnimplementedError();
+}

--- a/packages/riverpod_generator/test/integration/dependencies.dart
+++ b/packages/riverpod_generator/test/integration/dependencies.dart
@@ -45,11 +45,10 @@ int transitiveDependencies(TransitiveDependenciesRef ref) => 0;
 int smallTransitiveDependencyCount(SmallTransitiveDependencyCountRef ref) => 0;
 
 @Riverpod(dependencies: [])
-int emptyDependenciesStateless(EmptyDependenciesStatelessRef ref) =>
-    throw UnimplementedError();
+int emptyDependenciesStateless(EmptyDependenciesStatelessRef ref) => 0;
 
 @Riverpod(dependencies: [])
 class EmptyDependenciesStateful extends _$EmptyDependenciesStateful {
   @override
-  int build() => throw UnimplementedError();
+  int build() => 0;
 }

--- a/packages/riverpod_generator/test/integration/dependencies.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies.g.dart
@@ -214,6 +214,22 @@ final smallTransitiveDependencyCountProvider =
 );
 
 typedef SmallTransitiveDependencyCountRef = AutoDisposeProviderRef<int>;
+String _$emptyDependenciesStatelessHash() =>
+    r'aec0bd8c67f34613ec89c86cdbbe21cde4b869b8';
+
+/// See also [emptyDependenciesStateless].
+@ProviderFor(emptyDependenciesStateless)
+final emptyDependenciesStatelessProvider = AutoDisposeProvider<int>.internal(
+  emptyDependenciesStateless,
+  name: r'emptyDependenciesStatelessProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$emptyDependenciesStatelessHash,
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
+);
+
+typedef EmptyDependenciesStatelessRef = AutoDisposeProviderRef<int>;
 String _$dep2Hash() => r'2778537df77f6431148c2ce400724da3e2ab4b94';
 
 /// See also [Dep2].
@@ -451,4 +467,22 @@ class Provider4Provider
     );
   }
 }
+
+String _$emptyDependenciesStatefulHash() =>
+    r'dbcaefd3f0bab7d3dac57d4d96471c1630e53ff4';
+
+/// See also [EmptyDependenciesStateful].
+@ProviderFor(EmptyDependenciesStateful)
+final emptyDependenciesStatefulProvider =
+    AutoDisposeNotifierProvider<EmptyDependenciesStateful, int>.internal(
+  EmptyDependenciesStateful.new,
+  name: r'emptyDependenciesStatefulProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$emptyDependenciesStatefulHash,
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
+);
+
+typedef _$EmptyDependenciesStateful = AutoDisposeNotifier<int>;
 // ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/packages/riverpod_generator/test/integration/dependencies.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies.g.dart
@@ -215,7 +215,7 @@ final smallTransitiveDependencyCountProvider =
 
 typedef SmallTransitiveDependencyCountRef = AutoDisposeProviderRef<int>;
 String _$emptyDependenciesStatelessHash() =>
-    r'aec0bd8c67f34613ec89c86cdbbe21cde4b869b8';
+    r'2415aab6f03b1cb67fa8fecc5d2af1ec5d261398';
 
 /// See also [emptyDependenciesStateless].
 @ProviderFor(emptyDependenciesStateless)
@@ -469,7 +469,7 @@ class Provider4Provider
 }
 
 String _$emptyDependenciesStatefulHash() =>
-    r'dbcaefd3f0bab7d3dac57d4d96471c1630e53ff4';
+    r'7cd5d081bbfb866823b0d493e63bfc63b9d9c804';
 
 /// See also [EmptyDependenciesStateful].
 @ProviderFor(EmptyDependenciesStateful)

--- a/packages/riverpod_lint_flutter_test/test/goldens/fixes/provider_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/fixes/provider_dependencies.g.dart
@@ -15,8 +15,8 @@ final depProvider = AutoDisposeProvider<int>.internal(
   name: r'depProvider',
   debugGetCreateSourceHash:
       const bool.fromEnvironment('dart.vm.product') ? null : _$depHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef DepRef = AutoDisposeProviderRef<int>;
@@ -29,8 +29,8 @@ final dep2Provider = AutoDisposeProvider<int>.internal(
   name: r'dep2Provider',
   debugGetCreateSourceHash:
       const bool.fromEnvironment('dart.vm.product') ? null : _$dep2Hash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef Dep2Ref = AutoDisposeProviderRef<int>;
@@ -91,8 +91,8 @@ final existingDepProvider = AutoDisposeProvider<int>.internal(
   name: r'existingDepProvider',
   debugGetCreateSourceHash:
       const bool.fromEnvironment('dart.vm.product') ? null : _$existingDepHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef ExistingDepRef = AutoDisposeProviderRef<int>;
@@ -105,8 +105,8 @@ final multipleDepsProvider = AutoDisposeProvider<int>.internal(
   name: r'multipleDepsProvider',
   debugGetCreateSourceHash:
       const bool.fromEnvironment('dart.vm.product') ? null : _$multipleDepsHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef MultipleDepsRef = AutoDisposeProviderRef<int>;

--- a/packages/riverpod_lint_flutter_test/test/goldens/lints/dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/lints/dependencies.g.dart
@@ -34,8 +34,8 @@ final depProvider = AutoDisposeProvider<int>.internal(
   name: r'depProvider',
   debugGetCreateSourceHash:
       const bool.fromEnvironment('dart.vm.product') ? null : _$depHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef DepRef = AutoDisposeProviderRef<int>;
@@ -49,8 +49,8 @@ final generatedScopedProvider = AutoDisposeProvider<int>.internal(
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
       : _$generatedScopedHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef GeneratedScopedRef = AutoDisposeProviderRef<int>;
@@ -164,8 +164,8 @@ final watchScopedButEmptyDependenciesProvider =
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
       : _$watchScopedButEmptyDependenciesHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef WatchScopedButEmptyDependenciesRef = AutoDisposeProviderRef<int>;
@@ -181,8 +181,8 @@ final watchGeneratedScopedButEmptyDependenciesProvider =
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
       : _$watchGeneratedScopedButEmptyDependenciesHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef WatchGeneratedScopedButEmptyDependenciesRef
@@ -198,8 +198,8 @@ final watchRootButEmptyDependenciesProvider = AutoDisposeProvider<int>.internal(
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
       : _$watchRootButEmptyDependenciesHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef WatchRootButEmptyDependenciesRef = AutoDisposeProviderRef<int>;
@@ -215,8 +215,8 @@ final watchGeneratedRootButEmptyDependenciesProvider =
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
       : _$watchGeneratedRootButEmptyDependenciesHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef WatchGeneratedRootButEmptyDependenciesRef = AutoDisposeProviderRef<int>;
@@ -374,8 +374,8 @@ final classWatchGeneratedRootButMissingDependenciesProvider =
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
       : _$classWatchGeneratedRootButMissingDependenciesHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef _$ClassWatchGeneratedRootButMissingDependencies
@@ -393,8 +393,8 @@ final classWatchGeneratedScopedButMissingDependenciesProvider =
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
       : _$classWatchGeneratedScopedButMissingDependenciesHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef _$ClassWatchGeneratedScopedButMissingDependencies

--- a/packages/riverpod_lint_flutter_test/test/goldens/lints/scoped_providers_should_specify_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/lints/scoped_providers_should_specify_dependencies.g.dart
@@ -15,8 +15,8 @@ final scopedProvider = AutoDisposeProvider<int>.internal(
   name: r'scopedProvider',
   debugGetCreateSourceHash:
       const bool.fromEnvironment('dart.vm.product') ? null : _$scopedHash,
-  dependencies: <ProviderOrFamily>[],
-  allTransitiveDependencies: <ProviderOrFamily>[],
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>[],
 );
 
 typedef ScopedRef = AutoDisposeProviderRef<int>;


### PR DESCRIPTION
When creating a provider with an empty list for dependencies, a warning was raised.
I fixed it by adding const.

![SCR-20230313-ljy](https://user-images.githubusercontent.com/90010509/224627998-93c63ec3-a245-4c46-9553-ddaa898cc4c4.png)

https://dart-lang.github.io/linter/lints/prefer_const_literals_to_create_immutables.html