### PR TITLE
riverpod_graph: don't crash on: 1) provider is a method of instance of another provider 2) recursive watch calls, like:  ref.watch(ref.watch(provider))

### DIFF
--- a/packages/riverpod_graph/lib/src/analyze.dart
+++ b/packages/riverpod_graph/lib/src/analyze.dart
@@ -812,6 +812,22 @@ VariableElement parseProviderFromExpression(
     if (target != null) return parseProviderFromExpression(target, context);
   }
 
+  if (providerExpression is SimpleIdentifier) {
+    // if local variable is used as provider, try to get actual provider
+    final block = providerExpression.thisOrAncestorOfType<Block>();
+    if (block != null) {
+      final vars = block.statements.whereType<VariableDeclarationStatement>();
+      for (final vv in vars) {
+        final element = vv.variables.variables.firstWhereOrNull(
+          (element) => element.name.toString() == providerExpression.toString(),
+        );
+        if (element != null) {
+          return element.declaredElement!;
+        }
+      }
+    }
+  }
+
   throw UnsupportedError(
     'unknown expression $providerExpression ${providerExpression.runtimeType}',
   );


### PR DESCRIPTION
ConsumerWidgetVisitor: store map of local variables, to solve cases there provider is a method of instance of another provider state, i.e.:
```Dart
final worker = ref.watch(currentWorker); 
final clients = ref.watch(worker.clientsOf) 
//there: 
class Worker{ 
Provider get clients => clientsOfWorker(this); 
// other code....
}
```

ConsumerWidgetVisitor: allow recursive watch, like: 
```Dart
ref.watch(provider1(ref.watch(provider2)))  // updated
```