### PR TITLE
fix(riverpod_lint): correctly detects nested ref invocations

### DIFF
--- a/packages/riverpod_analyzer_utils/CHANGELOG.md
+++ b/packages/riverpod_analyzer_utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- Fixed analyzer to correctly detect nested RefInvocations when used as parameters (e.g., ref.watch(provider(ref.watch(...)))). This improves the accuracy of the analyzer's error detection for complex provider compositions. (thanks to @josh-burton)
+
 ## 0.5.7 - 2024-10-27
 
 - Support latest custom_lint

--- a/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/resolve_riverpod.dart
+++ b/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/resolve_riverpod.dart
@@ -110,6 +110,12 @@ mixin _ParseRefInvocationMixin on RecursiveAstVisitor<void> {
     final refInvocation = RefInvocation._parse(node, superCall: superCall);
     if (refInvocation != null) {
       visitRefInvocation(refInvocation);
+
+      for (final argument in refInvocation.node.argumentList.arguments
+          .whereType<InvocationExpression>()) {
+        argument.accept(this);
+      }
+
       // Don't call super as RefInvocation should already be recursive
       return;
     }

--- a/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/resolve_riverpod.dart
+++ b/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/resolve_riverpod.dart
@@ -124,6 +124,11 @@ mixin _ParseRefInvocationMixin on RecursiveAstVisitor<void> {
         WidgetRefInvocation._parse(node, superCall: superCall);
     if (widgetRefInvocation != null) {
       visitWidgetRefInvocation(widgetRefInvocation);
+
+      for (final argument in widgetRefInvocation.node.argumentList.arguments
+          .whereType<InvocationExpression>()) {
+        argument.accept(this);
+      }
       // Don't call super as WidgetRefInvocation should already be recursive
       return;
     }

--- a/packages/riverpod_analyzer_utils_tests/test/ref_invocation_test.dart
+++ b/packages/riverpod_analyzer_utils_tests/test/ref_invocation_test.dart
@@ -420,18 +420,26 @@ part 'foo.g.dart';
 
 final dep = FutureProvider((ref) => 0);
 final dep2 = FutureProvider.family((ref, int arg) => 0);
+final dep3 = FutureProvider.family((ref, int arg) => 0);
 
 final provider = Provider<int>((ref) {
   ref.read(dep2(ref.read(dep)));
 
   return 0;
 });
+
+final provider2 = Provider<int>((ref) {
+  ref.read(dep3(ref.read(dep2(ref.read(dep)))));
+
+  return 0;
+});
 ''', (resolver) async {
     final result = await resolver.resolveRiverpodAnalysisResult();
 
-    expect(result.refReadInvocations, hasLength(2));
+    expect(result.refReadInvocations, hasLength(5));
     expect(result.refInvocations, result.refReadInvocations);
 
+    // provider
     expect(
       result.refReadInvocations[0].node.toSource(),
       'ref.read(dep2(ref.read(dep)))',
@@ -452,6 +460,25 @@ final provider = Provider<int>((ref) {
         result.legacyProviderDeclarations.findByName('dep').providerElement,
       ),
     );
+
+    // provider2
+    expect(
+      result.refReadInvocations[2].node.toSource(),
+      'ref.read(dep3(ref.read(dep2(ref.read(dep)))))',
+    );
+    expect(result.refReadInvocations[2].function.toSource(), 'read');
+    expect(
+      result.refReadInvocations[2].provider.providerElement,
+      same(
+        result.legacyProviderDeclarations.findByName('dep3').providerElement,
+      ),
+    );
+
+    expect(
+      result.refReadInvocations[3].node.toSource(),
+      'ref.read(dep2(ref.read(dep)))',
+    );
+    expect(result.refReadInvocations[4].node.toSource(), 'ref.read(dep)');
   });
 
   testSource('Decodes unknown ref usages', source: '''
@@ -615,6 +642,123 @@ void fn(_Ref ref) {
     expect(
       result.refWatchInvocations[2].provider.familyArguments?.toSource(),
       '(id: 0)',
+    );
+  });
+
+  testSource('Decodes nested ref.watch invocations with family providers',
+      runGenerator: true, source: '''
+import 'package:riverpod/riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'foo.g.dart';
+
+final dep = FutureProvider((ref) => 0);
+final dep2 = FutureProvider.family((ref, int arg) => 0);
+final dep3 = FutureProvider.family((ref, int arg) => 0);
+
+final provider = Provider<int>((ref) {
+  ref.watch(dep2(ref.watch(dep)));
+
+  return 0;
+});
+
+final provider2 = Provider<int>((ref) {
+  ref.watch(dep3(ref.watch(dep2(ref.watch(dep)))));
+
+  return 0;
+});
+''', (resolver) async {
+    final result = await resolver.resolveRiverpodAnalysisResult();
+
+    expect(result.refWatchInvocations, hasLength(5));
+    expect(result.refInvocations, result.refWatchInvocations);
+
+    // provider
+    expect(
+      result.refWatchInvocations[0].node.toSource(),
+      'ref.watch(dep2(ref.watch(dep)))',
+    );
+    expect(result.refWatchInvocations[0].function.toSource(), 'watch');
+    expect(
+      result.refWatchInvocations[0].provider.providerElement,
+      same(
+        result.legacyProviderDeclarations.findByName('dep2').providerElement,
+      ),
+    );
+
+    expect(result.refWatchInvocations[1].node.toSource(), 'ref.watch(dep)');
+    expect(result.refWatchInvocations[1].function.toSource(), 'watch');
+    expect(
+      result.refWatchInvocations[1].provider.providerElement,
+      same(
+        result.legacyProviderDeclarations.findByName('dep').providerElement,
+      ),
+    );
+
+    // provider2
+    expect(
+      result.refWatchInvocations[2].node.toSource(),
+      'ref.watch(dep3(ref.watch(dep2(ref.watch(dep)))))',
+    );
+    expect(result.refWatchInvocations[2].function.toSource(), 'watch');
+    expect(
+      result.refWatchInvocations[2].provider.providerElement,
+      same(
+        result.legacyProviderDeclarations.findByName('dep3').providerElement,
+      ),
+    );
+
+    expect(
+      result.refWatchInvocations[3].node.toSource(),
+      'ref.watch(dep2(ref.watch(dep)))',
+    );
+    expect(result.refWatchInvocations[4].node.toSource(), 'ref.watch(dep)');
+  });
+
+  testSource('Decodes mix of nested ref.watch and ref.read invocations',
+      runGenerator: true, source: '''
+import 'package:riverpod/riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'foo.g.dart';
+
+final dep = FutureProvider((ref) => 0);
+final dep2 = FutureProvider.family((ref, int arg) => 0);
+
+final provider = Provider<int>((ref) {
+  ref.watch(dep2(ref.read(dep)));
+
+  return 0;
+});
+''', (resolver) async {
+    final result = await resolver.resolveRiverpodAnalysisResult();
+
+    expect(result.refWatchInvocations, hasLength(1));
+    expect(result.refReadInvocations, hasLength(1));
+    expect(
+      result.refInvocations,
+      [...result.refWatchInvocations, ...result.refReadInvocations],
+    );
+
+    expect(
+      result.refWatchInvocations[0].node.toSource(),
+      'ref.watch(dep2(ref.read(dep)))',
+    );
+    expect(result.refWatchInvocations[0].function.toSource(), 'watch');
+    expect(
+      result.refWatchInvocations[0].provider.providerElement,
+      same(
+        result.legacyProviderDeclarations.findByName('dep2').providerElement,
+      ),
+    );
+
+    expect(result.refReadInvocations[0].node.toSource(), 'ref.read(dep)');
+    expect(result.refReadInvocations[0].function.toSource(), 'read');
+    expect(
+      result.refReadInvocations[0].provider.providerElement,
+      same(
+        result.legacyProviderDeclarations.findByName('dep').providerElement,
+      ),
     );
   });
 

--- a/packages/riverpod_analyzer_utils_tests/test/widget_ref_invocation_test.dart
+++ b/packages/riverpod_analyzer_utils_tests/test/widget_ref_invocation_test.dart
@@ -609,6 +609,96 @@ void fn(_Ref ref) {
     );
   });
 
