### PR TITLE
Fix typos

### DIFF
--- a/website/i18n/ko/code.json
+++ b/website/i18n/ko/code.json
@@ -28,7 +28,7 @@
     "message": "안전한 컴파일"
   },
   "homepage.compile_safe_body": {
-    "message": "더 이상 {ProviderNotFound} 예외가 발생하지 않고, 로딩 상태를 처리하는 것을 걱정하지 않아도 됩니다. Riverpod를 사용하면 코드가 컴파일되면 작동합니다."
+    "message": "더 이상 {ProviderNotFound} 예외가 발생하지 않고, 로딩 상태를 처리하는 것을 걱정하지 않아도 됩니다. Riverpod를 사용하면 코드가 컴파일되어 작동합니다."
   },
   "homepage.unlimited_provider_title": {
     "message": "제한없는 Provider"


### PR DESCRIPTION
Riverpod works when the code is compiled.
(Riverpod를 사용하면 코드가 컴파일되면 작동합니다.)

When used, this part is unnatural when compiled.
To express the sentence more naturally

With Riverpod, the code is compiled and operated.
(Riverpod를 사용하면 코드가 컴파일되어 작동합니다.)
(컴파일되면(X) => 컴파일되어(O) 수정해야합니다.)

When you construct a sentence like this, it's a sentence that's made up of two independent phrases, each of which has a full meaning.