### PR TITLE
fix: dialog scope example in docs

### DIFF
--- a/website/docs/concepts/dialog_scope.dart
+++ b/website/docs/concepts/dialog_scope.dart
@@ -6,7 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /* SNIPPET START */
 
 // Have a counter that is being incremented by the FloatingActionButton
-final counterProvider = StateProvider((ref) => 0);
+final counterProvider = StateProvider.autoDispose((ref) => 0);
 
 class Home extends ConsumerWidget {
   const Home({super.key});


### PR DESCRIPTION
Hi,

I fixed an issue in dialog scope example.

Currently since **stateProvider** is always alive then the example of scoping won't be useful because the **stateProvider** won't be disposed anyway