### PR TITLE
docs: Prefix Future/Stream with async in Defining a provider table

### DIFF
--- a/website/docs/about_code_generation.mdx
+++ b/website/docs/about_code_generation.mdx
@@ -154,7 +154,7 @@ When defining a provider using code generation, it is useful to keep in mind the
   <tr style={TRANSPARENT_STYLE}>
     <td>
       <span style={FONT_16_STYLE}>
-        <span style={RED_STYLE}>Async</span>
+        <span style={RED_STYLE}>Async - Future</span>
       </span>
     </td>
     <td>
@@ -167,7 +167,7 @@ When defining a provider using code generation, it is useful to keep in mind the
   <tr style={TRANSPARENT_STYLE}>
     <td>
       <span style={FONT_16_STYLE}>
-        <span style={RED_STYLE}>Stream</span>
+        <span style={RED_STYLE}>Async - Stream</span>
       </span>
     </td>
     <td>


### PR DESCRIPTION
I think it's better to declare both future/stream as async in the table.
Declaring one row with "async" and the other with "stream" sounds unclear with the introduction above it.