### PR TITLE
Fix "Too many elements" error.

### DIFF
--- a/packages/riverpod_analyzer_utils/CHANGELOG.md
+++ b/packages/riverpod_analyzer_utils/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased minor
+
+- Added `providerForType` TypeChecker for `ProviderFor` annotation
+- Generated providers inside `.g.dart` no-longer are incorrectly parsed as legacy providers.
+
 ## 0.1.4 - 2023-03-10
 
 - Fixed an `Unsupported operation: Unknown type SimpleIdentifierImpl` crash

--- a/packages/riverpod_analyzer_utils/lib/src/riverpod_ast.dart
+++ b/packages/riverpod_analyzer_utils/lib/src/riverpod_ast.dart
@@ -10,7 +10,6 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
-import 'package:custom_lint_core/custom_lint_core.dart';
 import 'package:meta/meta.dart';
 
 import '../riverpod_analyzer_utils.dart';
@@ -30,11 +29,6 @@ part 'riverpod_ast/visitor.dart';
 part 'riverpod_ast/widget_ref_invocation.dart';
 part 'riverpod_ast/provider_scope.dart';
 part 'riverpod_ast/provider_override.dart';
-
-const _providerForAnnotationChecker = TypeChecker.fromName(
-  'ProviderFor',
-  packageName: 'riverpod_annotation',
-);
 
 @sealed
 abstract class RiverpodAst {

--- a/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/provider_listenable_expression.dart
+++ b/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/provider_listenable_expression.dart
@@ -28,8 +28,8 @@ class ProviderListenableExpression extends RiverpodAst {
         if (element is PropertyAccessorElement) {
           DartObject? annotation;
           try {
-            annotation = _providerForAnnotationChecker
-                .firstAnnotationOfExact(element.variable);
+            annotation =
+                providerForType.firstAnnotationOfExact(element.variable);
           } catch (_) {
             return;
           }

--- a/packages/riverpod_analyzer_utils/lib/src/riverpod_element.dart
+++ b/packages/riverpod_analyzer_utils/lib/src/riverpod_element.dart
@@ -193,6 +193,11 @@ class LegacyProviderDeclarationElement implements ProviderDeclarationElement {
     VariableElement element,
   ) {
     return _cache.putIfAbsent(element, () {
+      // Search for @ProviderFor annotation. If present, then this is a generated provider
+      if (providerForType.hasAnnotationOfExact(element)) {
+        return null;
+      }
+
       bool isAutoDispose;
       LegacyFamilyInvocationElement? familyElement;
       LegacyProviderType providerType;

--- a/packages/riverpod_analyzer_utils/lib/src/riverpod_types.dart
+++ b/packages/riverpod_analyzer_utils/lib/src/riverpod_types.dart
@@ -1,5 +1,11 @@
 import 'package:custom_lint_core/custom_lint_core.dart';
 
+/// TypeChecker for the `ProviderFor` annotation
+const providerForType = TypeChecker.fromName(
+  'ProviderFor',
+  packageName: 'riverpod_annotation',
+);
+
 /// Matches with the `Riverpod` annotation from riverpod_annotation.
 const riverpodType =
     TypeChecker.fromName('Riverpod', packageName: 'riverpod_annotation');

--- a/packages/riverpod_analyzer_utils_tests/test/legacy_provider_declaration_test.dart
+++ b/packages/riverpod_analyzer_utils_tests/test/legacy_provider_declaration_test.dart
@@ -7,6 +7,28 @@ import 'analyser_test_utils.dart';
 
 void main() {
   group('LegacyProviderDefinition.parse', () {
+    testSource('Does not try to parse generated providers',
+        runGenerator: true, source: '''
+import 'package:riverpod/riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'foo.g.dart';
+
+final legacy = Provider<int>((ref) => 0);
+
+@riverpod
+int simple(SimpleRef ref) => 0;
+
+// Regression test for https://github.com/rrousselGit/riverpod/issues/2194
+@riverpod
+int complex(ComplexRef ref, {int? id, String? another}) => 0;
+''', (resolver) async {
+      final result = await resolver.resolveRiverpodAnalyssiResult();
+
+      expect(result.legacyProviderDeclarations, hasLength(1));
+      expect(result.generatorProviderDeclarations, hasLength(2));
+    });
+
     testSource('Decode name', source: '''
 import 'package:riverpod/riverpod.dart';
 

--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- No-longer throw "Bad state: Too many elements"
+
 ## 1.1.5 - 2023-03-10
 
 - `riverpod_analyzer_utils` upgraded to `0.1.4`


### PR DESCRIPTION
This was triggered by the analysis incorrectly trying to decode generated
providers as legacy providers.

fixes #2194