### PR TITLE
Fix typo in the documentation

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- Fix typo in the documentation
+
 ## 2.6.1 - 2024-10-22
 
 - Added `AsyncNotifier.listenSelf`. It was mistakenly absent from the 2.6.0 release

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Unreleased fix
-
-- Fix typo in the documentation
-
 ## 2.6.1 - 2024-10-22
 
 - Added `AsyncNotifier.listenSelf`. It was mistakenly absent from the 2.6.0 release

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/about_hooks.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/about_hooks.mdx
@@ -38,7 +38,7 @@ Riverpod 때문에 훅(hooks)을 사용해서는 안됩니다. 오히려 훅(hoo
 이상적으로 향후에 Flutter를 위해 특별히 설계된 훅(hooks)이 해결하는 문제에 대한 솔루션이 있을 것입니다.
 
 Riverpod의 provider가 "전역(Global)" 애플리케이션 상태(State)를 위한 것이라면, 훅(Hooks)은 로컬 위젯 상태를 위한 것입니다. 
-훅(Hooks)dms 일반적으로 상태 저장형 UI 객체를 처리하는 데 사용됩니다,
+훅(Hooks)은 일반적으로 상태 저장형 UI 객체를 처리하는 데 사용됩니다,
 [TextEditingController](https://api.flutter.dev/flutter/widgets/TextEditingController-class.html),
 [AnimationController](https://api.flutter.dev/flutter/animation/AnimationController-class.html).  
 또한 "빌더(Builder)" 패턴을 대체하는 역할도 수행할 수 있는데,


### PR DESCRIPTION
## Related Issues

X, It's just a typo fix.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [X] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Fix typo in the documentation
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a typo in the Riverpod package changelog
	- Corrected a minor text error in the Korean documentation for hooks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->