### PR TITLE
Support flutter_hooks 0.21.x

### DIFF
--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- Support flutter_hooks 0.21.x
+
 ## 2.5.2 - 2024-08-15
 
 - Added mutation pending state to example (thanks to @luketg8)

--- a/packages/hooks_riverpod/pubspec.yaml
+++ b/packages/hooks_riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_riverpod
 description: >
   A reactive caching and data-binding framework.
   Riverpod makes working with asynchronous code a breeze.
-version: 2.5.2
+version: 2.5.3
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -17,7 +17,7 @@ dependencies:
   collection: ^1.15.0
   flutter:
     sdk: flutter
-  flutter_hooks: '>=0.18.0 <0.21.0'
+  flutter_hooks: '>=0.18.0 <0.22.0'
   flutter_riverpod: 2.5.1
   riverpod: 2.5.1
   state_notifier: ">=0.7.2 <2.0.0"


### PR DESCRIPTION
Makes it possible to use flutter_hooks 0.21.0 with riverpod, which contains pretty helpful hooks like `useOnListenableChange`

I take the opportunity to ask why is 0.21.x in flutter_hooks in a prerelease state. Does it have something to do with riverpod 3.0?

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for `flutter_hooks` version `0.21.x`.
- **Bug Fixes**
	- Improved handling of asynchronous providers and resource management.
	- Enhanced error handling and state management in the `AsyncValue` class.
- **Documentation**
	- Updated changelog with organized entries detailing updates and fixes.
- **Chores**
	- Incremented package version from `2.5.2` to `2.5.3` and updated dependency constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->