### PR TITLE
feat: keepAliveRiverpod shorthand

### DIFF
--- a/packages/riverpod_annotation/CHANGELOG.md
+++ b/packages/riverpod_annotation/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased patch
 
 - Improved `@Riverpod(dependencies: [...])` documentation.
+- Introduces `@keepAliveRiverpod` shorthand.
 
 ## 2.3.3 - 2023-11-27
 

--- a/packages/riverpod_annotation/lib/src/riverpod_annotation.dart
+++ b/packages/riverpod_annotation/lib/src/riverpod_annotation.dart
@@ -46,6 +46,10 @@ class Riverpod {
   /// // By not specifying "dependencies", we are saying that this provider is never scoped
   /// @riverpod
   /// Foo root(RootRef ref) => Foo();
+  /// 
+  /// @keepAliveRiverpod
+  /// Foo root(RootRef ref) => Foo();
+  /// 
   /// // By specifying "dependencies" (even if the list is empty),
   /// // we are saying that this provider is potentially scoped
   /// @Riverpod(dependencies: [])
@@ -60,6 +64,13 @@ class Riverpod {
   /// Object? dependent(DependentRef ref) {
   ///   ref.watch(rootProvider);
   ///   // This provider does not depend on any scoped provider,
+  ///   // as such "dependencies" is optional
+  /// }
+  ///
+  /// @keepAliveRiverpod
+  /// Object? dependent(DependentRef ref) {
+  ///   ref.watch(rootProvider);
+  ///   // This provider (with keepAlive set to true) does not depend on any scoped provider,
   ///   // as such "dependencies" is optional
   /// }
   ///
@@ -104,6 +115,10 @@ class Riverpod {
 /// {@macro riverpod_annotation.provider}
 @Target({TargetKind.classType, TargetKind.function})
 const riverpod = Riverpod();
+
+/// {@macro riverpod_annotation.provider}
+@Target({TargetKind.classType, TargetKind.function})
+const keepAliveRiverpod = Riverpod(keepAlive: true);
 
 /// An annotation used to help the linter find the user-defined element from
 /// the generated provider.


### PR DESCRIPTION
When using Riverpod for state management in Flutter, it is essential to ensure that your code is efficient and easy to read. One way to improve the readability and brevity of your code is to use a shorthand annotation, `@keepAliveRiverpod`, instead of `@Riverpod(keepAlive: true)`.

The `@keepAliveRiverpod` annotation is a concise way to indicate that a provider should remain active even when not being listened to. It is a simple and clear declaration that is easy to understand and write:

```dart
@keepAliveRiverpod
final myProvider = Provider((ref) => MyService());
```

Using `@keepAliveRiverpod` makes the intention of your code immediately clear to anyone who is reading it. It is more intuitive than the `@Riverpod` parameter and can be easily identified. So, by using `@keepAliveRiverpod`, you can improve the readability and brevity of your code.