### PR TITLE
Add type definition in provider boxes on 2nd line

### DIFF
--- a/packages/riverpod_graph/README.md
+++ b/packages/riverpod_graph/README.md
@@ -1,9 +1,10 @@
-**Work in progress**
+## Work in progress
 
 This project is a work-in-progress command that analyzes a Riverpod project and
 generates a graph of the interactions between providers/widgets
 
-The graph generated is generated using [Mermaid](https://mermaid-js.github.io/mermaid/#/)
+## Example
+Graphs can be generated using [d2](https://d2lang.com/) or [Mermaid](https://mermaid-js.github.io/mermaid/#/) text-to-graph syntax.
 
 Here is graph example, generated from the Flutter Devtool project (which uses Riverpod).
 
@@ -34,3 +35,110 @@ mermaid.js markup
 cd <the lib directory of the program you wish to analyze>
 $ dart pub global run riverpod_graph .
 ```
+________________________
+
+## Example Todos mermaid.js graph
+
+This graph was generated in mermaid format with _Provider Types_ enabled.
+
+```mermaid
+
+flowchart TB
+  subgraph Arrows
+    direction LR
+    start1[ ] -..->|read| stop1[ ]
+    style start1 height:0px;
+    style stop1 height:0px;
+    start2[ ] --->|listen| stop2[ ]
+    style start2 height:0px;
+    style stop2 height:0px;
+    start3[ ] ===>|watch| stop3[ ]
+    style start3 height:0px;
+    style stop3 height:0px;
+  end
+
+  subgraph Type
+    direction TB
+    ConsumerWidget((widget));
+    Provider[[provider]];
+  end
+  filteredTodos[["filteredTodos</br>Provider&lt; List&lt; Todo &gt; &gt;"]];
+  todoListProvider[["todoListProvider</br>StateNotifierProvider&lt; TodoList, List&lt; Todo &gt; &gt;"]];
+  todoListFilter[["todoListFilter</br>StateProvider&lt; TodoListFilter &gt;"]];
+  uncompletedTodosCount[["uncompletedTodosCount</br>Provider&lt; int &gt;"]];
+  _currentTodo[["_currentTodo</br>Provider&lt; Todo &gt;"]];
+  Home((Home));
+  filteredTodos ==> Home;
+  todoListProvider -.-> Home;
+  todoListProvider -.-> Home;
+  Toolbar((Toolbar));
+  todoListFilter ==> Toolbar;
+  uncompletedTodosCount ==> Toolbar;
+  todoListFilter -.-> Toolbar;
+  todoListFilter -.-> Toolbar;
+  todoListFilter -.-> Toolbar;
+  TodoItem((TodoItem));
+  _currentTodo ==> TodoItem;
+  todoListProvider -.-> TodoItem;
+  todoListProvider -.-> TodoItem;
+  todoListFilter ==> filteredTodos;
+  todoListProvider ==> filteredTodos;
+  todoListProvider ==> uncompletedTodosCount;
+
+  ```
+
+
+## Example with containing classes from a test case
+_A work in progress_
+
+  ```mermaid
+  flowchart TB
+  subgraph Arrows
+    direction LR
+    start1[ ] -..->|read| stop1[ ]
+    style start1 height:0px;
+    style stop1 height:0px;
+    start2[ ] --->|listen| stop2[ ]
+    style start2 height:0px;
+    style stop2 height:0px;
+    start3[ ] ===>|watch| stop3[ ]
+    style start3 height:0px;
+    style stop3 height:0px;
+  end
+  subgraph Type
+    direction TB
+    ConsumerWidget((widget));
+    Provider[[provider]];
+  end
+  additionProvider[["additionProvider</br>FutureProvider&lt; num&gt;"]];
+  normalProvider[["normalProvider</br>Provider&lt; int&gt;"]];
+  futureProvider[["futureProvider</br>FutureProvider&lt; int&gt;"]];
+  familyProviders[["familyProviders</br>ProviderFamily&lt; int, Object?&gt;"]];
+  functionProvider[["functionProvider</br>Provider&lt; int Function()&gt;"]];
+  selectedProvider[["selectedProvider</br>Provider&lt; int&gt;"]];
+  subgraph SampleClass
+    SampleClass.normalProvider[["normalProvider</br>Provider&lt; int&gt;"]];
+  end
+  subgraph SampleClass
+    SampleClass.futureProvider[["futureProvider</br>FutureProvider&lt; int&gt;"]];
+  end
+  subgraph SampleClass
+    SampleClass.familyProviders[["familyProviders</br>ProviderFamily&lt; int, Object?&gt;"]];
+  end
+  subgraph SampleClass
+    SampleClass.functionProvider[["functionProvider</br>Provider&lt; int Function()&gt;"]];
+  end
+  subgraph SampleClass
+    SampleClass.selectedProvider[["selectedProvider</br>Provider&lt; int&gt;"]];
+  end
+  normalProvider ==> additionProvider;
+  futureProvider ==> additionProvider;
+  familyProviders ==> additionProvider;
+  functionProvider ==> additionProvider;
+  selectedProvider ==> additionProvider;
+  SampleClass.normalProvider ==> additionProvider;
+  SampleClass.futureProvider ==> additionProvider;
+  SampleClass.familyProviders ==> additionProvider;
+  SampleClass.functionProvider ==> additionProvider;
+  SampleClass.selectedProvider ==> additionProvider;
+  ```

--- a/packages/riverpod_graph/test/integration/addition/addition_test.dart
+++ b/packages/riverpod_graph/test/integration/addition/addition_test.dart
@@ -15,7 +15,8 @@ void main() {
       }
 
       expect(
-        stdoutList.first,
+        // replace windows file separator with linux - make test pass on windows
+        stdoutList.first.replaceAll(r'\', '/'),
         allOf(
           [
             startsWith('Analyzing'),
@@ -38,18 +39,37 @@ flowchart TB
     style stop1 height:0px;
     start2[ ] --->|listen| stop2[ ]
     style start2 height:0px;
-    style stop2 height:0px; 
+    style stop2 height:0px;
     start3[ ] ===>|watch| stop3[ ]
     style start3 height:0px;
-    style stop3 height:0px; 
+    style stop3 height:0px;
   end
-
   subgraph Type
     direction TB
     ConsumerWidget((widget));
     Provider[[provider]];
   end
-  additionProvider[[additionProvider]];
+  additionProvider[["additionProvider</br>FutureProvider&lt; num&gt;"]];
+  normalProvider[["normalProvider</br>Provider&lt; int&gt;"]];
+  futureProvider[["futureProvider</br>FutureProvider&lt; int&gt;"]];
+  familyProviders[["familyProviders</br>ProviderFamily&lt; int, Object?&gt;"]];
+  functionProvider[["functionProvider</br>Provider&lt; int Function()&gt;"]];
+  selectedProvider[["selectedProvider</br>Provider&lt; int&gt;"]];
+  subgraph SampleClass
+    SampleClass.normalProvider[["normalProvider</br>Provider&lt; int&gt;"]];
+  end
+  subgraph SampleClass
+    SampleClass.futureProvider[["futureProvider</br>FutureProvider&lt; int&gt;"]];
+  end
+  subgraph SampleClass
+    SampleClass.familyProviders[["familyProviders</br>ProviderFamily&lt; int, Object?&gt;"]];
+  end
+  subgraph SampleClass
+    SampleClass.functionProvider[["functionProvider</br>Provider&lt; int Function()&gt;"]];
+  end
+  subgraph SampleClass
+    SampleClass.selectedProvider[["selectedProvider</br>Provider&lt; int&gt;"]];
+  end
   normalProvider ==> additionProvider;
   futureProvider ==> additionProvider;
   familyProviders ==> additionProvider;
@@ -59,27 +79,7 @@ flowchart TB
   SampleClass.futureProvider ==> additionProvider;
   SampleClass.familyProviders ==> additionProvider;
   SampleClass.functionProvider ==> additionProvider;
-  SampleClass.selectedProvider ==> additionProvider;
-  normalProvider[[normalProvider]];
-  futureProvider[[futureProvider]];
-  familyProviders[[familyProviders]];
-  functionProvider[[functionProvider]];
-  selectedProvider[[selectedProvider]];
-  subgraph SampleClass
-    SampleClass.normalProvider[[normalProvider]];
-  end
-  subgraph SampleClass
-    SampleClass.futureProvider[[futureProvider]];
-  end
-  subgraph SampleClass
-    SampleClass.familyProviders[[familyProviders]];
-  end
-  subgraph SampleClass
-    SampleClass.functionProvider[[functionProvider]];
-  end
-  subgraph SampleClass
-    SampleClass.selectedProvider[[selectedProvider]];
-  end''',
+  SampleClass.selectedProvider ==> additionProvider;''',
         reason: 'It should log the riverpod graph',
       );
       await process.shouldExit(0);
@@ -104,7 +104,8 @@ flowchart TB
       }
 
       expect(
-        stdoutList.first,
+        // replace windows file separator with linux - make test pass on windows
+        stdoutList.first.replaceAll(r'\', '/'),
         allOf(
           [
             startsWith('Analyzing'),
@@ -118,7 +119,40 @@ flowchart TB
 
       expect(
         stdoutList.sublist(1).join('\n'),
-        '''
+        r'''
+Legend: {
+  Type: {
+    Widget.shape: circle
+    Provider: rectangle
+  }
+  Arrows: {
+    "." -> "..": read: {style.stroke-dash: 4}
+    "." -> "..": listen
+    "." -> "..": watch: {style.stroke-width: 4}
+  }
+}
+additionProvider: "additionProvider\nFutureProvider<num>"
+additionProvider.shape: rectangle
+normalProvider: "normalProvider\nProvider<int>"
+normalProvider.shape: rectangle
+futureProvider: "futureProvider\nFutureProvider<int>"
+futureProvider.shape: rectangle
+familyProviders: "familyProviders\nProviderFamily<int, Object?>"
+familyProviders.shape: rectangle
+functionProvider: "functionProvider\nProvider<int Function()>"
+functionProvider.shape: rectangle
+selectedProvider: "selectedProvider\nProvider<int>"
+selectedProvider.shape: rectangle
+SampleClass.normalProvider: "SampleClass.normalProvider\nProvider<int>"
+SampleClass.normalProvider.shape: rectangle
+SampleClass.futureProvider: "SampleClass.futureProvider\nFutureProvider<int>"
+SampleClass.futureProvider.shape: rectangle
+SampleClass.familyProviders: "SampleClass.familyProviders\nProviderFamily<int, Object?>"
+SampleClass.familyProviders.shape: rectangle
+SampleClass.functionProvider: "SampleClass.functionProvider\nProvider<int Function()>"
+SampleClass.functionProvider.shape: rectangle
+SampleClass.selectedProvider: "SampleClass.selectedProvider\nProvider<int>"
+SampleClass.selectedProvider.shape: rectangle
 normalProvider -> additionProvider: {style.stroke-width: 4}
 futureProvider -> additionProvider: {style.stroke-width: 4}
 familyProviders -> additionProvider: {style.stroke-width: 4}

--- a/packages/riverpod_graph/test/integration/consumer_widget/consumer_widget_test.dart
+++ b/packages/riverpod_graph/test/integration/consumer_widget/consumer_widget_test.dart
@@ -20,7 +20,8 @@ void main() {
       }
 
       expect(
-        stdoutList.first,
+        // replace windows file separator with linux - make test pass on windows
+        stdoutList.first.replaceAll(r'\', '/'),
         allOf(
           [
             startsWith('Analyzing'),
@@ -43,21 +44,20 @@ flowchart TB
     style stop1 height:0px;
     start2[ ] --->|listen| stop2[ ]
     style start2 height:0px;
-    style stop2 height:0px; 
+    style stop2 height:0px;
     start3[ ] ===>|watch| stop3[ ]
     style start3 height:0px;
-    style stop3 height:0px; 
+    style stop3 height:0px;
   end
-
   subgraph Type
     direction TB
     ConsumerWidget((widget));
     Provider[[provider]];
   end
+  counterProvider[["counterProvider</br>StateProvider&lt; int&gt;"]];
   CounterWidget((CounterWidget));
   counterProvider ==> CounterWidget;
-  counterProvider -.-> CounterWidget;
-  counterProvider[[counterProvider]];''',
+  counterProvider -.-> CounterWidget;''',
         reason: 'It should log the riverpod graph',
       );
       await process.shouldExit(0);
@@ -83,7 +83,8 @@ flowchart TB
       }
 
       expect(
-        stdoutList.first,
+        // replace windows file separator with linux - make test pass on windows
+        stdoutList.first.replaceAll(r'\', '/'),
         allOf(
           [
             startsWith('Analyzing'),
@@ -97,8 +98,21 @@ flowchart TB
 
       expect(
         stdoutList.sublist(1).join('\n'),
-        '''
-CounterWidget.shape: Circle
+        r'''
+Legend: {
+  Type: {
+    Widget.shape: circle
+    Provider: rectangle
+  }
+  Arrows: {
+    "." -> "..": read: {style.stroke-dash: 4}
+    "." -> "..": listen
+    "." -> "..": watch: {style.stroke-width: 4}
+  }
+}
+counterProvider: "counterProvider\nStateProvider<int>"
+counterProvider.shape: rectangle
+CounterWidget.shape: circle
 counterProvider -> CounterWidget: {style.stroke-width: 4}
 counterProvider -> CounterWidget: {style.stroke-dash: 4}''',
         reason: 'It should log the riverpod graph',

--- a/packages/riverpod_graph/test/integration/generated/generated_test.dart
+++ b/packages/riverpod_graph/test/integration/generated/generated_test.dart
@@ -20,7 +20,8 @@ void main() {
       }
 
       expect(
-        stdoutList.first,
+        // replace windows file separator with linux - make test pass on windows
+        stdoutList.first.replaceAll(r'\', '/'),
         allOf(
           [
             startsWith('Analyzing'),
@@ -43,32 +44,31 @@ flowchart TB
     style stop1 height:0px;
     start2[ ] --->|listen| stop2[ ]
     style start2 height:0px;
-    style stop2 height:0px; 
+    style stop2 height:0px;
     start3[ ] ===>|watch| stop3[ ]
     style start3 height:0px;
-    style stop3 height:0px; 
+    style stop3 height:0px;
   end
-
   subgraph Type
     direction TB
     ConsumerWidget((widget));
     Provider[[provider]];
   end
-  publicClassProvider[[publicClassProvider]];
-  publicProvider ==> publicClassProvider;
-  publicProvider[[publicProvider]];
-  _privateClassProvider[[_privateClassProvider]];
-  publicProvider ==> _privateClassProvider;
-  familyClassProvider[[familyClassProvider]];
-  publicProvider ==> familyClassProvider;
-  supports$InClassNameProvider[[supports$InClassNameProvider]];
-  publicProvider ==> supports$InClassNameProvider;
-  supports$inNamesProvider[[supports$inNamesProvider]];
+  supports$inNamesProvider[["supports$inNamesProvider</br>AutoDisposeProvider&lt; String&gt;"]];
+  publicProvider[["publicProvider</br>AutoDisposeProvider&lt; String&gt;"]];
+  familyProvider[["familyProvider</br>FamilyFamily"]];
+  _privateProvider[["_privateProvider</br>AutoDisposeProvider&lt; String&gt;"]];
+  publicClassProvider[["publicClassProvider</br>AutoDisposeNotifierProviderImpl&lt; PublicClass, String&gt;"]];
+  _privateClassProvider[["_privateClassProvider</br>AutoDisposeNotifierProviderImpl&lt; _PrivateClass, String&gt;"]];
+  familyClassProvider[["familyClassProvider</br>FamilyClassFamily"]];
+  supports$InClassNameProvider[["supports$InClassNameProvider</br>AutoDisposeNotifierProviderImpl&lt; Supports$InClassName, String&gt;"]];
   publicProvider ==> supports$inNamesProvider;
-  familyProvider[[familyProvider]];
   publicProvider ==> familyProvider;
-  _privateProvider[[_privateProvider]];
-  publicProvider ==> _privateProvider;''',
+  publicProvider ==> _privateProvider;
+  publicProvider ==> publicClassProvider;
+  publicProvider ==> _privateClassProvider;
+  publicProvider ==> familyClassProvider;
+  publicProvider ==> supports$InClassNameProvider;''',
         reason: 'It should log the riverpod graph',
       );
       await process.shouldExit(0);
@@ -93,7 +93,8 @@ flowchart TB
       }
 
       expect(
-        stdoutList.first,
+        // replace windows file separator with linux - make test pass on windows
+        stdoutList.first.replaceAll(r'\', '/'),
         allOf(
           [
             startsWith('Analyzing'),
@@ -108,13 +109,40 @@ flowchart TB
       expect(
         stdoutList.sublist(1).join('\n'),
         r'''
+Legend: {
+  Type: {
+    Widget.shape: circle
+    Provider: rectangle
+  }
+  Arrows: {
+    "." -> "..": read: {style.stroke-dash: 4}
+    "." -> "..": listen
+    "." -> "..": watch: {style.stroke-width: 4}
+  }
+}
+supports$inNamesProvider: "supports$inNamesProvider\nAutoDisposeProvider<String>"
+supports$inNamesProvider.shape: rectangle
+publicProvider: "publicProvider\nAutoDisposeProvider<String>"
+publicProvider.shape: rectangle
+familyProvider: "familyProvider\nFamilyFamily"
+familyProvider.shape: rectangle
+_privateProvider: "_privateProvider\nAutoDisposeProvider<String>"
+_privateProvider.shape: rectangle
+publicClassProvider: "publicClassProvider\nAutoDisposeNotifierProviderImpl<PublicClass, String>"
+publicClassProvider.shape: rectangle
+_privateClassProvider: "_privateClassProvider\nAutoDisposeNotifierProviderImpl<_PrivateClass, String>"
+_privateClassProvider.shape: rectangle
+familyClassProvider: "familyClassProvider\nFamilyClassFamily"
+familyClassProvider.shape: rectangle
+supports$InClassNameProvider: "supports$InClassNameProvider\nAutoDisposeNotifierProviderImpl<Supports$InClassName, String>"
+supports$InClassNameProvider.shape: rectangle
+publicProvider -> supports$inNamesProvider: {style.stroke-width: 4}
+publicProvider -> familyProvider: {style.stroke-width: 4}
+publicProvider -> _privateProvider: {style.stroke-width: 4}
 publicProvider -> publicClassProvider: {style.stroke-width: 4}
 publicProvider -> _privateClassProvider: {style.stroke-width: 4}
 publicProvider -> familyClassProvider: {style.stroke-width: 4}
-publicProvider -> supports$InClassNameProvider: {style.stroke-width: 4}
-publicProvider -> supports$inNamesProvider: {style.stroke-width: 4}
-publicProvider -> familyProvider: {style.stroke-width: 4}
-publicProvider -> _privateProvider: {style.stroke-width: 4}''',
+publicProvider -> supports$InClassNameProvider: {style.stroke-width: 4}''',
         reason: 'It should log the riverpod graph',
       );
       await process.shouldExit(0);


### PR DESCRIPTION
Changes
1. Add the node definition to provider nodes so people can see the type of data handled by the provider.  Added on the 2nd line for both d2 and mermaid.
1. Updated _golden_ tests with new comparison files
2. Updated _golden_ tests to support running on windows in addition to linux

Verification
1. Ran tests in VS Code test pane
3. Unable to run from the command line

Issues
1. 'contained classes' are handled poorly in both d2 and mermaid IMO. Maybe I don't understand what they are so I didnt' touch them. They effectively appear twice in the graph.

A picture of the todo's app D2 diagram with this change.
![image](https://github.com/rrousselGit/riverpod/assets/1217160/7cfeb975-2fe2-40a6-a29d-061b9a7a8188)
