### PR TITLE
Docs typo fix

### DIFF
--- a/packages/flutter_riverpod/lib/src/framework.dart
+++ b/packages/flutter_riverpod/lib/src/framework.dart
@@ -269,7 +269,7 @@ class ProviderScopeState extends State<ProviderScope> {
 /// {@template riverpod.UncontrolledProviderScope}
 /// Expose a [ProviderContainer] to the widget tree.
 ///
-/// This is what makes `ref.watch(`/`Consumer`/`ref.read` work.
+/// This is what makes `ref.watch`/`Consumer`/`ref.read` work.
 /// {@endtemplate}
 @sealed
 class UncontrolledProviderScope extends InheritedWidget {


### PR DESCRIPTION
## Related Issues

Docs typo fix on `UncontrolledProviderScope`.

## Checklist

  ```md
  ## Unreleased fix/major/minor

  - Docs typo fix on `UncontrolledProviderScope`. (thanks to @bqubique)
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Minor documentation comment update for `UncontrolledProviderScope` class
	- Improved clarity by correcting formatting in comment text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->