### PR TITLE
RFC: Use a data structure that allows for fast removal of watchers/subscribers

### DIFF
--- a/packages/riverpod/lib/src/framework/element.dart
+++ b/packages/riverpod/lib/src/framework/element.dart
@@ -84,7 +84,7 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
   ///
   /// This is typically Flutter widgets or manual calls to [ProviderContainer.listen]
   /// with this provider as target.
-  final _externalDependents = <_ExternalProviderSubscription<State>>[];
+  final _externalDependents = LinkedList<_ExternalProviderSubscription<State>>();
 
   /// The [ProviderSubscription]s associated to the providers that this
   /// [ProviderElementBase] listens to.
@@ -536,9 +536,10 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     final subscribers = _subscribers.toList(growable: false);
     newState.map(
       data: (newState) {
-        for (var i = 0; i < listeners.length; i++) {
+        for (final listener in listeners) {
+        // for (var i = 0; i < listeners.length; i++) {
           Zone.current.runBinaryGuarded(
-            listeners[i]._listener,
+            listener._listener,
             previousState,
             newState.state,
           );
@@ -552,9 +553,9 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
         }
       },
       error: (newState) {
-        for (var i = 0; i < listeners.length; i++) {
+        for (final listener in listeners) {
           Zone.current.runBinaryGuarded(
-            listeners[i].onError,
+            listener.onError,
             newState.error,
             newState.stackTrace,
           );

--- a/packages/riverpod/lib/src/framework/provider_base.dart
+++ b/packages/riverpod/lib/src/framework/provider_base.dart
@@ -148,6 +148,7 @@ abstract class ProviderBase<State> extends ProviderOrFamily
 var _debugIsRunningSelector = false;
 
 class _ExternalProviderSubscription<State>
+    extends LinkedListEntry<_ExternalProviderSubscription<State>>
     implements ProviderSubscription<State> {
   _ExternalProviderSubscription._(
     this._listenedElement,
@@ -163,7 +164,9 @@ class _ExternalProviderSubscription<State>
   @override
   void close() {
     _closed = true;
-    _listenedElement._externalDependents.remove(this);
+    if (list != null) {
+      unlink();
+    }
     _listenedElement._onRemoveListener();
   }
 


### PR DESCRIPTION
At this point, this PR is mostly meant as an RFC to get some early input.

I had a use case of with hundreds of watchers and depending on the UI state they would get disposed and created. I noticed that I spend some non-tivial time unregistering watchers. You could argue that maybe one should generally avoid having hundreds or thousand of ever-changing watchers. On the other hand, maybe List isn't the best data structure :shrug:. Curious to hear your thoughts.