### PR TITLE
Fix typo in testing docs

### DIFF
--- a/website/docs/essentials/testing.mdx
+++ b/website/docs/essentials/testing.mdx
@@ -45,7 +45,7 @@ The main difference with any other test is that we will want to create
 a `ProviderContainer` object. This object will enable our test to interact
 with providers.
 
-It encouraged to make a testing utility for both creating and disposing
+It is encouraged to make a testing utility for both creating and disposing
 of a `ProviderContainer` object:
 
 <AutoSnippet raw={createContainer} />


### PR DESCRIPTION
"It is" is currently more common in the project than "It's", hence I picked that.