### PR TITLE
Docs. Remove duplicate sentences

### DIFF
--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -107,8 +107,6 @@ void main() {
 
 이것은 프로바이더 내부에서 사용하는 `ref` 객체의 [onDispose] 메소드를 사용할 수 있습니다. 
 
-This is done using the `ref` object, which is passed to the callback of all providers, using its [onDispose] method.
-
 다음 사용예시에서 [onDispose]를 사용하여 `StreamController`를 닫는 과정을 알아봅시다.
 
 


### PR DESCRIPTION
`이것은 프로바이더 내부에서 사용하는 ref 객체의 onDispose 메소드를 사용할 수 있습니다.`

`This is done using the ref object, which is passed to the callback of all providers, using its onDispose method.`

The above two sentences have the same meaning, and it is likely that the original English sentence has not been removed.