### PR TITLE
Bump dependencies

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -14,6 +14,7 @@ analyzer:
     # I prefer specifying a parameter on a widget even if they are unused (such as Key)
     # for the sake of consistency.
     unused_element_parameter: false
+    unrecognized_error_code: ignore
 
 linter:
   rules:

--- a/examples/marvel/analysis_options.yaml
+++ b/examples/marvel/analysis_options.yaml
@@ -9,3 +9,4 @@ analyzer:
     # I prefer specifying a parameter on a widget even if they are unused (such as Key)
     # for the sake of consistency.
     unused_element_parameter: false
+    unrecognized_error_code: ignore

--- a/packages/riverpod/pubspec.yaml
+++ b/packages/riverpod/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   state_notifier: ">=0.7.2 <2.0.0"
 
 dev_dependencies:
-  analyzer: ^6.7.0
+  analyzer: ^7.0.0
   expect_error: ^1.0.0
   mockito: ^5.0.0
   test: ^1.16.0

--- a/packages/riverpod/pubspec_overrides.yaml
+++ b/packages/riverpod/pubspec_overrides.yaml
@@ -1,3 +1,3 @@
 dependency_overrides:
   # necessary for mockito
-  analyzer: ^6.7.0
+  analyzer: ^7.0.0

--- a/packages/riverpod_analyzer_utils/CHANGELOG.md
+++ b/packages/riverpod_analyzer_utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+Support latest analyzer
+
 ## 0.5.8 - 2024-11-18
 
 - Fixed analyzer to correctly detect nested RefInvocations when used as parameters (e.g., ref.watch(provider(ref.watch(...)))). This improves the accuracy of the analyzer's error detection for complex provider compositions. (thanks to @josh-burton)

--- a/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/ref_invocation.dart
+++ b/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/ref_invocation.dart
@@ -21,8 +21,7 @@ abstract class RefInvocation extends RiverpodAst
     final functionOwner = function.staticElement
         .cast<MethodElement>()
         ?.declaration
