### PR TITLE
Fix typo in quickstart.mdx

### DIFF
--- a/website/docs/from_provider/quickstart.mdx
+++ b/website/docs/from_provider/quickstart.mdx
@@ -64,7 +64,7 @@ This should boost and simplify the migration process, while also minimizing / tr
 ## Riverpod and Provider can coexist
 *Keep in mind that it is entirely possible to use both Provider and Riverpod at the same time.*
 
-Indeed, using import aliases, it is possible to use the two APIs altogheter.  
+Indeed, using import aliases, it is possible to use the two APIs altogether.  
 This is also great for readibilty and it removes any ambiguous API usage.
 
 If you plan on doing this, consider using import aliases for each Provider import in your codebase.


### PR DESCRIPTION
'altogheter' -> 'altogether'
