### PR TITLE
Change deprecated terminal command (Second PR)

### DIFF
--- a/website/docs/getting_started.mdx
+++ b/website/docs/getting_started.mdx
@@ -67,7 +67,7 @@ Alternatively, you can manually add the dependency to your app from within your 
 Then, install packages with `flutter pub get`.
 
 <ConditionalSnippet codegen={true}>
-  Run the code-generator with <code>flutter pub run build_runner watch</code>.
+  Run the code-generator with <code>dart run build_runner watch</code>.
 </ConditionalSnippet>
 
 </TabItem>


### PR DESCRIPTION
While running the command `flutter pub run build_runner watch` Flutter 3.10.5 says: `Deprecated. Use dart run instead.`
Reference: #2705 