-        // ignore: deprecated_member_use, necessary to support older versions of analyzer
-        .enclosingElement;
+        .enclosingElement3;
 
     if (functionOwner == null ||
         // Since Ref is sealed, checking that the function is from the package:riverpod

--- a/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/widget_ref_invocation.dart
+++ b/packages/riverpod_analyzer_utils/lib/src/riverpod_ast/widget_ref_invocation.dart
@@ -26,8 +26,7 @@ abstract class WidgetRefInvocation extends RiverpodAst
     final functionOwner = function.staticElement
         .cast<MethodElement>()
         ?.declaration
-        // ignore: deprecated_member_use, necessary to support older versions of analyzer
-        .enclosingElement;
+        .enclosingElement3;
 
     if (functionOwner == null ||
         // Since Ref is sealed, checking that the function is from the package:riverpod

--- a/packages/riverpod_analyzer_utils/pubspec.yaml
+++ b/packages/riverpod_analyzer_utils/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.7.0
+  analyzer: ^7.0.0
   collection: ^1.16.0
   crypto: ^3.0.2
   custom_lint_core: ^0.7.0

--- a/packages/riverpod_analyzer_utils_tests/pubspec.yaml
+++ b/packages/riverpod_analyzer_utils_tests/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.7.0
+  analyzer: ^7.0.0
   collection: ^1.16.0
   freezed_annotation: ^2.2.0
   meta: ^1.7.0

--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+Support latest analyzer
+
 ## 2.6.3 - 2024-11-18
 
 - `riverpod_analyzer_utils` upgraded to `0.5.8`

--- a/packages/riverpod_generator/pubspec.yaml
+++ b/packages/riverpod_generator/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.7.0
+  analyzer: ^7.0.0
   build: ^2.0.0
   build_config: ^1.0.0
   collection: ^1.15.0
@@ -19,7 +19,7 @@ dependencies:
   path: ^1.8.0
   riverpod_analyzer_utils: 0.5.8
   riverpod_annotation: 2.6.1
-  source_gen: ^1.2.0
+  source_gen: ^2.0.0
 
 dev_dependencies:
   build_runner: ^2.1.7

--- a/packages/riverpod_graph/lib/src/analyze.dart
+++ b/packages/riverpod_graph/lib/src/analyze.dart
@@ -683,10 +683,7 @@ class _ProviderName {
 /// Returns the name of the provider.
 _ProviderName _displayNameForProvider(VariableElement provider) {
   final providerName = provider.name;
-  final enclosingElementName = provider
-      // ignore: deprecated_member_use, necessary to support older versions of analyzer
-      .enclosingElement
-      ?.displayName;
+  final enclosingElementName = provider.enclosingElement3?.displayName;
   return _ProviderName(
     providerName: providerName,
     enclosingElementName: enclosingElementName ?? '',

--- a/packages/riverpod_graph/pubspec.yaml
+++ b/packages/riverpod_graph/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: ">=2.15.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.7.0
+  analyzer: ^7.0.0
   args: ^2.4.0
   collection: ^1.0.0
   path: ^1.8.2

--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+Support latest analyzer
+
 ## 2.6.3 - 2024-11-18
 
 - provider_dependencies now correctly detects nested ref invocations where a dependency is used as a parameter of another dependency (thanks to @josh-burton)

--- a/packages/riverpod_lint/lib/src/assists/convert_to_stateful_base_widget.dart
+++ b/packages/riverpod_lint/lib/src/assists/convert_to_stateful_base_widget.dart
@@ -291,10 +291,7 @@ class _ReplacementEditBuilder extends RecursiveAstVisitor<void> {
     }
     final element = node.staticElement;
     if (element is ExecutableElement &&
-        element
-                // ignore: deprecated_member_use, necessary to support older versions of analyzer
-                .enclosingElement ==
-            widgetClassElement &&
+        element.enclosingElement3 == widgetClassElement &&
         !elementsToMove.contains(element)) {
       final offset = node.offset;
       final qualifier =

--- a/packages/riverpod_lint/lib/src/assists/convert_to_stateless_base_widget.dart
+++ b/packages/riverpod_lint/lib/src/assists/convert_to_stateless_base_widget.dart
@@ -333,10 +333,7 @@ class _ReplacementEditBuilder extends RecursiveAstVisitor<void> {
     }
     final element = node.staticElement;
     if (element is ExecutableElement &&
-        element
-                // ignore: deprecated_member_use, necessary to support older versions of analyzer
-                .enclosingElement ==
-            widgetClassElement &&
+        element.enclosingElement3 == widgetClassElement &&
         !elementsToMove.contains(element)) {
       final parent = node.parent;
       if (parent is PrefixedIdentifier) {

--- a/packages/riverpod_lint/lib/src/lints/provider_parameters.dart
+++ b/packages/riverpod_lint/lib/src/lints/provider_parameters.dart
@@ -45,14 +45,10 @@ class ProviderParameters extends RiverpodLintRule {
           final instantiatedObject = value.constructorName.staticElement
               ?.applyRedirectedConstructors();
 
-          final operatorEqual = instantiatedObject
-              // ignore: deprecated_member_use, necessary to support older versions of analyzer
-              ?.enclosingElement
-              .recursiveGetMethod('==');
+          final operatorEqual =
+              instantiatedObject?.enclosingElement3.recursiveGetMethod('==');
 
-          final isEqualFromObjectMethod = operatorEqual
-              // ignore: deprecated_member_use, necessary to support older versions of analyzer
-              ?.enclosingElement
+          final isEqualFromObjectMethod = operatorEqual?.enclosingElement3
               .safeCast<ClassElement>()
               ?.thisType
               .isDartCoreObject;

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.7.0
-  analyzer_plugin: ^0.11.2
+  analyzer: ^7.0.0
+  analyzer_plugin: ^0.12.0
   collection: ^1.16.0
   custom_lint_builder: ^0.7.0
   meta: ^1.7.0

--- a/packages/riverpod_lint_flutter_test/pubspec_overrides.yaml
+++ b/packages/riverpod_lint_flutter_test/pubspec_overrides.yaml
@@ -14,3 +14,6 @@ dependency_overrides:
     path: ../riverpod_annotation
   riverpod_lint:
     path: ../riverpod_lint
+
+  # Fix flutter_test conflict for now
+  test_api: ^0.7.4

--- a/website/pubspec_overrides.yaml
+++ b/website/pubspec_overrides.yaml
@@ -12,7 +12,3 @@ dependency_overrides:
     path: ../packages/riverpod_generator
   riverpod_analyzer_utils:
     path: ../packages/riverpod_analyzer_utils
-
-  ## Needed due to Flutter not supporting 6.0.0 yet
-  analyzer: ^6.7.0
-  analyzer_plugin: ^0.11.3


### PR DESCRIPTION
## Related Issues

fixes #3909


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependencies**
	- Updated `analyzer` package to version 7.0.0 across multiple packages
	- Updated `source_gen` package to version 2.0.0 in `riverpod_generator`
	- Removed analyzer dependency overrides in website configuration
	- Added `test_api` dependency override in `riverpod_lint_flutter_test`

- **Configuration**
	- Added `unrecognized_error_code: ignore` in analysis options to improve linting flexibility

- **Changelog**
	- Added unreleased patch notes for upcoming analyzer support in multiple packages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->