### PR TITLE
Add Korean Translation in provider of docs v2

### DIFF
--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/providers/provider.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/providers/provider.mdx
@@ -12,90 +12,70 @@ import unoptimizedPreviousButton from "!!raw-loader!/i18n/ko/docusaurus-plugin-c
 import optimizedPreviousButton from "!!raw-loader!/i18n/ko/docusaurus-plugin-content-docs/current/providers/provider/optimized_previous_button.dart";
 import { trimSnippet } from "../../../../../src/components/CodeSnippet";
 
-`Provider` is the most basic of all providers. It creates a value... And that's about it.
+`Provider`는 프로바이더들 중 가장 기본입니다. 프로바이더는 값을 생성하고... 그게 다입니다.
 
-`Provider` is typically used for:
+`Provider` 일반적으로 아래와 같은 상황에서 사용됩니다.
 
-- caching computations
-- exposing a value to other providers (such as a `Repository`/`HttpClient`).
-- offering a way for tests or widgets to override a value.
-- reducing rebuilds of providers/widgets without having to use `select`.
+- 계산 결과를 캐싱할 때
+- `Repository`나 `HttpClient`와 같은 다른 프로바이더에 값을 노출할 때
+- 테스트나 위젯이 값을 덮어쓸 수 있도록 할 때
+- `select`를 사용하지 않고 프로바이더나 위젯의 리빌드를 줄이고자 할 때
 
-## Using `Provider` to cache computations
+## `Provider`를 사용하여 계산 결과를 캐싱하는 경우
 
-`Provider` is a powerful tool for caching synchronous operations when combined
-with [ref.watch].
+`Provider`는 [ref.watch]와 같이 사용할 때 동기식 작업을 캐싱하는 강력한 도구입니다.
 
-An example would be filtering a list of todos.
-Since filtering a list could be slightly expensive, we ideally do not want to
-filter our list of todos whenever our application re-renders.
-In this situation, we could use `Provider` to do the filtering for us.
+예를 들면, to-do 목록을 필터링 한다고 가정합시다.
+목록을 필터링 할 때 약간의 비용이 들 수 있으므로, 어플리케이션이 다시 렌더링 될 때마다 to-do 목록을 필터링하지 않는 것이 이상적입니다.
+이 상황에서는 `Provider`를 사용해서 필터링을 수행할 수 있습니다.
 
-For that, assume that our application has an existing [StateNotifierProvider]
-which manipulates a list of todos:
+이를 위해 어플리케이션에 to-do 목록을 변경할 수 있도록 작성된 [StateNotifierProvider]가 있다고 가정합시다.
 
 <CodeBlock>{trimSnippet(todo)}</CodeBlock>
 
-From there, we can use `Provider` to expose the filtered list of todos, showing
-only the completed todos:
+이제 우리는 `Provider`를 사용하여 필터링된 할 일 목록을 노출하여 완료된 to-do만 표시할 수 있습니다.
 
 <CodeBlock>{trimSnippet(completedTodos)}</CodeBlock>
 
-With this code, our UI is now able to show the list of the completed todos
-by listening to `completedTodosProvider`:
+이 코드를 통해 이제 UI는 `completeTodosProvider`를 구독해서 완료된 to-do 목록을 표시할 수 있습니다:
 
 <CodeBlock>{trimSnippet(todosConsumer)}</CodeBlock>
 
-The interesting part is, the list filtering is now cached.
+흥미로운 점은 목록 필터링이 이제 캐시된다는 점입니다.
 
-Meaning that the list of completed todos will not be recomputed until
-todos are added/removed/updated, even if we are reading the list of completed
-todos multiple times.
+즉, 완료된 to-do 목록을 여러 번 읽더라도 to-do가 추가/제거/업데이트될 때까지 완료된 to-do 목록이 다시 계산되지 않습니다.
 
-Note how we do not need to manually invalidate the cache when the list of todos
-changes. `Provider` is automatically able to know when the result must be recomputed
-thanks to [ref.watch].
+할 일 목록이 변경될 때 캐시를 수동으로 무효화할 필요가 없다는 점에 주목하세요. `Provider`는 [ref.watch] 덕분에 언제 결과를 다시 계산해야 하는지를 별도의 과정 없이 알 수 있습니다.
 
