### PR TITLE
fix: replaced invalid discord link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -76,7 +76,7 @@ module.exports = {
           items: [
             {
               label: "Discord",
-              href: "https://discord.gg/Bbumvej",
+              href: "https://discord.com/invite/riverpod-765557403865186374",
             },
             {
               label: "GitHub",


### PR DESCRIPTION
Current discord invitation link seems to be invalid / expired. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Discord community invitation link in the website footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->