### PR TITLE
docs: Fixed typo in code snippet

### DIFF
--- a/website/docs/concepts/about_codegen/provider_type/family_class.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_class.dart
@@ -10,7 +10,7 @@ class Example extends _$Example {
     int param1, {
     String param2 = 'foo',
   }) {
-    return 'Hello $param1 & param2';
+    return 'Hello $param1 & $param2';
   }
 
   // Add methods to mutate the state

--- a/website/docs/concepts/about_codegen/provider_type/family_fn.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_fn.dart
@@ -9,5 +9,5 @@ String example(
   int param1, {
   String param2 = 'foo',
 }) {
-  return 'Hello $param1 & param2';
+  return 'Hello $param1 & $param2';
 }


### PR DESCRIPTION
## Related Issues

fixes possible typos in docs.

AFAIK, there is no CHANGELOG.md for the docs, so no contribution there.