### PR TITLE
Make ref.state nullable property for non-async

### DIFF
--- a/packages/riverpod/lib/src/framework/element.dart
+++ b/packages/riverpod/lib/src/framework/element.dart
@@ -171,6 +171,13 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
   @visibleForTesting
   Result<State>? getState() => _state;
 
+  /// Obtains the current state, or null if the provider has yet to initialize.
+  ///
+  /// This is not meant for public consumption. Instead, public API should use
+  /// [readSelf].
+  @protected
+  State? get stateOrNull => _state?.stateOrNull;
+
   /// Read the current value of a provider and:
   ///
   /// - if in error state, rethrow the error

--- a/packages/riverpod/lib/src/notifier.dart
+++ b/packages/riverpod/lib/src/notifier.dart
@@ -24,21 +24,27 @@ abstract class NotifierBase<State> {
   /// The value currently exposed by this [Notifier].
   ///
   /// Invoking the setter will notify listeners if [updateShouldNotify] returns true.
+  /// If setter is null then it will throw [ArgumentError.notNull].
   /// By default, this will compare the previous and new value using [identical].
   ///
   /// Reading [state] if the provider is out of date (such as if one of its
   /// dependency has changed) will trigger [Notifier.build] to be re-executed.
   ///
   /// If [Notifier.build] threw, reading [state] will rethow the exception.
+  /// if provider is not initialized then it will return null.
   @protected
-  State get state {
+  State? get state {
     _element.flush();
     // ignore: invalid_use_of_protected_member
-    return _element.requireState;
+    return _element.stateOrNull;
   }
 
   @protected
-  set state(State value) {
+  set state(State? value) {
+    if (value == null) {
+      throw ArgumentError.notNull();
+    }
+
     // ignore: invalid_use_of_protected_member
     _element.setState(value);
   }


### PR DESCRIPTION
fixes #2589 

@rrousselGit If you make state getter nullable, we also need to make state setter nullable and throw runtime error if the state passed is null.

Additionally we can either throw state error or create new custom error like Argument Error for setter.

on the other have we can have getter stateOrNull, let me know which one you like to opt. I will update that to everywhere and  update tests.
