### PR TITLE
Fix `provider_dependencies` not considering dependencies inside methods other than `build` of a notifier.

### DIFF
--- a/packages/riverpod_analyzer_utils/CHANGELOG.md
+++ b/packages/riverpod_analyzer_utils/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased fix
 
 - Handle cascade operators in ref expressions
+- Fix ref.watch/read/... not being decoded inside Notifier methods of generated providers.
 
 ## 0.2.0 - 2023-03-13
 

--- a/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/generator_provider_declaration.dart
+++ b/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/generator_provider_declaration.dart
@@ -161,7 +161,7 @@ class StatefulProviderDeclaration extends GeneratorProviderDeclaration {
       valueType: _getValueType(createdType),
     );
     riverpodAnnotation._parent = statefulProviderDeclaration;
-    buildMethod.accept(
+    node.accept(
       _GeneratorRefInvocationVisitor(statefulProviderDeclaration, parent),
     );
 

--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Disable unsupported_provider_value when a notifier returns "this"
 - Fix scoped_providers_should_specify_dependencies incorrectly triggering on functions other than "main"
 - Handle cascade operators in ref expressions
+- Fix `provider_dependencies` not considering dependencies inside methods
+  other than `build` of a notifier.
 
 ## 1.1.7 - 2023-04-06
 

--- a/packages/riverpod_lint_flutter_test/test/goldens/lints/dependencies.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/lints/dependencies.dart
@@ -175,3 +175,13 @@ int regression2348(Regression2348Ref ref) {
   ref..watch(generatedScopedProvider);
   return 0;
 }
+
+@Riverpod(dependencies: [generatedScoped])
+class Regression2417 extends _$Regression2417 {
+  @override
+  int build() => 0;
+
+  void method() {
+    ref.watch(generatedScopedProvider);
+  }
+}

--- a/packages/riverpod_lint_flutter_test/test/goldens/lints/dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/lints/dependencies.g.dart
@@ -399,4 +399,20 @@ final classWatchGeneratedScopedButMissingDependenciesProvider =
 
 typedef _$ClassWatchGeneratedScopedButMissingDependencies
     = AutoDisposeNotifier<int>;
+String _$regression2417Hash() => r'c9ac0ba44e849ea1460c79c1f676feba1b5400da';
+
+/// See also [Regression2417].
+@ProviderFor(Regression2417)
+final regression2417Provider =
+    AutoDisposeNotifierProvider<Regression2417, int>.internal(
+  Regression2417.new,
+  name: r'regression2417Provider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$regression2417Hash,
+  dependencies: <ProviderOrFamily>[generatedScopedProvider],
+  allTransitiveDependencies: <ProviderOrFamily>[generatedScopedProvider],
+);
+
+typedef _$Regression2417 = AutoDisposeNotifier<int>;
 // ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions


### PR DESCRIPTION
fixes #2417