### PR TITLE
first request documentation update

### DIFF
--- a/website/docs/essentials/first_request/raw/consumer.dart
+++ b/website/docs/essentials/first_request/raw/consumer.dart
@@ -29,11 +29,11 @@ class Home extends StatelessWidget {
           /// Since network-requests are asynchronous and can fail, we need to
           /// handle both error and loading states. We can use pattern matching for this.
           /// We could alternatively use `if (activity.isLoading) { ... } else if (...)`
-          child: switch (activity) {
-            AsyncData(:final value) => Text('Activity: ${value.activity}'),
-            AsyncError() => const Text('Oops, something unexpected happened'),
-            _ => const CircularProgressIndicator(),
-          },
+          child: activity.when(
+              data: (value) => Text('Activity: ${value.activity}'),
+              error: (e, st) =>
+              const Text('Oops, something unexpected happened'),
+              loading: () =>const CircularProgressIndicator()),
         );
       },
     );


### PR DESCRIPTION
Current switch-based dart code gives error while adding provider as per the documentation.
It can be replaced with ` .when(` block.