### PR TITLE
docs: add missing closing fence in `AsyncValue.guard`

### DIFF
--- a/packages/riverpod/lib/src/common.dart
+++ b/packages/riverpod/lib/src/common.dart
@@ -157,6 +157,7 @@ abstract class AsyncValue<T> {
   ///     });
   ///   }
   /// }
+  /// ```
   ///
   /// An optional callback can be specified to catch errors only under a certain condition.
   /// In the following example, we catch all exceptions beside FormatExceptions.


### PR DESCRIPTION
This broke gh syntax highlighting for the file.

## Related Issues

n/a

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced documentation for the `AsyncValue<T>` class with an illustrative code block example for error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

^^^ It hallucinated 😉