### PR TITLE
Fix typo in missing_provider_scope.dart

### DIFF
--- a/packages/riverpod_lint/lib/src/lints/missing_provider_scope.dart
+++ b/packages/riverpod_lint/lib/src/lints/missing_provider_scope.dart
@@ -61,7 +61,7 @@ class AddProviderScope extends DartFix {
     List<AnalysisError> others,
   ) {
     context.registry.addMethodInvocation((node) {
-      // The method is not impacte by this analysis error
+      // The method is not impacted by this analysis error
       if (!node.sourceRange.intersects(analysisError.sourceRange)) return;
 
       final changeBuilder = reporter.createChangeBuilder(


### PR DESCRIPTION
No related issue. It just fixes a typo I saw in a comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a minor typographical error in a code comment for the `AddProviderScope` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->