### PR TITLE
Update side_effects.mdx typo; snipper --> spinner

### DIFF
--- a/website/docs/essentials/side_effects.mdx
+++ b/website/docs/essentials/side_effects.mdx
@@ -427,7 +427,7 @@ performed, nor any information if failed.
 
 One way to do so is to store the Future returned by `addTodo`
 in the local widget state, and then listen to that future to show
-a snipper or error message.  
+a spinner or error message.  
 This is one scenario where [flutter_hooks](https://pub.dev/packages/flutter_hooks)
 comes in handy. But of course, you can also use a `StatefulWidget` instead.
 


### PR DESCRIPTION
Just a simple doc change. `snipper` :arrow_right: `spinner`.