### PR TITLE
🐞 fix(i18n, Link): path.sep & link path

### DIFF
--- a/website/meta_generator.js
+++ b/website/meta_generator.js
@@ -99,10 +99,10 @@ function decodeDocuments(documents) {
     let id = parsedDoc.data.id;
     if (!id) {
       let pathSplit;
-      if (docFile.startsWith("docs/")) {
-        pathSplit = docFile.split("/").slice(1);
-      } else if (docFile.startsWith("i18n/")) {
-        pathSplit = docFile.split("/").slice(4);
+      if (docFile.startsWith(`docs${path.sep}`)) {
+        pathSplit = docFile.split(path.sep).slice(1);
+      } else if (docFile.startsWith(`i18n${path.sep}`)) {
+        pathSplit = docFile.split(path.sep).slice(4);
       } else {
         throw new Error(`Unknown document type ${docFile}`);
       }
@@ -130,14 +130,14 @@ function decodeDocuments(documents) {
   return result;
 }
 
-function getCountryCodeForPath(path) {
-  if (path.startsWith("docs/")) return "en";
+function getCountryCodeForPath(docFile) {
+  if (docFile.startsWith(`docs${path.sep}`)) return "en";
 
-  if (!path.startsWith("i18n/")) {
-    throw new Error(`Unknown path ${path}`);
+  if (!docFile.startsWith(`i18n${path.sep}`)) {
+    throw new Error(`Unknown docFile ${docFile}`);
   }
 
-  return path.split("/")[1];
+  return docFile.split(path.sep)[1];
 }
 
 class OutdatedTranslation {

--- a/website/src/components/Link/index.tsx
+++ b/website/src/components/Link/index.tsx
@@ -14,6 +14,10 @@ export function Link(props: LinkProps) {
     ? doc.metadata.source.split("/")[2]
     : "en";
 
+  const prefix = countryCode === "en"
+    ? ""
+    : `/${countryCode}`;
+
   const docTitle = documentTitles[countryCode][props.documentID];
 
   if (!docTitle) {
@@ -24,5 +28,5 @@ export function Link(props: LinkProps) {
 
   const trailing = props.hash ? `#${props.hash}` : "";
 
-  return <a href={`/docs/${props.documentID}${trailing}`}>{docTitle}</a>;
+  return <a href={`${prefix}/docs/${props.documentID}${trailing}`}>{docTitle}</a>;
 }


### PR DESCRIPTION
1. fix meta_generator cann't read doc type by path.sep.
2. fix Link components cann't use in i18n langurage.