-## Reducing provider/widget rebuilds by using `Provider`
+## `Provider`를 사용하여 공급자/위젯 리빌드 줄이기
 
-A unique aspect of `Provider` is that even when `Provider` is recomputed
-(typically when using [ref.watch]), it will not update the widgets/providers
-that listen to it unless the value changed.
+`Provider`의 독특한 측면은 `Provider`가 다시 계산되더라도(일반적으로 [ref.watch]를 사용할 때) 값이 변경되지 않는 한 이를 구독하는 위젯/provider를 업데이트하지 않는다는 점입니다.
 
-A real world example would be for enabling/disabling previous/next buttons
-of a paginated view:
+예를 들면 페이지네이션이 적용된 보기의 이전/다음 버튼을 활성화/비활성화할 수 있습니다:
 
 ![stepper example](https://user-images.githubusercontent.com/134939/47580830-31263a00-d950-11e8-9b61-0eaddab2709e.png)
 
-In our case, we will focus specifically on the "previous" button.
-A naive implementation of such button would be a widget which obtains the
-current page index, and if that index is equal to 0, we would disable the button.
+여기서는 특히 "이전" 버튼에 집중하겠습니다.
+이러한 버튼을 단순하게 구현하자면, 현재 페이지 인덱스를 가져오는 위젯이며, 해당 인덱스가 0이면 버튼을 비활성화합니다.
 
-This code could be:
+이 코드는 아래처럼 작성할 수 있습니다:
 
 <CodeBlock>{trimSnippet(unoptimizedPreviousButton)}</CodeBlock>
 
-The issue with this code is that whenever we change the current page, the "previous"
-button will rebuild.  
-In the ideal world, we would want the button to rebuild only when changing between
-activated and deactivated.
+이 코드의 문제점은 현재 페이지를 변경할 때마다 "이전" 버튼이 다시 빌드된다는 것입니다.  
+하지만 활성화와 비활성화 사이를 변경할 때만 버튼이 다시 빌드되는 것이 이상적입니다.
 
-The root of the issue here is that we are computing whether the user is
-allowed to go to the previous page directly within the "previous" button.
+이 문제의 원인은 사용자가 '이전' 버튼 내에서 바로 이전 페이지로 이동할 수 있는지 여부를 계산한다는 것입니다.
 
-A way to solve this is to extract this logic outside of the widget and into a `Provider`:
+이 문제를 해결하는 방법은 이 로직을 위젯 외부의 `Provider`로 추출하는 것입니다:
 
 <CodeBlock>{trimSnippet(optimizedPreviousButton)}</CodeBlock>
 
-By doing this small refactoring, our `PreviousButton` widget will no longer
-rebuild when the page index changes thanks to `Provider`.
+간단한 리팩터링을 통해 `PreviousButton` 위젯은 `Provider` 덕분에 페이지 인덱스가 변경되더라도 더 이상 다시 빌드되지 않습니다.
 
-From now on when the page index changes, our `canGoToPreviousPageProvider` provider
-will be recomputed. But if the value exposed by the provider does not change,
-then `PreviousButton` will not rebuild.
+이제부터는 페이지 인덱스가 변경될 때 `canGoToPreviousPageProvider` 라는 provider에서 다시 계산합니다. 그러나 provider가 노출한 값이 변경되지 않으면 `PreviousButton`은 다시 빌드되지 않습니다.
 
-This change both improved the performance of our button and had the interesting
-benefit of extracting the logic outside of our widget.
+이를 통해 버튼의 성능이 향상되고 위젯 외부에서 로직을 추출할 수 있다는 이점이 있습니다.
 
 [ref.watch]: ../concepts/reading#using-refwatch-to-observe-a-provider
 [statenotifierprovider]: ./state_notifier_provider


### PR DESCRIPTION
I did not translate `provider` and `to-do` on purpose as most Korean software developers are more familiar with the English terminology than their translated equivalent. 