### PR TITLE
Added `avoid_public_properties_in_notifiers` lint.

### DIFF
--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased minor
 
+- Added `avoid_public_properties_in_notifiers` lint.
+  This warns if a Notifier/AsyncNotifier contains any form of public state
+  outside the `state` property.
 - Added assists for converting widgets to HookWidget/HookConsumerWidget (thanks to @K9i-0)
 
 ## 1.1.8 - 2023-04-07

--- a/packages/riverpod_lint/README.md
+++ b/packages/riverpod_lint/README.md
@@ -43,8 +43,9 @@ Riverpod_lint adds various warnings with quick fixes and refactoring options, su
   - [missing\_provider\_scope](#missing_provider_scope)
   - [provider\_dependencies (riverpod\_generator only)](#provider_dependencies-riverpod_generator-only)
   - [scoped\_providers\_should\_specify\_dependencies (generator only)](#scoped_providers_should_specify_dependencies-generator-only)
-  - [avoid\_manual\_providers\_as\_generated\_provider\_depenency](#avoid_manual_providers_as_generated_provider_dependency)
+  - [avoid\_manual\_providers\_as\_generated\_provider\_dependency](#avoid_manual_providers_as_generated_provider_dependency)
   - [provider\_parameters](#provider_parameters)
+  - [avoid\_public\_notifier\_properties](#avoid_public_notifier_properties)
   - [unsupported\_provider\_value (riverpod\_generator only)](#unsupported_provider_value-riverpod_generator-only)
   - [stateless\_ref (riverpod\_generator only)](#stateless_ref-riverpod_generator-only)
   - [generator\_class\_extends (riverpod\_generator only)](#generator_class_extends-riverpod_generator-only)
@@ -368,6 +369,47 @@ ref.watch(myProvider(variable));
 ref.watch(myProvider(ClassWithNoCustomEqual()));
 // List/map/set litterals do not have a custom ==
 ref.watch(myProvider([42]));
+```
+
+### avoid_public_notifier_properties
+
+The `Notifier`/`AsyncNotifier` classes should not have public state outside
+of the `state` property.
+
+**Good**:
+
+```dart
+class Model {
+  Model(this.a, this.b);
+  final int a;
+  final int b;
+}
+
+// Notifiers using the code-generator
+@riverpod
+class GeneratedNotifier extends _$GeneratedNotifier {
+  @override
+  Model build() => Model(0, 0);
+}
+
+// Manually written Notifiers
+class ManualNotifier extends Notifier<Model> {
+  @override
+  Model build() => Model(0, 0);
+}
+```
+
+**Bad**:
+
+```dart
+@riverpod
+class GeneratedNotifier extends _$GeneratedNotifier {
+  // Notifiers should not have public properties/getters
+  int b = 0;
+
+  @override
+  int build() => 0;
+}
 ```
 
 ### unsupported_provider_value (riverpod_generator only)

--- a/packages/riverpod_lint/lib/riverpod_lint.dart
+++ b/packages/riverpod_lint/lib/riverpod_lint.dart
@@ -8,6 +8,7 @@ import 'src/assists/stateless_to_stateful_provider.dart';
 import 'src/assists/wrap_with_consumer.dart';
 import 'src/assists/wrap_with_provider_scope.dart';
 import 'src/lints/avoid_manual_providers_as_generated_provider_dependency.dart';
+import 'src/lints/avoid_public_notifier_properties.dart';
 import 'src/lints/generator_class_extends.dart';
 import 'src/lints/missing_provider_scope.dart';
 import 'src/lints/provider_dependencies.dart';
@@ -21,6 +22,7 @@ PluginBase createPlugin() => _RiverpodPlugin();
 class _RiverpodPlugin extends PluginBase {
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
+        const AvoidPublicNotifierProperties(),
         const StatelessRef(),
         const MissingProviderScope(),
         const ProviderParameters(),

--- a/packages/riverpod_lint/lib/src/lints/avoid_public_notifier_properties.dart
+++ b/packages/riverpod_lint/lib/src/lints/avoid_public_notifier_properties.dart
@@ -1,0 +1,60 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:riverpod_analyzer_utils/riverpod_analyzer_utils.dart';
+
+class AvoidPublicNotifierProperties extends DartLintRule {
+  const AvoidPublicNotifierProperties() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_public_notifier_properties',
+    problemMessage: 'Notifiers should not have public properties/getters. '
+        'Instead, all their public API should be exposed through the `state` property.',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addClassDeclaration((node) {
+      final notifierElement = node.declaredElement;
+
+      if (notifierElement == null ||
+          !anyNotifierType.isAssignableFromType(notifierElement.thisType)) {
+        return;
+      }
+
+      for (final member in node.members) {
+        bool isVisibleOutsiteTheNotifier(Element? element) {
+          return element != null &&
+              element.isPublic &&
+              !element.hasProtected &&
+              !element.hasVisibleForOverriding &&
+              !element.hasVisibleForTesting;
+        }
+
+        if (member is FieldDeclaration) {
+          // We only check class fields, not top-level fields
+          if (member.isStatic) continue;
+
+          for (final variable in member.fields.variables) {
+            if (!isVisibleOutsiteTheNotifier(variable.declaredElement)) {
+              continue;
+            }
+
+            reporter.reportErrorForNode(_code, member);
+          }
+        } else if (member is MethodDeclaration) {
+          if (!member.isGetter && !member.isSetter) continue;
+          if (member.isStatic) continue;
+          if (!isVisibleOutsiteTheNotifier(member.declaredElement)) continue;
+
+          reporter.reportErrorForNode(_code, member);
+        }
+      }
+    });
+  }
+}

--- a/packages/riverpod_lint_flutter_test/test/goldens/lints/avoid_public_notifier_properties.dart
+++ b/packages/riverpod_lint_flutter_test/test/goldens/lints/avoid_public_notifier_properties.dart
@@ -1,0 +1,92 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class MyNotifier extends Notifier<int> {
+  static int get staticPublicGetter => 0;
+
+  static int staticPublicProperty = 0;
+
+  int _privateProperty = 0;
+  int get _privateGetter => _privateProperty;
+
+  // expect_lint: avoid_public_notifier_properties
+  int get publicGetter => _privateGetter;
+
+  // expect_lint: avoid_public_notifier_properties
+  set publicSetter(int value) {
+    _privateProperty = value;
+  }
+
+  // expect_lint: avoid_public_notifier_properties
+  int publicProperty = 0;
+
+  @protected
+  int get protectedMember => 0;
+
+  @visibleForTesting
+  int get visibleForTestingMember => 0;
+
+  @visibleForOverriding
+  int get visibleForOverridingMember => 0;
+
+  @override
+  int build() => 0;
+
+  void _privateMethod() {}
+
+  // Public methods are OK
+  void publicMethod() {
+    _privateMethod();
+  }
+}
+
+class MyAutoDisposeNotifier extends AutoDisposeNotifier<int> {
+  int get _privateGetter => 0;
+
+  // expect_lint: avoid_public_notifier_properties
+  int get publicGetter => _privateGetter;
+
+  @override
+  int build() => 0;
+}
+
+class MyAutoDisposeFamilyNotifier extends AutoDisposeFamilyNotifier<int, int> {
+  int get _privateGetter => 0;
+
+  // expect_lint: avoid_public_notifier_properties
+  int get publicGetter => _privateGetter;
+
+  @override
+  int build(int param) => 0;
+}
+
+class MyAsyncNotifier extends AsyncNotifier<int> {
+  int get _privateGetter => 0;
+
+  // expect_lint: avoid_public_notifier_properties
+  int get publicGetter => _privateGetter;
+
+  @override
+  Future<int> build() async => 0;
+}
+
+class MyAutoDisposeAsyncNotifier extends AutoDisposeAsyncNotifier<int> {
+  int get _privateGetter => 0;
+
+  // expect_lint: avoid_public_notifier_properties
+  int get publicGetter => _privateGetter;
+
+  @override
+  Future<int> build() async => 0;
+}
+
+class MyAutoDisposeFamilyAsyncNotifier
+    extends AutoDisposeFamilyAsyncNotifier<int, int> {
+  int get _privateGetter => 0;
+
+  // expect_lint: avoid_public_notifier_properties
+  int get publicGetter => _privateGetter;
+
+  @override
+  Future<int> build(int param) async => 0;
+}


### PR DESCRIPTION
This warns if a Notifier/AsyncNotifier contains any form of public state outside the `state` property.

fixes #2311