### PR TITLE
Fix a typo in examples/counter/README

### DIFF
--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,6 +1,6 @@
 The standard Flutter Counter example built with [Riverpod]
 
-This uses `ProvidedScope`.
+This uses `ProviderScope`.
 
 
 [riverpod]: https://github.com/rrousselGit/riverpod


### PR DESCRIPTION
Fix #3253