### PR TITLE
Fix `async_value_nullable_pattern` false positive when used with generics

### DIFF
--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased fix
+
+- Fix `async_value_nullable_pattern` false positive when used with generics
+  that have non-nullable type constrains.
+
 ## 2.3.7 - 2023-11-27
 
 - `riverpod` upgraded to `2.4.9`

--- a/packages/riverpod_lint/lib/src/lints/async_value_nullable_pattern.dart
+++ b/packages/riverpod_lint/lib/src/lints/async_value_nullable_pattern.dart
@@ -53,7 +53,15 @@ class AsyncValueNullablePattern extends RiverpodLintRule {
       }
 
       grandParentType as InterfaceType;
-      final genericType = grandParentType.typeArguments.first;
+      var genericType = grandParentType.typeArguments.first;
+
+      // If the AsyncValue's type is a generic type, we check the generic's constraint
+      if (genericType is TypeParameterType) {
+        final unit = node.thisOrAncestorOfType<CompilationUnit>()!;
+
+        genericType = genericType.element.bound ??
+            unit.declaredElement!.library.typeProvider.dynamicType;
+      }
 
       if (genericType is! DynamicType &&
           genericType.nullabilitySuffix != NullabilitySuffix.question) {

--- a/packages/riverpod_lint_flutter_test/test/lints/async_value_nullable_pattern/async_value_nullable_pattern.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/async_value_nullable_pattern/async_value_nullable_pattern.dart
@@ -55,3 +55,26 @@ void main() {
       print(value);
   }
 }
+
+void fn<T>(T obj) {
+  switch (obj) {
+    // expect_lint: async_value_nullable_pattern
+    case AsyncValue<T>(:final value?):
+      print(value);
+  }
+}
+
+void fn2<T extends Object>(T obj) {
+  switch (obj) {
+    case AsyncValue<T>(:final value?):
+      print(value);
+  }
+}
+
+void fn3<T extends Object?>(T obj) {
+  switch (obj) {
+    // expect_lint: async_value_nullable_pattern
+    case AsyncValue<T>(:final value?):
+      print(value);
+  }
+}


### PR DESCRIPTION
that have non-nullable type constrains.