### PR TITLE
Clarify ignored prefer_final_parameters comments

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -32,7 +32,7 @@ linter:
     # false positive
     one_member_abstracts: false
 
-    # too verbose
+    # Conflicts with `avoid_final_parameters`
     prefer_final_parameters: false
 
     # Too verbose with little value, and this is taken care of by the Flutter devtool anyway.


### PR DESCRIPTION
`prefer_final_parameters` now conflicts with the subsequently introduced `avoid_final_parameters`.
In line with others, the comments have been revised to clarify this.

Thanks!

## Related Issues

Since this concerns documentation, I have not created an issue.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
