### PR TITLE
docs: code snippets for concepts/combining_providers

### DIFF
--- a/website/docs/concepts/combining_provider_states/characters_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/characters_provider/codegen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'models.dart';
+
+part 'codegen.g.dart';
+
+final dio = Dio();
+
+/* SNIPPET START */
+
+// The current search filter
+final searchProvider = StateProvider((ref) => '');
+
+@riverpod
+Stream<Configuration> configs(ConfigsRef ref) {
+  return Stream.value(Configuration());
+}
+
+@riverpod
+Future<List<Character>> characters(CharactersRef ref) async {
+  final search = ref.watch(searchProvider);
+  final configs = await ref.watch(configsProvider.future);
+  final response = await dio.get('${configs.host}/characters?search=$search');
+
+  return response.data.map(Character.fromJson).toList();
+}

--- a/website/docs/concepts/combining_provider_states/characters_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/characters_provider/codegen.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -21,7 +22,8 @@ Stream<Configuration> configs(ConfigsRef ref) {
 Future<List<Character>> characters(CharactersRef ref) async {
   final search = ref.watch(searchProvider);
   final configs = await ref.watch(configsProvider.future);
-  final response = await dio.get('${configs.host}/characters?search=$search');
+  final response = await dio.get<List<Map<String, dynamic>>>(
+      '${configs.host}/characters?search=$search');
 
-  return response.data.map(Character.fromJson).toList();
+  return response.data!.map(Character.fromJson).toList();
 }

--- a/website/docs/concepts/combining_provider_states/characters_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/characters_provider/codegen.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint
+
+part of 'codegen.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$configsHash() => r'166cbe95e6b49ed7bc78c96041fb14abddbf6911';
+
+/// See also [configs].
+@ProviderFor(configs)
+final configsProvider = AutoDisposeStreamProvider<Configuration>.internal(
+  configs,
+  name: r'configsProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$configsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef ConfigsRef = AutoDisposeStreamProviderRef<Configuration>;
+String _$charactersHash() => r'22f84439c47a6f3b440f0c0740f85cc69344dede';
+
+/// See also [characters].
+@ProviderFor(characters)
+final charactersProvider = AutoDisposeFutureProvider<List<Character>>.internal(
+  characters,
+  name: r'charactersProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$charactersHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef CharactersRef = AutoDisposeFutureProviderRef<List<Character>>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/website/docs/concepts/combining_provider_states/characters_provider/index.tsx
+++ b/website/docs/concepts/combining_provider_states/characters_provider/index.tsx
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw.dart";
+import codegen from "!!raw-loader!./codegen.dart";
+
+export default {
+  raw,
+  hooks: raw,
+  codegen,
+  hooksCodegen: codegen,
+};

--- a/website/docs/concepts/combining_provider_states/characters_provider/models.dart
+++ b/website/docs/concepts/combining_provider_states/characters_provider/models.dart
@@ -1,0 +1,25 @@
+
+class Character {
+  Character();
+
+  // ignore: avoid_unused_constructor_parameters
+  factory Character.fromJson(Map<String, dynamic> json) {
+    return Character();
+  }
+}
+
+class Configuration {
+  Configuration({
+    this.host = '',
+  });
+
+  final String host;
+}
+
+class Dio {
+  Future<Response> get(String path) async => Response();
+}
+
+class Response {
+  List<Map<String, dynamic>> get data => [];
+}

--- a/website/docs/concepts/combining_provider_states/characters_provider/models.dart
+++ b/website/docs/concepts/combining_provider_states/characters_provider/models.dart
@@ -15,11 +15,3 @@ class Configuration {
 
   final String host;
 }
-
-class Dio {
-  Future<Response> get(String path) async => Response();
-}
-
-class Response {
-  List<Map<String, dynamic>> get data => [];
-}

--- a/website/docs/concepts/combining_provider_states/characters_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/characters_provider/raw.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'models.dart';
+
+final dio = Dio();
+
+/* SNIPPET START */
+
+// The current search filter
+final searchProvider = StateProvider((ref) => '');
+
+/// Configurations which can change over time
+final configsProvider = StreamProvider<Configuration>(
+  (ref) => Stream.value(Configuration()),
+);
+
+final charactersProvider = FutureProvider<List<Character>>((ref) async {
+  final search = ref.watch(searchProvider);
+  final configs = await ref.watch(configsProvider.future);
+  final response = await dio.get('${configs.host}/characters?search=$search');
+
+  return response.data.map(Character.fromJson).toList();
+});

--- a/website/docs/concepts/combining_provider_states/characters_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/characters_provider/raw.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'models.dart';
@@ -17,7 +18,8 @@ final configsProvider = StreamProvider<Configuration>(
 final charactersProvider = FutureProvider<List<Character>>((ref) async {
   final search = ref.watch(searchProvider);
   final configs = await ref.watch(configsProvider.future);
-  final response = await dio.get('${configs.host}/characters?search=$search');
+  final response = await dio.get<List<Map<String, dynamic>>>(
+      '${configs.host}/characters?search=$search');
 
-  return response.data.map(Character.fromJson).toList();
+  return response.data!.map(Character.fromJson).toList();
 });

--- a/website/docs/concepts/combining_provider_states/city_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/city_provider/codegen.dart
@@ -1,0 +1,7 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'codegen.g.dart';
+
+/* SNIPPET START */
+@riverpod
+String city(CityRef ref) => 'London';

--- a/website/docs/concepts/combining_provider_states/city_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/city_provider/codegen.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint
+
+part of 'codegen.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$cityHash() => r'2ccdee096b5d5c1cafa736b3e52b788431b9af38';
+
+/// See also [city].
+@ProviderFor(city)
+final cityProvider = AutoDisposeProvider<String>.internal(
+  city,
+  name: r'cityProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$cityHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef CityRef = AutoDisposeProviderRef<String>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/website/docs/concepts/combining_provider_states/city_provider/index.tsx
+++ b/website/docs/concepts/combining_provider_states/city_provider/index.tsx
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw.dart";
+import codegen from "!!raw-loader!./codegen.dart";
+
+export default {
+  raw,
+  hooks: raw,
+  codegen,
+  hooksCodegen: codegen,
+};

--- a/website/docs/concepts/combining_provider_states/city_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/city_provider/raw.dart
@@ -1,0 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+final cityProvider = Provider((ref) => 'London');

--- a/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/codegen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../todo_list_provider/raw.dart';
+
+part 'codegen.g.dart';
+
+enum Filter {
+  none,
+  completed,
+  uncompleted,
+}
+
+final filterProvider = StateProvider((ref) => Filter.none);
+
+/* SNIPPET START */
+
+@riverpod
+List<Todo> filteredTodoList(FilteredTodoListRef ref) {
+  final filter = ref.watch(filterProvider);
+  final todos = ref.watch(todoListProvider);
+
+  switch (filter) {
+    case Filter.none:
+      return todos;
+    case Filter.completed:
+      return todos.where((todo) => todo.completed).toList();
+    case Filter.uncompleted:
+      return todos.where((todo) => !todo.completed).toList();
+  }
+}

--- a/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/codegen.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint
+
+part of 'codegen.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$filteredTodoListHash() => r'1c35eb0fce8fc7c7cda86413b02f606f8c8ae2b4';
+
+/// See also [filteredTodoList].
+@ProviderFor(filteredTodoList)
+final filteredTodoListProvider = AutoDisposeProvider<List<Todo>>.internal(
+  filteredTodoList,
+  name: r'filteredTodoListProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$filteredTodoListHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef FilteredTodoListRef = AutoDisposeProviderRef<List<Todo>>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/index.tsx
+++ b/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/index.tsx
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw.dart";
+import codegen from "!!raw-loader!./codegen.dart";
+
+export default {
+  raw,
+  hooks: raw,
+  codegen,
+  hooksCodegen: codegen,
+};

--- a/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/raw.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../todo_list_provider/raw.dart';
+
+enum Filter {
+  none,
+  completed,
+  uncompleted,
+}
+
+final filterProvider = StateProvider((ref) => Filter.none);
+
+/* SNIPPET START */
+
+final filteredTodoListProvider = Provider<List<Todo>>((ref) {
+  final filter = ref.watch(filterProvider);
+  final todos = ref.watch(todoListProvider);
+
+  switch (filter) {
+    case Filter.none:
+      return todos;
+    case Filter.completed:
+      return todos.where((todo) => todo.completed).toList();
+    case Filter.uncompleted:
+      return todos.where((todo) => !todo.completed).toList();
+  }
+});

--- a/website/docs/concepts/combining_provider_states/read_in_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/read_in_provider/codegen.dart
@@ -1,0 +1,17 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'codegen.g.dart';
+
+@riverpod
+MyValue another(AnotherRef ref) => MyValue();
+
+class MyValue {}
+
+/* SNIPPET START */
+
+@riverpod
+MyValue my(MyRef ref) {
+  // Bad practice to call `read` here
+  final value = ref.read(anotherProvider);
+  return value;
+}

--- a/website/docs/concepts/combining_provider_states/read_in_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/read_in_provider/codegen.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint
+
+part of 'codegen.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$anotherHash() => r'bb412edc55657c14eace37792cd18e5254604a36';
+
+/// See also [another].
+@ProviderFor(another)
+final anotherProvider = AutoDisposeProvider<MyValue>.internal(
+  another,
+  name: r'anotherProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$anotherHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef AnotherRef = AutoDisposeProviderRef<MyValue>;
+String _$myHash() => r'2712c772be4dbaabd4c99fd803f927a7e9938b21';
+
+/// See also [my].
+@ProviderFor(my)
+final myProvider = AutoDisposeProvider<MyValue>.internal(
+  my,
+  name: r'myProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$myHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef MyRef = AutoDisposeProviderRef<MyValue>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/website/docs/concepts/combining_provider_states/read_in_provider/index.tsx
+++ b/website/docs/concepts/combining_provider_states/read_in_provider/index.tsx
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw.dart";
+import codegen from "!!raw-loader!./codegen.dart";
+
+export default {
+  raw,
+  hooks: raw,
+  codegen,
+  hooksCodegen: codegen,
+};

--- a/website/docs/concepts/combining_provider_states/read_in_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/read_in_provider/raw.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final anotherProvider = Provider((ref) => MyValue());
+
+class MyValue {}
+
+/* SNIPPET START */
+
+final myProvider = Provider((ref) {
+  // Bad practice to call `read` here
+  final value = ref.read(anotherProvider);
+  return value;
+});

--- a/website/docs/concepts/combining_provider_states/select_async_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/select_async_provider/codegen.dart
@@ -1,4 +1,5 @@
 
+import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'models.dart';
@@ -18,5 +19,7 @@ Future<List<Product>> products(ProductsRef ref) async {
   // changes, this will not pointlessly re-evaluate our provider.
   final host = await ref.watch(configProvider.selectAsync((config) => config.host));
 
-  return dio.get('$host/products');
+  final result = await dio.get<List<Map<String, dynamic>>>('$host/products');
+
+  return result.data!.map(Product.fromJson).toList();
 }

--- a/website/docs/concepts/combining_provider_states/select_async_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/select_async_provider/codegen.dart
@@ -1,0 +1,22 @@
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'models.dart';
+
+part 'codegen.g.dart';
+
+final dio = Dio();
+
+/* SNIPPET START */
+
+@riverpod
+Stream<Configuration> config(ConfigRef ref) => Stream.value(Configuration());
+
+@riverpod
+Future<List<Product>> products(ProductsRef ref) async {
+  // Listens only to the host. If something else in the configurations
+  // changes, this will not pointlessly re-evaluate our provider.
+  final host = await ref.watch(configProvider.selectAsync((config) => config.host));
+
+  return dio.get('$host/products');
+}

--- a/website/docs/concepts/combining_provider_states/select_async_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/select_async_provider/codegen.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint
+
+part of 'codegen.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$configHash() => r'3021d1a8aac384e99d5d22714ffe6e868954888b';
+
+/// See also [config].
+@ProviderFor(config)
+final configProvider = AutoDisposeStreamProvider<Configuration>.internal(
+  config,
+  name: r'configProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$configHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef ConfigRef = AutoDisposeStreamProviderRef<Configuration>;
+String _$productsHash() => r'a3bf499c8c660f94db3f5a2fbaab9040b361eb0d';
+
+/// See also [products].
+@ProviderFor(products)
+final productsProvider = AutoDisposeFutureProvider<List<Product>>.internal(
+  products,
+  name: r'productsProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$productsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef ProductsRef = AutoDisposeFutureProviderRef<List<Product>>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/website/docs/concepts/combining_provider_states/select_async_provider/index.tsx
+++ b/website/docs/concepts/combining_provider_states/select_async_provider/index.tsx
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw.dart";
+import codegen from "!!raw-loader!./codegen.dart";
+
+export default {
+  raw,
+  hooks: raw,
+  codegen,
+  hooksCodegen: codegen,
+};

--- a/website/docs/concepts/combining_provider_states/select_async_provider/models.dart
+++ b/website/docs/concepts/combining_provider_states/select_async_provider/models.dart
@@ -1,0 +1,13 @@
+class Dio {
+  List<Product> get(String path) => [];
+}
+
+class Product {}
+
+class Configuration {
+  Configuration({
+    this.host = '',
+  });
+
+  final String host;
+}

--- a/website/docs/concepts/combining_provider_states/select_async_provider/models.dart
+++ b/website/docs/concepts/combining_provider_states/select_async_provider/models.dart
@@ -1,8 +1,16 @@
-class Dio {
-  List<Product> get(String path) => [];
-}
+// ignore_for_file: sort_constructors_first
 
-class Product {}
+class Product {
+  const Product({this.title = ''});
+  
+  final String title;
+
+  factory Product.fromJson(Map<String, dynamic> map) {
+    return Product(
+      title: map['title'] as String,
+    );
+  }
+}
 
 class Configuration {
   Configuration({

--- a/website/docs/concepts/combining_provider_states/select_async_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/select_async_provider/raw.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'models.dart';
@@ -13,6 +14,7 @@ final productsProvider = FutureProvider<List<Product>>((ref) async {
   // Listens only to the host. If something else in the configurations
   // changes, this will not pointlessly re-evaluate our provider.
   final host = await ref.watch(configProvider.selectAsync((config) => config.host));
+  final result = await dio.get<List<Map<String, dynamic>>>('$host/products');
 
-  return dio.get('$host/products');
+  return result.data!.map(Product.fromJson).toList();
 });

--- a/website/docs/concepts/combining_provider_states/select_async_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/select_async_provider/raw.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'models.dart';
+
+final dio = Dio();
+
+/* SNIPPET START */
+
+final configProvider =
+    StreamProvider<Configuration>((ref) => Stream.value(Configuration()));
+
+final productsProvider = FutureProvider<List<Product>>((ref) async {
+  // Listens only to the host. If something else in the configurations
+  // changes, this will not pointlessly re-evaluate our provider.
+  final host = await ref.watch(configProvider.selectAsync((config) => config.host));
+
+  return dio.get('$host/products');
+});

--- a/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'codegen.freezed.dart';
+part 'codegen.g.dart';
+
+@freezed
+class Todo with _$Todo {
+  factory Todo({
+    required String id,
+    required String description,
+    required bool completed,
+  }) = _Todo;
+}
+
+/* SNIPPET START */
+
+@riverpod
+class TodoList extends _$TodoList {
+  @override
+  List<Todo> build() {
+    return [];
+  }
+}

--- a/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.freezed.dart
+++ b/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.freezed.dart
@@ -1,0 +1,163 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'codegen.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$Todo {
+  String get id => throw _privateConstructorUsedError;
+  String get description => throw _privateConstructorUsedError;
+  bool get completed => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $TodoCopyWith<Todo> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TodoCopyWith<$Res> {
+  factory $TodoCopyWith(Todo value, $Res Function(Todo) then) =
+      _$TodoCopyWithImpl<$Res, Todo>;
+  @useResult
+  $Res call({String id, String description, bool completed});
+}
+
+/// @nodoc
+class _$TodoCopyWithImpl<$Res, $Val extends Todo>
+    implements $TodoCopyWith<$Res> {
+  _$TodoCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? description = null,
+    Object? completed = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      completed: null == completed
+          ? _value.completed
+          : completed // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_TodoCopyWith<$Res> implements $TodoCopyWith<$Res> {
+  factory _$$_TodoCopyWith(_$_Todo value, $Res Function(_$_Todo) then) =
+      __$$_TodoCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String id, String description, bool completed});
+}
+
+/// @nodoc
+class __$$_TodoCopyWithImpl<$Res> extends _$TodoCopyWithImpl<$Res, _$_Todo>
+    implements _$$_TodoCopyWith<$Res> {
+  __$$_TodoCopyWithImpl(_$_Todo _value, $Res Function(_$_Todo) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? description = null,
+    Object? completed = null,
+  }) {
+    return _then(_$_Todo(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      completed: null == completed
+          ? _value.completed
+          : completed // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Todo implements _Todo {
+  _$_Todo(
+      {required this.id, required this.description, required this.completed});
+
+  @override
+  final String id;
+  @override
+  final String description;
+  @override
+  final bool completed;
+
+  @override
+  String toString() {
+    return 'Todo(id: $id, description: $description, completed: $completed)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Todo &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.completed, completed) ||
+                other.completed == completed));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, description, completed);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_TodoCopyWith<_$_Todo> get copyWith =>
+      __$$_TodoCopyWithImpl<_$_Todo>(this, _$identity);
+}
+
+abstract class _Todo implements Todo {
+  factory _Todo(
+      {required final String id,
+      required final String description,
+      required final bool completed}) = _$_Todo;
+
+  @override
+  String get id;
+  @override
+  String get description;
+  @override
+  bool get completed;
+  @override
+  @JsonKey(ignore: true)
+  _$$_TodoCopyWith<_$_Todo> get copyWith => throw _privateConstructorUsedError;
+}

--- a/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint
+
+part of 'codegen.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$todoListHash() => r'6c965beb867ffeee119133f0ae2e6ebeb68e6f7e';
+
+/// See also [TodoList].
+@ProviderFor(TodoList)
+final todoListProvider =
+    AutoDisposeNotifierProvider<TodoList, List<Todo>>.internal(
+  TodoList.new,
+  name: r'todoListProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$todoListHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$TodoList = AutoDisposeNotifier<List<Todo>>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/website/docs/concepts/combining_provider_states/todo_list_provider/index.tsx
+++ b/website/docs/concepts/combining_provider_states/todo_list_provider/index.tsx
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw.dart";
+import codegen from "!!raw-loader!./codegen.dart";
+
+export default {
+  raw,
+  hooks: raw,
+  codegen,
+  hooksCodegen: codegen,
+};

--- a/website/docs/concepts/combining_provider_states/todo_list_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/todo_list_provider/raw.dart
@@ -1,0 +1,36 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class Todo {
+  const Todo({
+    required this.id,
+    required this.description,
+    required this.completed,
+  });
+
+  // All properties should be `final` on our class.
+  final String id;
+  final String description;
+  final bool completed;
+
+  // Since Todo is immutable, we implement a method that allows cloning the
+  // Todo with slightly different content.
+  Todo copyWith({String? id, String? description, bool? completed}) {
+    return Todo(
+      id: id ?? this.id,
+      description: description ?? this.description,
+      completed: completed ?? this.completed,
+    );
+  }
+}
+
+/* SNIPPET START */
+
+class TodoList extends Notifier<List<Todo>> {
+  @override
+  List<Todo> build() {
+    return [];
+  }
+}
+
+final todoListProvider = NotifierProvider<TodoList, List<Todo>>(TodoList.new);

--- a/website/docs/concepts/combining_provider_states/weather_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/weather_provider/codegen.dart
@@ -1,0 +1,20 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'codegen.g.dart';
+
+@riverpod
+String city(CityRef ref) => 'London';
+
+class Weather {}
+
+Future<Weather> fetchWeather({required String city}) async => Weather();
+/* SNIPPET START */
+@riverpod
+Future<Weather> weather(WeatherRef ref) {
+  // We use `ref.watch` to listen to another provider, and we pass it the provider
+  // that we want to consume. Here: cityProvider
+  final city = ref.watch(cityProvider);
+
+  // We can then use the result to do something based on the value of `cityProvider`.
+  return fetchWeather(city: city);
+}

--- a/website/docs/concepts/combining_provider_states/weather_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/weather_provider/codegen.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint
+
+part of 'codegen.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$cityHash() => r'2ccdee096b5d5c1cafa736b3e52b788431b9af38';
+
+/// See also [city].
+@ProviderFor(city)
+final cityProvider = AutoDisposeProvider<String>.internal(
+  city,
+  name: r'cityProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$cityHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef CityRef = AutoDisposeProviderRef<String>;
+String _$weatherHash() => r'9a79d0269032630918eef9d3f562ff35b5860061';
+
+/// See also [weather].
+@ProviderFor(weather)
+final weatherProvider = AutoDisposeFutureProvider<Weather>.internal(
+  weather,
+  name: r'weatherProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$weatherHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef WeatherRef = AutoDisposeFutureProviderRef<Weather>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/website/docs/concepts/combining_provider_states/weather_provider/index.tsx
+++ b/website/docs/concepts/combining_provider_states/weather_provider/index.tsx
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw.dart";
+import codegen from "!!raw-loader!./codegen.dart";
+
+export default {
+  raw,
+  hooks: raw,
+  codegen,
+  hooksCodegen: codegen,
+};

--- a/website/docs/concepts/combining_provider_states/weather_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/weather_provider/raw.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final cityProvider = Provider((ref) => 'London');
+
+class Weather {}
+
+Future<Weather> fetchWeather({required String city}) async => Weather();
+
+/* SNIPPET START */
+
+final weatherProvider = FutureProvider((ref) async {
+  // We use `ref.watch` to listen to another provider, and we pass it the provider
+  // that we want to consume. Here: cityProvider
+  final city = ref.watch(cityProvider);
+
+  // We can then use the result to do something based on the value of `cityProvider`.
+  return fetchWeather(city: city);
+});

--- a/website/docs/concepts/combining_provider_states/whole_object_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/whole_object_provider/codegen.dart
@@ -1,0 +1,22 @@
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'models.dart';
+
+part 'codegen.g.dart';
+
+final dio = Dio();
+
+/* SNIPPET START */
+
+@riverpod
+Stream<Configuration> config(ConfigRef ref) => Stream.value(Configuration());
+
+@riverpod
+Future<List<Product>> products(ProductsRef ref) async {
+  // Will cause productsProvider to re-fetch the products if anything in the
+  // configurations changes
+  final configs = await ref.watch(configProvider.future);
+
+  return dio.get('${configs.host}/products');
+}

--- a/website/docs/concepts/combining_provider_states/whole_object_provider/codegen.dart
+++ b/website/docs/concepts/combining_provider_states/whole_object_provider/codegen.dart
@@ -1,4 +1,4 @@
-
+import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'models.dart';
@@ -18,5 +18,7 @@ Future<List<Product>> products(ProductsRef ref) async {
   // configurations changes
   final configs = await ref.watch(configProvider.future);
 
-  return dio.get('${configs.host}/products');
+  final result =
+      await dio.get<List<Map<String, dynamic>>>('${configs.host}/products');
+  return result.data!.map(Product.fromJson).toList();
 }

--- a/website/docs/concepts/combining_provider_states/whole_object_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/whole_object_provider/codegen.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint
+
+part of 'codegen.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$configHash() => r'3021d1a8aac384e99d5d22714ffe6e868954888b';
+
+/// See also [config].
+@ProviderFor(config)
+final configProvider = AutoDisposeStreamProvider<Configuration>.internal(
+  config,
+  name: r'configProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$configHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef ConfigRef = AutoDisposeStreamProviderRef<Configuration>;
+String _$productsHash() => r'85b52bc6b95afadccaf19c337e6dd096c5f1d791';
+
+/// See also [products].
+@ProviderFor(products)
+final productsProvider = AutoDisposeFutureProvider<List<Product>>.internal(
+  products,
+  name: r'productsProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$productsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef ProductsRef = AutoDisposeFutureProviderRef<List<Product>>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/website/docs/concepts/combining_provider_states/whole_object_provider/index.tsx
+++ b/website/docs/concepts/combining_provider_states/whole_object_provider/index.tsx
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw.dart";
+import codegen from "!!raw-loader!./codegen.dart";
+
+export default {
+  raw,
+  hooks: raw,
+  codegen,
+  hooksCodegen: codegen,
+};

--- a/website/docs/concepts/combining_provider_states/whole_object_provider/models.dart
+++ b/website/docs/concepts/combining_provider_states/whole_object_provider/models.dart
@@ -1,0 +1,13 @@
+class Dio {
+  List<Product> get(String path) => [];
+}
+
+class Product {}
+
+class Configuration {
+  Configuration({
+    this.host = '',
+  });
+
+  final String host;
+}

--- a/website/docs/concepts/combining_provider_states/whole_object_provider/models.dart
+++ b/website/docs/concepts/combining_provider_states/whole_object_provider/models.dart
@@ -1,8 +1,11 @@
-class Dio {
-  List<Product> get(String path) => [];
-}
+// ignore_for_file: avoid_unused_constructor_parameters
 
-class Product {}
+class Product {
+  Product();
+  factory Product.fromJson(Map<String, dynamic> json) {
+    return Product();
+  }
+}
 
 class Configuration {
   Configuration({

--- a/website/docs/concepts/combining_provider_states/whole_object_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/whole_object_provider/raw.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'models.dart';
+
+final dio = Dio();
+
+/* SNIPPET START */
+
+final configProvider =
+    StreamProvider<Configuration>((ref) => Stream.value(Configuration()));
+
+final productsProvider = FutureProvider<List<Product>>((ref) async {
+  // Will cause productsProvider to re-fetch the products if anything in the
+  // configurations changes
+  final configs = await ref.watch(configProvider.future);
+
+  return dio.get('${configs.host}/products');
+});

--- a/website/docs/concepts/combining_provider_states/whole_object_provider/raw.dart
+++ b/website/docs/concepts/combining_provider_states/whole_object_provider/raw.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'models.dart';
@@ -14,5 +15,6 @@ final productsProvider = FutureProvider<List<Product>>((ref) async {
   // configurations changes
   final configs = await ref.watch(configProvider.future);
 
-  return dio.get('${configs.host}/products');
+  final result = await dio.get<List<Map<String, dynamic>>>('${configs.host}/products');
+  return result.data!.map(Product.fromJson).toList();
 });

--- a/website/docs/concepts/combining_providers.mdx
+++ b/website/docs/concepts/combining_providers.mdx
@@ -2,6 +2,20 @@
 title: Combining Provider States
 ---
 
+import charactersProvider from './combining_provider_states/characters_provider'
+import cityProvider from './combining_provider_states/city_provider'
+import filteredTodoListProvider from './combining_provider_states/filtered_todo_list_provider'
+import readInProvider from './combining_provider_states/read_in_provider'
+import selectAsyncProvider from './combining_provider_states/select_async_provider'
+import todoListProvider from './combining_provider_states/todo_list_provider'
+import weatherProvider from './combining_provider_states/weather_provider'
+import wholeObjectProvider from './combining_provider_states/whole_object_provider'
+import {
+  trimSnippet,
+  AutoSnippet,
+  ConditionalSnippet,
+} from "../../src/components/CodeSnippet";
+
 Make sure to [read about Providers](/docs/concepts/providers) first.  
 In this guide, we will learn about combining provider states.
 
@@ -15,22 +29,11 @@ and use its [watch] method.
 
 As an example, consider the following provider:
 
-```dart
-final cityProvider = Provider((ref) => 'London');
-```
+<AutoSnippet language="dart" {...cityProvider}></AutoSnippet>
 
 We can now create another provider that will consume our `cityProvider`:
 
-```dart
-final weatherProvider = FutureProvider((ref) async {
-  // We use `ref.watch` to listen to another provider, and we pass it the provider
-  // that we want to consume. Here: cityProvider
-  final city = ref.watch(cityProvider);
-
-  // We can then use the result to do something based on the value of `cityProvider`.
-  return fetchWeather(city: city);
-});
-```
+<AutoSnippet language="dart" {...weatherProvider}></AutoSnippet>
 
 That's it. We've created a provider that depends on another provider.
 
@@ -48,15 +51,9 @@ When using [watch], Riverpod is able to detect that the value being listened to 
 and will _automatically_ re-execute the provider's creation callback when needed.
 
 This can be useful for computed states.
-For example, consider a [StateNotifierProvider] that exposes a todo-list:
+For example, consider a [NotifierProvider](/docs/providers/notifier_provider) that exposes a todo-list:
 
-```dart
-class TodoList extends StateNotifier<List<Todo>> {
-  TodoList(): super(const []);
-}
-
-final todoListProvider = StateNotifierProvider((ref) => TodoList());
-```
+<AutoSnippet language="dart" {...todoListProvider}></AutoSnippet>
 
 A common use-case would be to have the UI filter the list of todos to show
 only the completed/uncompleted todos.
@@ -78,21 +75,7 @@ An easy way to implement such a scenario would be to:
 - make a separate provider which combines the filter method and the todo-list
   to expose the filtered todo-list:
 
-  ```dart
-  final filteredTodoListProvider = Provider<List<Todo>>((ref) {
-    final filter = ref.watch(filterProvider);
-    final todos = ref.watch(todoListProvider);
-
-    switch (filter) {
-      case Filter.none:
-        return todos;
-      case Filter.completed:
-        return todos.where((todo) => todo.completed).toList();
-      case Filter.uncompleted:
-        return todos.where((todo) => !todo.completed).toList();
-    }
-  });
-  ```
+  <AutoSnippet language="dart" {...filteredTodoListProvider}></AutoSnippet>
 
 Then, our UI can listen to `filteredTodoListProvider` to listen to the filtered todo-list.  
 Using such an approach, the UI will automatically update when either the filter
@@ -107,21 +90,7 @@ This behavior is not specific to [Provider], and works with all providers.
 For example, you could combine [watch] with [FutureProvider] to implement a search
 feature that supports live-configuration changes:
 
-```dart
-// The current search filter
-final searchProvider = StateProvider((ref) => '');
-
-/// Configurations which can change over time
-final configsProvider = StreamProvider<Configuration>(...);
-
-final charactersProvider = FutureProvider<List<Character>>((ref) async {
-  final search = ref.watch(searchProvider);
-  final configs = await ref.watch(configsProvider.future);
-  final response = await dio.get('${configs.host}/characters?search=$search');
-
-  return response.data.map((json) => Character.fromJson(json)).toList();
-});
-```
+<AutoSnippet language="dart" {...charactersProvider}></AutoSnippet>
 
 This code will fetch a list of characters from the service, and automatically
 re-fetch the list whenever the configurations change or when the search query changes.
@@ -167,12 +136,7 @@ class Repository {
 
 :::danger **DON'T** call [read] inside the body of a provider
 
-```dart
-final myProvider = Provider((ref) {
-  // Bad practice to call `read` here
-  final value = ref.read(anotherProvider);
-});
-```
+<AutoSnippet language="dart" {...readInProvider}></AutoSnippet>
 
 If you used [read] as an attempt to avoid unwanted rebuilds of your object,
 refer to [My provider updates too often, what can I do?](#my-provider-updates-too-often-what-can-i-do)
@@ -218,32 +182,11 @@ what you need in `Configuration` (so `host`):
 
 **AVOID** listening to the entire object:
 
-```dart
-final configProvider = StreamProvider<Configuration>(...);
-
-final productsProvider = FutureProvider<List<Product>>((ref) async {
-  // Will cause productsProvider to re-fetch the products if anything in the
-  // configurations changes
-  final configs = await ref.watch(configProvider.future);
-
-  return dio.get('${configs.host}/products');
-});
-```
-
+<AutoSnippet language="dart" {...wholeObjectProvider}></ AutoSnippet>
 
 **PREFER** using select when you only need a single property of an object:
 
-```dart
-final configProvider = StreamProvider<Configuration>(...);
-
-final productsProvider = FutureProvider<List<Product>>((ref) async {
-  // Listens only to the host. If something else in the configurations
-  // changes, this will not pointlessly re-evaluate our provider.
-  final host = await ref.watch(configProvider.selectAsync((config) => config.host));
-
-  return dio.get('$host/products');
-});
-```
+<AutoSnippet language="dart" {...selectAsyncProvider}></ AutoSnippet>
 
 This will only rebuild the `productsProvider` when the `host` changes.
 

--- a/website/pubspec.yaml
+++ b/website/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
+  dio: ^5.0.3
   flutter:
     sdk: flutter
   flutter_hooks: ^0.18.2


### PR DESCRIPTION
This adds code snippets for the concepts/combining provider states page.

It enables toggling between code generation and the raw way.

To note: I did not use the actual dio package and instead would use a class I made for convenience (Not visible in documentation though). If this is not desired I can switch to dio :)