### PR TITLE
Introducing Riverpod Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <a href="https://github.com/rrousselgit/riverpod"><img src="https://img.shields.io/github/stars/rrousselgit/riverpod.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on Github"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
   <a href="https://discord.gg/Bbumvej"><img src="https://img.shields.io/discord/765557403865186374.svg?logo=discord&color=blue" alt="Discord"></a>
+  <a href="https://gurubase.io/g/riverpod"><img src="https://img.shields.io/badge/Gurubase-Ask%20Riverpod%20Guru-006BFF" alt="Gurubase"></a>
 
   <p>
     <a href="https://www.netlify.com">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Riverpod Guru](https://gurubase.io/g/riverpod) to Gurubase. Riverpod Guru uses the data from this repo and data from the [docs](https://riverpod.dev) to answer questions by leveraging the LLM.

In this PR, I showcased the "Riverpod Guru", which highlights that Riverpod now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Riverpod Guru in Gurubase, just let me know that's totally fine.
