### PR TITLE
The following packages have been updated:

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased fix
+## 2.4.9 - 2023-11-27
 
 - Fix "pending timer" issue inside tests when using `ref.keepAlive()`.
 - Fix `Ref.invalidate`/`Ref.refresh` not throwing on circular dependency.

--- a/packages/flutter_riverpod/pubspec.yaml
+++ b/packages/flutter_riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_riverpod
 description: >
   A simple way to access state from anywhere in your application
   while robust and testable.
-version: 2.4.8
+version: 2.4.9
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.4.0
-  riverpod: 2.4.8
+  riverpod: 2.4.9
   state_notifier: ">=0.7.2 <2.0.0"
 
 dev_dependencies:

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased fix
+## 2.4.9 - 2023-11-27
 
 - Fix "pending timer" issue inside tests when using `ref.keepAlive()`.
 - Fix `Ref.invalidate`/`Ref.refresh` not throwing on circular dependency.

--- a/packages/hooks_riverpod/pubspec.yaml
+++ b/packages/hooks_riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_riverpod
 description: >
   A simple way to access state from anywhere in your application
   while robust and testable.
-version: 2.4.8
+version: 2.4.9
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -18,8 +18,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks: '>=0.18.0 <0.21.0'
-  flutter_riverpod: 2.4.8
-  riverpod: 2.4.8
+  flutter_riverpod: 2.4.9
+  riverpod: 2.4.9
   state_notifier: ">=0.7.2 <2.0.0"
 
 dev_dependencies:

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased fix
+## 2.4.9 - 2023-11-27
 
 - Fix "pending timer" issue inside tests when using `ref.keepAlive()`.
 - Fix `Ref.invalidate`/`Ref.refresh` not throwing on circular dependency.

--- a/packages/riverpod/pubspec.yaml
+++ b/packages/riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: riverpod
 description: >
   A simple way to access state from anywhere in your application while robust
   and testable.
-version: 2.4.8
+version: 2.4.9
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues

--- a/packages/riverpod_annotation/CHANGELOG.md
+++ b/packages/riverpod_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.3 - 2023-11-27
+
+- `riverpod` upgraded to `2.4.9`
+
 ## 2.3.2 - 2023-11-20
 
 - `riverpod` upgraded to `2.4.8`

--- a/packages/riverpod_annotation/pubspec.yaml
+++ b/packages/riverpod_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_annotation
 description: A package exposing annotations for riverpod_generator
-version: 2.3.2
+version: 2.3.3
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
 funding:
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   meta: ^1.7.0
-  riverpod: ^2.4.8
+  riverpod: ^2.4.9
 
 dev_dependencies:
   test: ^1.21.0

--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.9 - 2023-11-27
+
+- `riverpod_annotation` upgraded to `2.3.3`
+- `riverpod` upgraded to `2.4.9`
+
 ## 2.3.8 - 2023-11-20
 
 - `riverpod_annotation` upgraded to `2.3.2`

--- a/packages/riverpod_generator/pubspec.yaml
+++ b/packages/riverpod_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_generator
 description: A code generator for Riverpod. This both simplifies the syntax empowers it, such as allowing stateful hot-reload.
-version: 2.3.8
+version: 2.3.9
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
 funding:
@@ -18,11 +18,11 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   riverpod_analyzer_utils: ^0.5.0
-  riverpod_annotation: ^2.3.2
+  riverpod_annotation: ^2.3.3
   source_gen: ^1.2.0
 
 dev_dependencies:
   build_runner: ^2.1.7
   build_verify: ^3.0.0
-  riverpod: ^2.4.8
+  riverpod: ^2.4.9
   test: ^1.21.0

--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.7 - 2023-11-27
+
+- `riverpod` upgraded to `2.4.9`
+
 ## 2.3.6 - 2023-11-20
 
 - `riverpod` upgraded to `2.4.8`

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_lint
 description: Riverpod_lint is a developer tool for users of Riverpod, designed to help stop common issues and simplify repetitive tasks.
-version: 2.3.6
+version: 2.3.7
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/river_pod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -17,7 +17,7 @@ dependencies:
   custom_lint_builder: ^0.5.2
   meta: ^1.7.0
   path: ^1.8.1
-  riverpod: ^2.4.8
+  riverpod: ^2.4.9
   riverpod_analyzer_utils: ^0.5.0
   source_span: ^1.8.0
   yaml: ^3.1.1


### PR DESCRIPTION
riverpod            : 2.4.8 -> 2.4.9
riverpod_annotation : 2.3.2 -> 2.3.3
riverpod_generator  : 2.3.8 -> 2.3.9
riverpod_lint       : 2.3.6 -> 2.3.7
flutter_riverpod    : 2.4.8 -> 2.4.9
hooks_riverpod      : 2.4.8 -> 2.4.9