### PR TITLE
docs: add one line install command

### DIFF
--- a/website/docs/getting_started.mdx
+++ b/website/docs/getting_started.mdx
@@ -50,7 +50,7 @@ run in your terminal
 
 </Tabs>
 
-Once you know what package you want to install, proceed to add the following to your `pubspec.yaml`:
+or add the following to your `pubspec.yaml`:
 
 <Tabs
   groupId="riverpod"

--- a/website/docs/getting_started.mdx
+++ b/website/docs/getting_started.mdx
@@ -8,8 +8,10 @@ import TabItem from "@theme/TabItem";
 import CodeBlock from "@theme/CodeBlock";
 import pubspec from "./getting_started/pubspec";
 import dartHelloWorld from "./getting_started/dart_hello_world";
+import pubadd from  "./getting_started/pub_add";
 import helloWorld from "./getting_started/hello_world";
 import dartPubspec from "./getting_started/dart_pubspec";
+import dartPubadd from  "./getting_started/dart_pub_add";
 import {
   trimSnippet,
   AutoSnippet,
@@ -24,6 +26,30 @@ To get a feel of Riverpod, try it online on [Dartpad](https://dartpad.dev/?null_
 
 ## Installing the package
 
+run in your terminal
+
+<Tabs
+  groupId="riverpod"
+  defaultValue="flutter_riverpod"
+  values={[
+    { label: 'Flutter', value: 'flutter_riverpod', },
+    { label: 'Dart only', value: 'riverpod', },
+  ]}
+>
+<TabItem value="flutter_riverpod">
+
+<AutoSnippet title="Terminal" {...pubadd}></AutoSnippet>
+
+</TabItem>
+
+<TabItem value="riverpod">
+
+<AutoSnippet title="Terminal" {...dartPubadd}></AutoSnippet>
+
+</TabItem>
+
+</Tabs>
+
 Once you know what package you want to install, proceed to add the following to your `pubspec.yaml`:
 
 <Tabs
@@ -36,26 +62,6 @@ Once you know what package you want to install, proceed to add the following to 
 >
 <TabItem value="flutter_riverpod">
 
-<p/>
-
-<ConditionalSnippet codegen={false} hooks={true}>
-  <code>flutter pub add hooks_riverpod dev:custom_lint dev:riverpod_lint</code>
-</ConditionalSnippet>
-
-<ConditionalSnippet codegen={false} hooks={false}>
-  <code>flutter pub add flutter_riverpod dev:custom_lint dev:riverpod_lint</code>
-</ConditionalSnippet>
-
-<ConditionalSnippet codegen={true} hooks={true}>
-  <code>flutter pub add hooks_riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator</code>
-</ConditionalSnippet>
-
-<ConditionalSnippet codegen={true} hooks={false}>
-  <code>flutter pub add flutter_riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator</code>
-</ConditionalSnippet>
-
-<p/>
-
 <AutoSnippet title="pubspec.yaml" language="yaml" {...pubspec}></AutoSnippet>
 
 Then install packages with `flutter pub get`.
@@ -67,18 +73,6 @@ Then install packages with `flutter pub get`.
 
 </TabItem>
 <TabItem value="riverpod">
-
-<p/>
-
-<ConditionalSnippet codegen={true}>
-  <code>dart pub add riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator</code>
-</ConditionalSnippet>
-
-<ConditionalSnippet codegen={false}>
-  <code>dart pub add riverpod dev:custom_lint dev:riverpod_lint</code>
-</ConditionalSnippet>
-
-<p/>
 
 <AutoSnippet
   title="pubspec.yaml"

--- a/website/docs/getting_started.mdx
+++ b/website/docs/getting_started.mdx
@@ -36,6 +36,26 @@ Once you know what package you want to install, proceed to add the following to 
 >
 <TabItem value="flutter_riverpod">
 
+<p/>
+
+<ConditionalSnippet codegen={false} hooks={true}>
+  <code>flutter pub add hooks_riverpod dev:custom_lint dev:riverpod_lint</code>
+</ConditionalSnippet>
+
+<ConditionalSnippet codegen={false} hooks={false}>
+  <code>flutter pub add flutter_riverpod dev:custom_lint dev:riverpod_lint</code>
+</ConditionalSnippet>
+
+<ConditionalSnippet codegen={true} hooks={true}>
+  <code>flutter pub add hooks_riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator</code>
+</ConditionalSnippet>
+
+<ConditionalSnippet codegen={true} hooks={false}>
+  <code>flutter pub add flutter_riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator</code>
+</ConditionalSnippet>
+
+<p/>
+
 <AutoSnippet title="pubspec.yaml" language="yaml" {...pubspec}></AutoSnippet>
 
 Then install packages with `flutter pub get`.
@@ -47,6 +67,18 @@ Then install packages with `flutter pub get`.
 
 </TabItem>
 <TabItem value="riverpod">
+
+<p/>
+
+<ConditionalSnippet codegen={true}>
+  <code>dart pub add riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator</code>
+</ConditionalSnippet>
+
+<ConditionalSnippet codegen={false}>
+  <code>dart pub add riverpod dev:custom_lint dev:riverpod_lint</code>
+</ConditionalSnippet>
+
+<p/>
 
 <AutoSnippet
   title="pubspec.yaml"

--- a/website/docs/getting_started.mdx
+++ b/website/docs/getting_started.mdx
@@ -26,31 +26,7 @@ To get a feel of Riverpod, try it online on [Dartpad](https://dartpad.dev/?null_
 
 ## Installing the package
 
-run in your terminal
-
-<Tabs
-  groupId="riverpod"
-  defaultValue="flutter_riverpod"
-  values={[
-    { label: 'Flutter', value: 'flutter_riverpod', },
-    { label: 'Dart only', value: 'riverpod', },
-  ]}
->
-<TabItem value="flutter_riverpod">
-
-<AutoSnippet title="Terminal" {...pubadd}></AutoSnippet>
-
-</TabItem>
-
-<TabItem value="riverpod">
-
-<AutoSnippet title="Terminal" {...dartPubadd}></AutoSnippet>
-
-</TabItem>
-
-</Tabs>
-
-or add the following to your `pubspec.yaml`:
+Once you know what package you want to install, proceed to add the following to your `pubspec.yaml`:
 
 <Tabs
   groupId="riverpod"
@@ -88,6 +64,30 @@ Then install packages with `dart pub get`.
 </ConditionalSnippet>
 
 </TabItem>
+</Tabs>
+
+Alternatively, you can add the dependency to your app in a single line like this:
+
+<Tabs
+  groupId="riverpod"
+  defaultValue="flutter_riverpod"
+  values={[
+    { label: 'Flutter', value: 'flutter_riverpod', },
+    { label: 'Dart only', value: 'riverpod', },
+  ]}
+>
+<TabItem value="flutter_riverpod">
+
+<AutoSnippet title="Terminal" {...pubadd}></AutoSnippet>
+
+</TabItem>
+
+<TabItem value="riverpod">
+
+<AutoSnippet title="Terminal" {...dartPubadd}></AutoSnippet>
+
+</TabItem>
+
 </Tabs>
 
 That's it. You've added [Riverpod] to your app!

--- a/website/docs/getting_started/dart_pub_add.tsx
+++ b/website/docs/getting_started/dart_pub_add.tsx
@@ -1,0 +1,10 @@
+const raw = `dart pub add riverpod dev:custom_lint dev:riverpod_lint`;
+
+const codegen = `dart pub add riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator`;
+
+export default {
+    raw,
+    hooks: raw,
+    codegen,
+    hooksCodegen: codegen,
+};

--- a/website/docs/getting_started/dart_pub_add.tsx
+++ b/website/docs/getting_started/dart_pub_add.tsx
@@ -1,6 +1,6 @@
-const raw = `dart pub add riverpod dev:custom_lint dev:riverpod_lint`;
+const raw = "dart pub add riverpod dev:custom_lint dev:riverpod_lint";
 
-const codegen = `dart pub add riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator`;
+const codegen = "dart pub add riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator";
 
 export default {
     raw,

--- a/website/docs/getting_started/pub_add.tsx
+++ b/website/docs/getting_started/pub_add.tsx
@@ -1,0 +1,14 @@
+const raw = `flutter pub add flutter_riverpod dev:custom_lint dev:riverpod_lint`;
+
+const codegen = `flutter pub add flutter_riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator`;
+
+const hooks = `flutter pub add hooks_riverpod dev:custom_lint dev:riverpod_lint`;
+
+const hooksCodegen = `flutter pub add hooks_riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator`;
+
+export default {
+    raw: raw,
+    hooks: hooks,
+    codegen: codegen,
+    hooksCodegen: hooksCodegen
+};

--- a/website/docs/getting_started/pub_add.tsx
+++ b/website/docs/getting_started/pub_add.tsx
@@ -1,10 +1,10 @@
-const raw = `flutter pub add flutter_riverpod dev:custom_lint dev:riverpod_lint`;
+const raw = "flutter pub add flutter_riverpod dev:custom_lint dev:riverpod_lint";
 
-const codegen = `flutter pub add flutter_riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator`;
+const codegen = "flutter pub add flutter_riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator";
 
-const hooks = `flutter pub add hooks_riverpod dev:custom_lint dev:riverpod_lint`;
+const hooks = "flutter pub add hooks_riverpod dev:custom_lint dev:riverpod_lint";
 
-const hooksCodegen = `flutter pub add hooks_riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator`;
+const hooksCodegen = "flutter pub add hooks_riverpod dev:custom_lint dev:riverpod_lint riverpod_annotation dev:build_runner dev:riverpod_generator";
 
 export default {
     raw: raw,


### PR DESCRIPTION
## Description

I have added a single line command example to the Riverpod documentation site to make it easier for users to add the necessary dependencies

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/59682979/226559183-e81acc48-acb0-4871-90b1-85220797113f.png">
## Type of Change

- [x] 📝 `docs` -- Documentation
