### PR TITLE
Fixed canGoToPrevoiusPageProv…

### DIFF
--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart
@@ -10,7 +10,7 @@ final pageIndexProvider = StateProvider<int>((ref) => 0);
 /* highlight-start */
 final canGoToPreviousPageProvider = Provider<bool>((ref) {
 /* highlight-end */
-  return ref.watch(pageIndexProvider) == 0;
+  return ref.watch(pageIndexProvider) > 0;
 });
 
 class PreviousButton extends ConsumerWidget {


### PR DESCRIPTION
I have fixed the condition of the camGoToPreviousPageProvider because in order for you to touch the previous button, the current page must be greater than zero. I hope they accept this request soon because the documentation currently has that error.