### PR TITLE
Navigate to Introduction instead of Getting Started when clicking Docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -36,7 +36,7 @@ module.exports = {
       },
       items: [
         {
-          to: "docs/getting_started",
+          to: "docs/introduction",
           activeBasePath: "docs",
           label: "Docs",
           position: "right",


### PR DESCRIPTION
Navigate to Introduction instead of Getting Started when clicking Docs