### PR TITLE
Fix sample code in Consumer API Docs

### DIFF
--- a/packages/flutter_riverpod/lib/src/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/consumer.dart
@@ -312,12 +312,12 @@ typedef ConsumerBuilder = Widget Function(
 /// ```dart
 /// final counterProvider = StateProvider((ref) => 0);
 ///
-/// class MyHomePage extends StatelessWidget {
+/// class MyHomePage extends ConsumerWidget {
 ///   MyHomePage({Key? key, required this.title}) : super(key: key);
 ///   final String title;
 ///
 ///   @override
-///   Widget build(BuildContext context) {
+///   Widget build(BuildContext context, WidgetRef ref) {
 ///     return Scaffold(
 ///       appBar: AppBar(
 ///         title: Text(title)


### PR DESCRIPTION
I found a compilation error in the sample code of Consumer API Docs and fixed it.