+  testSource('Decodes nested ref.watch invocations with family providers',
+      runGenerator: true, source: '''
+import 'package:riverpod/riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/material.dart';
+
+part 'foo.g.dart';
+
+final family = FutureProvider.family<int, int>((ref, id) => 0);
+
+@Riverpod(keepAlive: true)
+Future<int> family2(Family2Ref ref, {required int id}) async => 0;
+
+class MyWidget extends ConsumerWidget {
+  const MyWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(family(ref.read(family2Provider(id: 0))));
+    ref.watch(family2Provider(ref.watch(family(id: 0))));
+    return Container();
+  }
+}
+''', (resolver) async {
+    final result = await resolver.resolveRiverpodAnalysisResult();
+
+    final libraryResult = result.resolvedRiverpodLibraryResults.single;
+
+    expect(libraryResult.unknownRefInvocations, isEmpty);
+    expect(libraryResult.unknownWidgetRefInvocations, isEmpty);
+
+    final providerRefInvocations =
+        libraryResult.consumerWidgetDeclarations.single.widgetRefInvocations;
+
+    expect(result.widgetRefWatchInvocations, hasLength(3));
+    expect(result.widgetRefInvocations, providerRefInvocations);
+
+    expect(
+      result.widgetRefWatchInvocations[0].node.toSource(),
+      'ref.watch(family(ref.read(family2Provider(id: 0))))',
+    );
+    expect(result.widgetRefWatchInvocations[0].function.toSource(), 'watch');
+    expect(
+      result.widgetRefWatchInvocations[0].provider.node.toSource(),
+      'family(ref.read(family2Provider(id: 0)))',
+    );
+    expect(
+      result.widgetRefWatchInvocations[0].provider.provider?.toSource(),
+      'family',
+    );
+    expect(
+      result.widgetRefWatchInvocations[0].provider.providerElement,
+      same(
+        result.legacyProviderDeclarations.findByName('family').providerElement,
+      ),
+    );
+    expect(
+      result.widgetRefWatchInvocations[0].provider.familyArguments?.toSource(),
+      '(ref.read(family2Provider(id: 0)))',
+    );
+
+    // ref.watch(family2Provider(ref.watch(family(id: 0)));
+    expect(
+      result.widgetRefWatchInvocations[1].node.toSource(),
+      'ref.watch(family2Provider(ref.watch(family(id: 0))))',
+    );
+    expect(result.widgetRefWatchInvocations[1].function.toSource(), 'watch');
+    expect(
+      result.widgetRefWatchInvocations[1].provider.node.toSource(),
+      'family2Provider(ref.watch(family(id: 0)))',
+    );
+    expect(
+      result.widgetRefWatchInvocations[1].provider.provider?.toSource(),
+      'family2Provider',
+    );
+    expect(
+      result.widgetRefWatchInvocations[1].provider.providerElement,
+      same(
+        result.functionalProviderDeclarations
+            .findByName('family2')
+            .providerElement,
+      ),
+    );
+    expect(
+      result.widgetRefWatchInvocations[1].provider.familyArguments?.toSource(),
+      '(ref.watch(family(id: 0)))',
+    );
+  });
+
   testSource('Decodes provider.query ref.watch usages',
       runGenerator: true, source: r'''
 import 'package:riverpod/riverpod.dart';

--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- provider_dependencies now correctly detects nested ref invocations where a dependency is used as a parameter of another dependency (thanks to @josh-burton)
+
 ## 2.6.2 - 2024-10-27
 
 - Support latest custom_lint

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/provider_dependencies.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/provider_dependencies.dart
@@ -9,6 +9,9 @@ int dep(Ref ref) => 0;
 @Riverpod(dependencies: [])
 int dep2(Ref ref) => 0;
 
+@Riverpod(dependencies: [])
+int dep3(Ref ref, int parameter) => 0;
+
 ////////////
 
 // expect_lint: provider_dependencies
@@ -67,6 +70,18 @@ int multipleDeps(Ref ref) {
 )
 int extraDep(Ref ref) {
   ref.watch(dep2Provider);
+  return 0;
+}
+
+@Riverpod(
+  keepAlive: false,
+  // expect_lint: provider_dependencies
+  dependencies: [
+    dep3,
+  ],
+)
+int onFamilyDep(Ref ref) {
+  ref.read(dep3Provider(ref.read(dep2Provider)));
   return 0;
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/provider_dependencies.diff
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/provider_dependencies.diff
@@ -1,6 +1,6 @@
 Message: `Specify "dependencies"`
 Priority: 100
-Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:15`:
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:18`:
 ```
 
 // expect_lint: provider_dependencies
@@ -12,7 +12,7 @@ int plainAnnotation(Ref ref) {
 ---
 Message: `Specify "dependencies"`
 Priority: 100
-Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:22`:
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:25`:
 ```
 
 // expect_lint: provider_dependencies
@@ -24,7 +24,7 @@ int customAnnotation(Ref ref) {
 ---
 Message: `Specify "dependencies"`
 Priority: 100
-Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:30`:
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:33`:
 ```
 // expect_lint: provider_dependencies
 @Riverpod(
@@ -36,7 +36,7 @@ int customAnnotationWithTrailingComma(
 ---
 Message: `Update "dependencies"`
 Priority: 100
-Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:42`:
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:45`:
 ```
   keepAlive: false,
   // expect_lint: provider_dependencies
@@ -48,7 +48,7 @@ int existingDep(Ref ref) {
 ---
 Message: `Update "dependencies"`
 Priority: 100
-Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:52`:
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:55`:
 ```
   keepAlive: false,
   // expect_lint: provider_dependencies
@@ -60,7 +60,7 @@ int multipleDeps(Ref ref) {
 ---
 Message: `Update "dependencies"`
 Priority: 100
-Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:62`:
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:65`:
 ```
 @Riverpod(
   keepAlive: false,
@@ -74,9 +74,23 @@ Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:62`:
 int extraDep(Ref ref) {
 ```
 ---
+Message: `Update "dependencies"`
+Priority: 100
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:79`:
+```
+  keepAlive: false,
+  // expect_lint: provider_dependencies
+-   dependencies: [
+-     dep3,
+-   ],
++   dependencies: [dep3, dep2],
+)
+int onFamilyDep(Ref ref) {
+```
+---
 Message: `Remove "dependencies"`
 Priority: 100
-Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:75`:
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:90`:
 ```
 @Riverpod(
   keepAlive: false,
@@ -92,7 +106,7 @@ int noDep(Ref ref) {
 ---
 Message: `Remove "dependencies"`
 Priority: 100
-Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:85`:
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:100`:
 ```
 
 @Riverpod(
@@ -108,7 +122,7 @@ int dependenciesFirstThenKeepAlive(Ref ref) {
 ---
 Message: `Remove "dependencies"`
 Priority: 100
-Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:95`:
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:110`:
 ```
 }
 
@@ -125,7 +139,7 @@ int noDepNoParam(Ref ref) {
 ---
 Message: `Remove "dependencies"`
 Priority: 100
-Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:106`:
+Diff for file `test/lints/provider_dependencies/provider_dependencies.dart:121`:
 ```
 
 // expect_lint: provider_dependencies

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/provider_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/provider_dependencies.g.dart
@@ -38,6 +38,156 @@ final dep2Provider = AutoDisposeProvider<int>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef Dep2Ref = AutoDisposeProviderRef<int>;
+String _$dep3Hash() => r'bb6a5b0a89055bc25a5edfd22f8674cf8b1ce771';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [dep3].
+@ProviderFor(dep3)
+const dep3Provider = Dep3Family();
+
+/// See also [dep3].
+class Dep3Family extends Family<int> {
+  /// See also [dep3].
+  const Dep3Family();
+
+  /// See also [dep3].
+  Dep3Provider call(
+    int parameter,
+  ) {
+    return Dep3Provider(
+      parameter,
+    );
+  }
+
+  @override
+  Dep3Provider getProviderOverride(
+    covariant Dep3Provider provider,
+  ) {
+    return call(
+      provider.parameter,
+    );
+  }
+
+  static final Iterable<ProviderOrFamily> _dependencies =
+      const <ProviderOrFamily>[];
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static final Iterable<ProviderOrFamily> _allTransitiveDependencies =
+      const <ProviderOrFamily>{};
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'dep3Provider';
+}
+
+/// See also [dep3].
+class Dep3Provider extends AutoDisposeProvider<int> {
+  /// See also [dep3].
+  Dep3Provider(
+    int parameter,
+  ) : this._internal(
+          (ref) => dep3(
+            ref as Dep3Ref,
+            parameter,
+          ),
+          from: dep3Provider,
+          name: r'dep3Provider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product') ? null : _$dep3Hash,
+          dependencies: Dep3Family._dependencies,
+          allTransitiveDependencies: Dep3Family._allTransitiveDependencies,
+          parameter: parameter,
+        );
+
+  Dep3Provider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.parameter,
+  }) : super.internal();
+
+  final int parameter;
+
+  @override
+  Override overrideWith(
+    int Function(Dep3Ref provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: Dep3Provider._internal(
+        (ref) => create(ref as Dep3Ref),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        parameter: parameter,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeProviderElement<int> createElement() {
+    return _Dep3ProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is Dep3Provider && other.parameter == parameter;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, parameter.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin Dep3Ref on AutoDisposeProviderRef<int> {
+  /// The parameter `parameter` of this provider.
+  int get parameter;
+}
+
+class _Dep3ProviderElement extends AutoDisposeProviderElement<int>
+    with Dep3Ref {
+  _Dep3ProviderElement(super.provider);
+
+  @override
+  int get parameter => (origin as Dep3Provider).parameter;
+}
+
 String _$plainAnnotationHash() =>
     r'6a3d1f1f2e53902af56cd7ce6ceba17358690b70'; ////////////
 ///
@@ -145,6 +295,25 @@ final extraDepProvider = AutoDisposeProvider<int>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef ExtraDepRef = AutoDisposeProviderRef<int>;
+String _$onFamilyDepHash() => r'ad04da6286b3475658b531d9a7dd8a47f11c56f2';
+
+/// See also [onFamilyDep].
+@ProviderFor(onFamilyDep)
+final onFamilyDepProvider = AutoDisposeProvider<int>.internal(
+  onFamilyDep,
+  name: r'onFamilyDepProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$onFamilyDepHash,
+  dependencies: <ProviderOrFamily>[dep3Provider],
+  allTransitiveDependencies: <ProviderOrFamily>{
+    dep3Provider,
+    ...?dep3Provider.allTransitiveDependencies
+  },
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef OnFamilyDepRef = AutoDisposeProviderRef<int>;
 String _$noDepHash() => r'99022366e7dd3e19464747d1e2f23184691aa134';
 
 /// See also [noDep].

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/provider_dependencies_test.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/provider_dependencies_test.dart
@@ -14,7 +14,7 @@ void main() {
       final fix = lint.getFixes().single;
 
       final errors = await lint.testRun(result);
-      expect(errors, hasLength(10));
+      expect(errors, hasLength(11));
 
       final changes = await Future.wait([
         for (final error in errors) fix.testRun(result, error, errors),


### PR DESCRIPTION
RefInvocations that take as a parameter another RefInvocation are now correctly detected by the analyzer.

**Details**

In this situation: `ref.read(dep2(ref.read(dep)));`

The second provider dependency (`dep)` is not currently detected by analyzer and the provider_dependency lints.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced capabilities for analyzing nested provider invocations, improving accuracy in detecting complex provider compositions.
	- Introduced new provider functions and dependencies for better handling of family providers.

- **Bug Fixes**
	- Fixed issues with `provider_dependencies` to correctly detect nested reference invocations.
	- Improved analyzer's capability to detect nested `RefInvocations` used as parameters.

- **Tests**
	- Added multiple test cases to ensure accurate analysis of nested `ref.read` and `ref.watch` functionalities, including family providers.
	- Added a test for decoding nested `ref.watch` invocations with family providers.
	- Updated existing tests to reflect changes in expected behavior.

- **Documentation**
	- Updated changelogs for `riverpod_lint` and `riverpod_analyzer_utils` to reflect new features and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->