### PR TITLE
fix: do not allow using ref functions after provider has been disposed

### DIFF
--- a/packages/riverpod/lib/src/framework/element.dart
+++ b/packages/riverpod/lib/src/framework/element.dart
@@ -662,6 +662,10 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
 
   @override
   T refresh<T>(Refreshable<T> provider) {
+    if (!_mounted) {
+      throw StateError('Cannot use ref functions after provider was disposed');
+    }
+
     _assertNotOutdated();
     assert(_debugAssertCanDependOn(provider), '');
     return _container.refresh(provider);
@@ -669,6 +673,10 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
 
   @override
   T read<T>(ProviderListenable<T> provider) {
+    if (!_mounted) {
+      throw StateError('Cannot use ref functions after provider was disposed');
+    }
+
     _assertNotOutdated();
     assert(!_debugIsRunningSelector, 'Cannot call ref.read inside a selector');
     assert(_debugAssertCanDependOn(provider), '');
@@ -680,6 +688,10 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
 
   @override
   T watch<T>(ProviderListenable<T> listenable) {
+    if (!_mounted) {
+      throw StateError('Cannot use ref functions after provider was disposed');
+    }
+
     _assertNotOutdated();
     assert(!_debugIsRunningSelector, 'Cannot call ref.watch inside a selector');
 
@@ -739,6 +751,10 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     // Not part of the public "Ref" API
     void Function()? onDependencyMayHaveChanged,
   }) {
+    if (!_mounted) {
+      throw StateError('Cannot use ref functions after provider was disposed');
+    }
+
     _assertNotOutdated();
     assert(!_debugIsRunningSelector, 'Cannot call ref.read inside a selector');
     assert(_debugAssertCanDependOn(listenable), '');


### PR DESCRIPTION
fixes #3522 

Using ref functions of the disposed provider can lead to unexpected behaviors e.g providers may never be disposed and hang around indefinitely if subscribed to using `Ref` of a disposed provider.

```dart
@riverpod
Future<void> future1(Future1Ref ref) async {}

@riverpod
Future<void> future2(Future2Ref ref) async {
  await Future.delayed(const Duration(seconds: 3));
  await ref.watch(future1Provider.future);
}
```
In the above example `future1Provider` will still be watched forever if `future2Provider` is disposed before timer expires.

Will handle checklist items if this even correct solution.

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
