### PR TITLE
Fix typo in provider_vs_riverpod.mdx

### DIFF
--- a/website/docs/from_provider/provider_vs_riverpod.mdx
+++ b/website/docs/from_provider/provider_vs_riverpod.mdx
@@ -134,7 +134,7 @@ Provider optionally comes with a widget named `Consumer` (and variants such as `
 for reading providers.
 
 `Consumer` is helpful as a performance optimization, by allowing more granular rebuilds
-of the widget tree - updating only the revelant widgets when the state changes:
+of the widget tree - updating only the relevant widgets when the state changes:
 
 As such, if a provider was defined as:
 


### PR DESCRIPTION
This pull request fixes a typo in the provider_vs_riverpod.mdx file, changing "revelant" to "relevant".
