### PR TITLE
`ref.invalidate` now correctly clear all resources associated with the provider if the provider is no-longer used.

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Improved `Provider(dependencies: [...])` documentation.
 - Fix out of date `pub.dev` description
+- `ref.invalidate` now correctly clear all resources associated
+  with the provider if the provider is no-longer used.
 
 ## 2.5.0 - 2024-02-03
 

--- a/packages/riverpod/lib/src/framework/element.dart
+++ b/packages/riverpod/lib/src/framework/element.dart
@@ -297,6 +297,7 @@ abstract class ProviderElementBase<State> implements Ref<State>, Node {
 
     _mustRecomputeState = true;
     runOnDispose();
+    mayNeedDispose();
     _container.scheduler.scheduleProviderRefresh(this);
 
     // We don't call this._markDependencyMayHaveChanged here because we voluntarily

--- a/packages/riverpod/test/framework/provider_container_test.dart
+++ b/packages/riverpod/test/framework/provider_container_test.dart
@@ -7,6 +7,23 @@ import '../utils.dart';
 
 void main() {
   group('ProviderContainer', () {
+    group('invalidate', () {
+      test('can disposes of the element if not used anymore', () async {
+        final provider = Provider.autoDispose((r) {
+          r.keepAlive();
+          return 0;
+        });
+        final container = createContainer();
+
+        container.read(provider);
+        container.invalidate(provider);
+
+        await container.pump();
+
+        expect(container.getAllProviderElements(), isEmpty);
+      });
+    });
+
     test('Supports unmounting containers in reverse order', () {
       final container = createContainer();
 

--- a/packages/riverpod/test/framework/ref_test.dart
+++ b/packages/riverpod/test/framework/ref_test.dart
@@ -6,6 +6,51 @@ import '../utils.dart';
 
 void main() {
   group('Ref', () {
+    group('invalidateSelf', () {
+      test('can disposes of the element if not used anymore', () async {
+        late Ref<Object?> ref;
+        final provider = Provider.autoDispose((r) {
+          ref = r;
+          r.keepAlive();
+          return 0;
+        });
+        final container = createContainer();
+
+        container.read(provider);
+        ref.invalidateSelf();
+
+        await container.pump();
+
+        expect(container.getAllProviderElements(), isEmpty);
+      });
+    });
+
+    group('invalidate', () {
+      test('can disposes of the element if not used anymore', () async {
+        late Ref<Object?> ref;
+        final dep = Provider((r) {
+          ref = r;
+          return 0;
+        });
+        final provider = Provider.autoDispose((r) {
+          r.keepAlive();
+          return 0;
+        });
+        final container = createContainer();
+
+        container.read(dep);
+        container.read(provider);
+        ref.invalidate(provider);
+
+        await container.pump();
+
+        expect(
+          container.getAllProviderElements().map((e) => e.origin),
+          [dep],
+        );
+      });
+    });
+
     test(
       'cannot call ref.watch/ref.read/ref.listen/ref.onDispose after a dependency changed',
       () {


### PR DESCRIPTION

## Related Issues

fixes #2729

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
