### PR TITLE
Added AsyncNotifier.listenSelf

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased 2.6.1
+
+- Added `AsyncNotifier.listenSelf`. It was mistakenly absent from the 2.6.0 release
+
 ## 2.6.0 - 2024-10-20
 
 - Deprecated all `Ref` subclasses. Instead, use `Ref` itself.

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased 2.6.1
+
+- Added `AsyncNotifier.listenSelf`. It was mistakenly absent from the 2.6.0 release
+
 ## 2.6.0 - 2024-10-20
 
 - Deprecated all `Ref` subclasses. Instead, use `Ref` itself.

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased 2.6.1
+
+- Added `AsyncNotifier.listenSelf`. It was mistakenly absent from the 2.6.0 release
+
 ## 2.6.0 - 2024-10-20
 
 - Deprecated all `Ref` subclasses. Instead, use `Ref` itself.

--- a/packages/riverpod/lib/src/async_notifier.dart
+++ b/packages/riverpod/lib/src/async_notifier.dart
@@ -33,6 +33,15 @@ abstract class AsyncNotifierBase<State> {
 
   void _setElement(ProviderElementBase<AsyncValue<State>> element);
 
+  /// {@macro notifier.listen}
+  void listenSelf(
+    void Function(AsyncValue<State>? previous, AsyncValue<State> next)
+        listener, {
+    void Function(Object error, StackTrace stackTrace)? onError,
+  }) {
+    _element.listenSelf(listener, onError: onError);
+  }
+
   /// The value currently exposed by this [AsyncNotifier].
   ///
   /// Defaults to [AsyncLoading] inside the [AsyncNotifier.build] method.

--- a/packages/riverpod/lib/src/notifier.dart
+++ b/packages/riverpod/lib/src/notifier.dart
@@ -21,6 +21,7 @@ abstract class NotifierBase<State> {
 
   void _setElement(ProviderElementBase<State> element);
 
+  /// {@template notifier.listen}
   /// Listens to changes on the value exposed by this provider.
   ///
   /// The listener will be called immediately after the provider completes building.
@@ -28,6 +29,7 @@ abstract class NotifierBase<State> {
   /// As opposed to [Ref.listen], the listener will be called even if
   /// [ProviderElementBase.updateShouldNotify] returns false, meaning that the previous
   /// and new value can potentially be identical.
+  /// {@endtemplate}
   void listenSelf(
     void Function(State? previous, State next) listener, {
     void Function(Object error, StackTrace stackTrace)? onError,


### PR DESCRIPTION
## Related Issues

fixes #3795

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `AsyncNotifier.listenSelf` and `Notifier.listenSelf` methods for enhanced state change notifications.
	- Updated `Ref.watch` to accept auto-dispose providers.

- **Deprecations**
	- Deprecated all `Ref` subclasses and type arguments.
	- Deprecated `Ref.listenSelf` and `Ref.state`, recommending `Notifier` as a replacement.

- **Bug Fixes**
	- Various improvements including better error handling and documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->