### PR TITLE
[riverpod_cli] fix super-parameter lint 

### DIFF
--- a/packages/riverpod_cli/fixtures/notifiers/golden/pubspec.yaml
+++ b/packages/riverpod_cli/fixtures/notifiers/golden/pubspec.yaml
@@ -3,7 +3,7 @@ description: Test riverpod codemods
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
In this directory, the super-parameters feature is being used, but since the minimum version is 2.12.0, the linter was issuing a warning.