### PR TITLE
Release

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased minor
+## 2.6.0 - 2024-10-20
 
 - Deprecated all `Ref` subclasses. Instead, use `Ref` itself.
 - Deprecated `Ref`'s type argument. Use `Ref` without its generic parameter instead.

--- a/packages/flutter_riverpod/pubspec.yaml
+++ b/packages/flutter_riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_riverpod
 description: >
   A reactive caching and data-binding framework.
   Riverpod makes working with asynchronous code a breeze.
-version: 2.5.3
+version: 2.6.0
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.4.0
-  riverpod: 2.5.3
+  riverpod: 2.6.0
   state_notifier: ">=0.7.2 <2.0.0"
 
 dev_dependencies:

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased minor
+## 2.6.0 - 2024-10-20
 
 - Deprecated all `Ref` subclasses. Instead, use `Ref` itself.
 - Deprecated `Ref`'s type argument. Use `Ref` without its generic parameter instead.

--- a/packages/hooks_riverpod/pubspec.yaml
+++ b/packages/hooks_riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks_riverpod
 description: >
   A reactive caching and data-binding framework.
   Riverpod makes working with asynchronous code a breeze.
-version: 2.5.4
+version: 2.6.0
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -18,8 +18,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks: '>=0.18.0 <0.22.0'
-  flutter_riverpod: ^2.5.3
-  riverpod: ^2.5.3
+  flutter_riverpod: 2.6.0
+  riverpod: 2.6.0
   state_notifier: ">=0.7.2 <2.0.0"
 
 dev_dependencies:

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased minor
+## 2.6.0 - 2024-10-20
 
 - Deprecated all `Ref` subclasses. Instead, use `Ref` itself.
 - Deprecated `Ref`'s type argument. Use `Ref` without its generic parameter instead.

--- a/packages/riverpod/pubspec.yaml
+++ b/packages/riverpod/pubspec.yaml
@@ -2,7 +2,7 @@ name: riverpod
 description: >
   A reactive caching and data-binding framework.
   Riverpod makes working with asynchronous code a breeze.
-version: 2.5.3
+version: 2.6.0
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues

--- a/packages/riverpod_annotation/CHANGELOG.md
+++ b/packages/riverpod_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.0 - 2024-10-20
+
+- `riverpod` upgraded to `2.6.0`
+
 ## 2.5.3 - 2024-10-12
 
 - `riverpod` upgraded to `2.5.3`

--- a/packages/riverpod_annotation/pubspec.yaml
+++ b/packages/riverpod_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_annotation
 description: A package exposing annotations for riverpod_generator
-version: 2.5.3
+version: 2.6.0
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
 funding:
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   meta: ^1.7.0
-  riverpod: 2.5.3
+  riverpod: 2.6.0
 
 dev_dependencies:
   test: ^1.21.0

--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased 2.6.0
+## 2.6.0 - 2024-10-20
 
 - Deprecated the generated `Ref` subclasses.
   Instead of:

--- a/packages/riverpod_generator/pubspec.yaml
+++ b/packages/riverpod_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_generator
 description: A code generator for Riverpod. This both simplifies the syntax empowers it, such as allowing stateful hot-reload.
-version: 2.4.4
+version: 2.6.0
 repository: https://github.com/rrousselGit/riverpod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
 funding:
@@ -17,12 +17,12 @@ dependencies:
   crypto: ^3.0.2
   meta: ^1.7.0
   path: ^1.8.0
-  riverpod_analyzer_utils: ^0.5.5
-  riverpod_annotation: 2.5.3
+  riverpod_analyzer_utils: 0.5.5
+  riverpod_annotation: 2.6.0
   source_gen: ^1.2.0
 
 dev_dependencies:
   build_runner: ^2.1.7
   build_verify: ^3.0.0
-  riverpod: 2.5.3
+  riverpod: 2.6.0
   test: ^1.21.0

--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased minor
+## 2.4.0 - 2024-10-20
 
 - `functional_ref` and its quick-fix now expect:
   ```dart

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_lint
 description: Riverpod_lint is a developer tool for users of Riverpod, designed to help stop common issues and simplify repetitive tasks.
-version: 2.3.14
+version: 2.4.0
 homepage: https://riverpod.dev
 repository: https://github.com/rrousselGit/river_pod
 issue_tracker: https://github.com/rrousselGit/riverpod/issues
@@ -17,8 +17,8 @@ dependencies:
   custom_lint_builder: ^0.6.5
   meta: ^1.7.0
   path: ^1.8.1
-  riverpod: ^2.5.3
-  riverpod_analyzer_utils: ^0.5.5
+  riverpod: 2.6.0
+  riverpod_analyzer_utils: 0.5.5
   source_span: ^1.8.0
   yaml: ^3.1.1
 


### PR DESCRIPTION
riverpod            : 2.5.3 -> 2.6.0
riverpod_annotation : 2.5.3 -> 2.6.0
riverpod_generator  : 2.4.4 -> 2.6.0
riverpod_lint       : 2.3.14 -> 2.4.0
flutter_riverpod    : 2.5.3 -> 2.6.0
hooks_riverpod      : 2.5.4 -> 2.6.0

## Related Issues

fixes #your-issue-number

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Version 2.6.0 (October 20, 2024)

- **New Features**
  - Introduced `Notifier.listenSelf` as a replacement for deprecated methods.
  - Updated methods to accept auto-dispose providers for enhanced resource management.

- **Deprecations**
  - Deprecated all `Ref` subclasses and their type arguments, encouraging direct use of `Ref`.
  - Deprecated `Ref.state` and `Ref.listenSelf` in favor of `Notifier`.

- **Bug Fixes & Improvements**
  - Various improvements to provider lifecycle management and error handling across packages.

- **Version Updates**
  - Incremented version numbers across multiple packages, including `flutter_riverpod`, `hooks_riverpod`, `riverpod`, and others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->