### PR TITLE
Remove partial doc {@template}s

### DIFF
--- a/packages/flutter_riverpod/lib/src/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/consumer.dart
@@ -364,7 +364,7 @@ typedef ConsumerBuilder = Widget Function(
 /// {@endtemplate}
 @sealed
 class Consumer extends ConsumerWidget {
-  /// {@template riverpod.consumer}
+  /// {@macro riverpod.consumer}
   const Consumer({super.key, required ConsumerBuilder builder, Widget? child})
       : _child = child,
         _builder = builder;

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fix invalid Dart docs (thanks to @srawlins)
+
 ## 2.4.0 - 2023-09-04
 
 - Added `Notifier.stateOrNull`.

--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -291,7 +291,6 @@ class ProviderContainer implements Node {
     );
   }
 
-  /// {@template riverpod.invalidate}
   void invalidate(ProviderOrFamily provider) {
     if (provider is ProviderBase) {
       final reader = _getStateReader(provider._origin);
@@ -310,7 +309,6 @@ class ProviderContainer implements Node {
     }
   }
 
-  /// {@template riverpod.refresh}
   State refresh<State>(Refreshable<State> provider) {
     invalidate(provider._origin);
     return read(provider);

--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -291,6 +291,7 @@ class ProviderContainer implements Node {
     );
   }
 
+  /// {@macro riverpod.invalidate}
   void invalidate(ProviderOrFamily provider) {
     if (provider is ProviderBase) {
       final reader = _getStateReader(provider._origin);
@@ -309,6 +310,7 @@ class ProviderContainer implements Node {
     }
   }
 
+  /// {@macro riverpod.refresh}
   State refresh<State>(Refreshable<State> provider) {
     invalidate(provider._origin);
     return read(provider);


### PR DESCRIPTION
I'm fairly certain these are broken; a `{@template}` directive must be followed by one or more lines and then `{@endtemplate}`.

Let me know if I'm mistaken 😁 