### PR TITLE
Fixed canGoToPreviousPagePr…

### DIFF
--- a/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
+++ b/website/i18n/es/docusaurus-plugin-content-docs/current/providers/provider/unoptimized_previous_button.dart
@@ -12,7 +12,7 @@ class PreviousButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // Si no está en la primera página, el botón anterior está activo
-    final canGoToPreviousPage = ref.watch(pageIndexProvider) == 0;
+    final canGoToPreviousPage = ref.watch(pageIndexProvider) > 0;
 
     void goToPreviousPage() {
       ref.read(pageIndexProvider.notifier).update((state) => state - 1);


### PR DESCRIPTION
I have fixed the condition of the camGoToPreviousPageProvider because in order for you to touch the previous button, the current page must be greater than zero. I hope they accept this request soon because the documentation currently has that error.