### PR TITLE
Export Ref type

### DIFF
--- a/packages/riverpod_annotation/CHANGELOG.md
+++ b/packages/riverpod_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- Export Ref type (thanks to @koji-1009)
+
 ## 2.6.0 - 2024-10-20
 
 - `riverpod` upgraded to `2.6.0`

--- a/packages/riverpod_annotation/lib/riverpod_annotation.dart
+++ b/packages/riverpod_annotation/lib/riverpod_annotation.dart
@@ -14,6 +14,7 @@ export 'package:riverpod/src/internals.dart'
         ProviderOverride,
         // ignore: invalid_use_of_internal_member, used by families for overrideWith
         FamilyOverride,
+        Ref,
 
         // Provider
         Provider,

--- a/packages/riverpod_generator/integration/build_yaml/lib/dependencies.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/dependencies.dart
@@ -1,4 +1,3 @@
-import 'package:riverpod/riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'main.dart';

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:riverpod/riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'main.g.dart';


### PR DESCRIPTION
## Related Issues

fixes #3791

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The `Ref` type has been made accessible through the `riverpod_annotation` package, enhancing usability for developers.
	- New providers (`count2`, `countFuture2`, `countStream2`) and notifiers (`CountNotifier2`, `CountAsyncNotifier2`, `CountStreamNotifier2`) have been introduced, allowing for more flexible state management with parameterized functionality.

- **Documentation**
	- The changelog has been updated to reflect the latest version (2.6.0) and includes a new entry for the `Ref` export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->