### PR TITLE
Fix: Correct onPressed logic for navigation button in documentation

### DIFF
--- a/website/i18n/bn/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
@@ -29,7 +29,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/bn/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
+++ b/website/i18n/bn/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
@@ -19,7 +19,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
@@ -29,7 +29,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
@@ -19,7 +19,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
@@ -29,7 +29,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
@@ -19,7 +19,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
@@ -31,7 +31,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
@@ -19,7 +19,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
@@ -30,7 +30,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
@@ -19,7 +19,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
@@ -29,7 +29,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
@@ -19,7 +19,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
@@ -29,7 +29,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
@@ -19,7 +19,7 @@ class PreviousButton extends ConsumerWidget {
     }
 
     return ElevatedButton(
-      onPressed: canGoToPreviousPage ? null : goToPreviousPage,
+      onPressed: canGoToPreviousPage ? goToPreviousPage : null,
       child: const Text('previous'),
     );
   }


### PR DESCRIPTION
Hello,
I was reading through the official documentation and came across an error in the sample code.
I'm always grateful for the library, and I hope my small contribution can help improve it.

This PR fixes the logic in the onPressed property of the navigation button within the sample code in the official documentation. 

Previously, the button's behavior was inverted, causing it to be disabled when it should have been enabled, and vice versa.
