### PR TITLE
The following packages have been updated:

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.7 - 2023-11-20
+
+- Fix `ProviderObserver.didUpdateProvider` being called with an incorrect
+  "provider" parameter when the provider is overridden.
+
 ## 2.4.6 - 2023-11-13
 
 - Exceptions in asynchronous providers are now correctly received

--- a/packages/flutter_riverpod/pubspec.yaml
+++ b/packages/flutter_riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_riverpod
 description: >
   A simple way to access state from anywhere in your application
   while robust and testable.
-version: 2.4.6
+version: 2.4.7
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.4.0
-  riverpod: 2.4.6
+  riverpod: 2.4.7
   state_notifier: ">=0.7.2 <2.0.0"
 
 dev_dependencies:

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.7 - 2023-11-20
+
+- Fix `ProviderObserver.didUpdateProvider` being called with an incorrect
+  "provider" parameter when the provider is overridden.
+
 ## 2.4.6 - 2023-11-13
 
 - Exceptions in asynchronous providers are now correctly received

--- a/packages/hooks_riverpod/pubspec.yaml
+++ b/packages/hooks_riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_riverpod
 description: >
   A simple way to access state from anywhere in your application
   while robust and testable.
-version: 2.4.6
+version: 2.4.7
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -18,8 +18,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks: '>=0.18.0 <0.21.0'
-  flutter_riverpod: 2.4.6
-  riverpod: 2.4.6
+  flutter_riverpod: 2.4.7
+  riverpod: 2.4.7
   state_notifier: ">=0.7.2 <2.0.0"
 
 dev_dependencies:

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased patch
+## 2.4.7 - 2023-11-20
 
 - Fix `ProviderObserver.didUpdateProvider` being called with an incorrect
   "provider" parameter when the provider is overridden.

--- a/packages/riverpod/pubspec.yaml
+++ b/packages/riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: riverpod
 description: >
   A simple way to access state from anywhere in your application while robust
   and testable.
-version: 2.4.6
+version: 2.4.7
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues

--- a/packages/riverpod_analyzer_utils/CHANGELOG.md
+++ b/packages/riverpod_analyzer_utils/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased minor
+## 0.5.0 - 2023-11-20
 
 - **Breaking** `LegacyProviderDeclarationElement.providerType` is now nullable.
 - Fix crash when parsing classes with a `ProviderBase` field.

--- a/packages/riverpod_analyzer_utils/pubspec.yaml
+++ b/packages/riverpod_analyzer_utils/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/rrousselGit/river_pod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
 funding:
   - https://github.com/sponsors/rrousselGit/
-version: 0.4.3
+version: 0.5.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/riverpod_annotation/CHANGELOG.md
+++ b/packages/riverpod_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1 - 2023-11-20
+
+- `riverpod` upgraded to `2.4.7`
+
 ## 2.3.1 - 2023-11-13
 
 - `riverpod` upgraded to `2.4.6`

--- a/packages/riverpod_annotation/pubspec.yaml
+++ b/packages/riverpod_annotation/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   meta: ^1.7.0
-  riverpod: ^2.4.6
+  riverpod: ^2.4.7
 
 dev_dependencies:
   test: ^1.21.0

--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased fix
+## 2.3.7 - 2023-11-20
 
 - Fix crash when encountering classes with a `ProviderBase` field.
 

--- a/packages/riverpod_generator/pubspec.yaml
+++ b/packages/riverpod_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_generator
 description: A code generator for Riverpod. This both simplifies the syntax empowers it, such as allowing stateful hot-reload.
-version: 2.3.6
+version: 2.3.7
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
 funding:
@@ -17,12 +17,12 @@ dependencies:
   crypto: ^3.0.2
   meta: ^1.7.0
   path: ^1.8.0
-  riverpod_analyzer_utils: ^0.4.3
+  riverpod_analyzer_utils: ^0.5.0
   riverpod_annotation: ^2.3.1
   source_gen: ^1.2.0
 
 dev_dependencies:
   build_runner: ^2.1.7
   build_verify: ^3.0.0
-  riverpod: ^2.4.6
+  riverpod: ^2.4.7
   test: ^1.21.0

--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased fix
+## 2.3.5 - 2023-11-20
 
 - Fix crash when encountering classes with a `ProviderBase` field.
 

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_lint
 description: Riverpod_lint is a developer tool for users of Riverpod, designed to help stop common issues and simplify repetitive tasks.
-version: 2.3.4
+version: 2.3.5
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/river_pod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -17,8 +17,8 @@ dependencies:
   custom_lint_builder: ^0.5.2
   meta: ^1.7.0
   path: ^1.8.1
-  riverpod: ^2.4.6
-  riverpod_analyzer_utils: ^0.4.3
+  riverpod: ^2.4.7
+  riverpod_analyzer_utils: ^0.5.0
   source_span: ^1.8.0
   yaml: ^3.1.1
 


### PR DESCRIPTION
riverpod                : 2.4.6 -> 2.4.7
riverpod_analyzer_utils : 0.4.3 -> 0.5.0
riverpod_annotation     : 2.3.1 -> 2.3.1
riverpod_generator      : 2.3.6 -> 2.3.7
riverpod_lint           : 2.3.4 -> 2.3.5
flutter_riverpod        : 2.4.6 -> 2.4.7
hooks_riverpod          : 2.4.6 -> 2.4.7