### PR TITLE
Mark various APIs as internal

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unreleased patch
+## Unreleased minor
 
-Upgrade to Dart 3.6.0
+- Upgrade to Dart 3.6.0
+- Marked various APIs as `@internal`
 
 ## 2.6.1 - 2024-10-22
 

--- a/packages/flutter_riverpod/lib/flutter_riverpod.dart
+++ b/packages/flutter_riverpod/lib/flutter_riverpod.dart
@@ -1,3 +1,4 @@
+// ignore: invalid_export_of_internal_element, Already tackled by riverpod/riverpod.dart. If we export internals, that's on purpose.
 export 'package:riverpod/riverpod.dart';
 
 export 'src/change_notifier_provider.dart';

--- a/packages/flutter_riverpod/test/consumer_listen_test.dart
+++ b/packages/flutter_riverpod/test/consumer_listen_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_use_of_internal_member
+
 import 'package:flutter/material.dart' hide Listener;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter_riverpod/test/consumer_test.dart
+++ b/packages/flutter_riverpod/test/consumer_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_use_of_internal_member
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/src/internals.dart';

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unreleased patch
+## Unreleased minor
 
-Upgrade to Dart 3.6.0
+- Upgrade to Dart 3.6.0
+- Marked various APIs as `@internal`
 
 ## 2.6.1 - 2024-10-22
 

--- a/packages/hooks_riverpod/lib/hooks_riverpod.dart
+++ b/packages/hooks_riverpod/lib/hooks_riverpod.dart
@@ -1,3 +1,4 @@
+// ignore: invalid_export_of_internal_element, Already tackled by riverpod/riverpod.dart. If we export internals, that's on purpose.
 export 'package:flutter_riverpod/flutter_riverpod.dart';
 
 export 'src/consumer.dart';

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unreleased patch
+## Unreleased minor
 
-Upgrade to Dart 3.6.0
+- Upgrade to Dart 3.6.0
+- Marked various APIs as `@internal`
 
 ## 2.6.1 - 2024-10-22
 

--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -18,7 +18,21 @@ export 'src/async_notifier.dart'
         AutoDisposeFamilyStreamNotifierProviderImpl,
         StreamNotifierProviderBase,
         BuildlessAutoDisposeStreamNotifier,
-        BuildlessStreamNotifier;
+        BuildlessStreamNotifier,
+        AsyncNotifierProviderElement,
+        AsyncNotifierProviderElementBase,
+        StreamNotifierProviderElement,
+        AutoDisposeAsyncNotifierProviderElement,
+        AutoDisposeStreamNotifierProviderElement;
+
+// ignore: invalid_export_of_internal_element, For the sake of backward compatibility. Remove in 3.0
+export 'src/async_notifier.dart'
+    show
+        AsyncNotifierProviderElement,
+        AsyncNotifierProviderElementBase,
+        StreamNotifierProviderElement,
+        AutoDisposeAsyncNotifierProviderElement,
+        AutoDisposeStreamNotifierProviderElement;
 
 export 'src/common.dart' hide AsyncTransition;
 
@@ -50,9 +64,17 @@ export 'src/framework.dart'
         Create,
         Node,
         ProviderElementProxy,
-        OnError;
+        OnError,
+        ProviderElementBase;
 
-export 'src/future_provider.dart';
+// ignore: invalid_export_of_internal_element, For the sake of backward compatibility. Remove in 3.0
+export 'src/framework.dart' show ProviderElementBase;
+
+export 'src/future_provider.dart'
+    hide FutureProviderElement, AutoDisposeFutureProviderElement;
+// ignore: invalid_export_of_internal_element, For the sake of backward compatibility. Remove in 3.0
+export 'src/future_provider.dart'
+    show FutureProviderElement, AutoDisposeFutureProviderElement;
 
 export 'src/notifier.dart'
     hide
@@ -63,10 +85,33 @@ export 'src/notifier.dart'
         FamilyNotifierProviderImpl,
         NotifierProviderImpl,
         BuildlessAutoDisposeNotifier,
-        BuildlessNotifier;
+        BuildlessNotifier,
+        NotifierProviderElement,
+        AutoDisposeNotifierProviderElement;
+// ignore: invalid_export_of_internal_element, For the sake of backward compatibility. Remove in 3.0
+export 'src/notifier.dart'
+    show NotifierProviderElement, AutoDisposeNotifierProviderElement;
 
-export 'src/provider.dart' hide InternalProvider;
+export 'src/provider.dart'
+    hide InternalProvider, ProviderElement, AutoDisposeProviderElement;
+// ignore: invalid_export_of_internal_element, For the sake of backward compatibility. Remove in 3.0
+export 'src/provider.dart' show ProviderElement, AutoDisposeProviderElement;
+
 export 'src/state_controller.dart';
-export 'src/state_notifier_provider.dart';
-export 'src/state_provider.dart';
-export 'src/stream_provider.dart';
+export 'src/state_notifier_provider.dart'
+    hide StateNotifierProviderElement, AutoDisposeStateNotifierProviderElement;
+// ignore: invalid_export_of_internal_element, For the sake of backward compatibility. Remove in 3.0
+export 'src/state_notifier_provider.dart'
+    show StateNotifierProviderElement, AutoDisposeStateNotifierProviderElement;
+
+export 'src/state_provider.dart'
+    hide StateProviderElement, AutoDisposeStateProviderElement;
+// ignore: invalid_export_of_internal_element, For the sake of backward compatibility. Remove in 3.0
+export 'src/state_provider.dart'
+    show StateProviderElement, AutoDisposeStateProviderElement;
+
+export 'src/stream_provider.dart'
+    hide StreamProviderElement, AutoDisposeStreamProviderElement;
+// ignore: invalid_export_of_internal_element, For the sake of backward compatibility. Remove in 3.0
+export 'src/stream_provider.dart'
+    show StreamProviderElement, AutoDisposeStreamProviderElement;

--- a/packages/riverpod/lib/src/async_notifier/auto_dispose.dart
+++ b/packages/riverpod/lib/src/async_notifier/auto_dispose.dart
@@ -120,6 +120,7 @@ class AutoDisposeAsyncNotifierProviderImpl<
 }
 
 /// The element of [AutoDisposeAsyncNotifierProvider].
+@internal
 class AutoDisposeAsyncNotifierProviderElement<
         NotifierT extends AsyncNotifierBase<T>,
         T> extends AsyncNotifierProviderElement<NotifierT, T>

--- a/packages/riverpod/lib/src/async_notifier/auto_dispose.dart
+++ b/packages/riverpod/lib/src/async_notifier/auto_dispose.dart
@@ -90,6 +90,7 @@ class AutoDisposeAsyncNotifierProviderImpl<
   @override
   late final Refreshable<Future<T>> future = _asyncFuture<T>(this);
 
+  @internal
   @override
   AutoDisposeAsyncNotifierProviderElement<NotifierT, T> createElement() {
     return AutoDisposeAsyncNotifierProviderElement(this);

--- a/packages/riverpod/lib/src/async_notifier/auto_dispose_family.dart
+++ b/packages/riverpod/lib/src/async_notifier/auto_dispose_family.dart
@@ -68,6 +68,7 @@ class AutoDisposeFamilyAsyncNotifierProviderImpl<
   @override
   late final Refreshable<Future<T>> future = _asyncFuture<T>(this);
 
+  @internal
   @override
   AutoDisposeAsyncNotifierProviderElement<NotifierT, T> createElement() {
     return AutoDisposeAsyncNotifierProviderElement(this);

--- a/packages/riverpod/lib/src/async_notifier/base.dart
+++ b/packages/riverpod/lib/src/async_notifier/base.dart
@@ -135,6 +135,7 @@ class AsyncNotifierProviderImpl<NotifierT extends AsyncNotifierBase<T>, T>
   // ignore: deprecated_member_use_from_same_package
   late final AlwaysAliveRefreshable<Future<T>> future = _asyncFuture<T>(this);
 
+  @internal
   @override
   AsyncNotifierProviderElement<NotifierT, T> createElement() {
     return AsyncNotifierProviderElement(this);

--- a/packages/riverpod/lib/src/async_notifier/base.dart
+++ b/packages/riverpod/lib/src/async_notifier/base.dart
@@ -485,6 +485,7 @@ mixin FutureHandlerProviderElementMixin<T>
 }
 
 /// The element of [AsyncNotifierProvider].
+@internal
 abstract class AsyncNotifierProviderElementBase<
         NotifierT extends AsyncNotifierBase<T>,
         T> extends ProviderElementBase<AsyncValue<T>>
@@ -516,6 +517,7 @@ abstract class AsyncNotifierProviderElementBase<
 }
 
 /// The element of [AsyncNotifierProvider].
+@internal
 class AsyncNotifierProviderElement<NotifierT extends AsyncNotifierBase<T>, T>
     extends AsyncNotifierProviderElementBase<NotifierT, T>
     implements

--- a/packages/riverpod/lib/src/async_notifier/family.dart
+++ b/packages/riverpod/lib/src/async_notifier/family.dart
@@ -84,6 +84,7 @@ class FamilyAsyncNotifierProviderImpl<NotifierT extends AsyncNotifierBase<T>, T,
   // ignore: deprecated_member_use_from_same_package
   late final AlwaysAliveRefreshable<Future<T>> future = _asyncFuture<T>(this);
 
+  @internal
   @override
   AsyncNotifierProviderElement<NotifierT, T> createElement() {
     return AsyncNotifierProviderElement(this);

--- a/packages/riverpod/lib/src/framework/container.dart
+++ b/packages/riverpod/lib/src/framework/container.dart
@@ -216,7 +216,7 @@ class ProviderContainer implements Node {
     return element != null;
   }
 
-  /// Executes [ProviderElementBase.debugReassemble] on all the providers.
+  /// Executes hot-reload on all the providers.
   void debugReassemble() {
 // TODO hot-reload handle provider type change
 // TODO hot-reload handle provider response type change
@@ -383,6 +383,7 @@ class ProviderContainer implements Node {
     );
   }
 
+  @internal
   @override
   ProviderElementBase<State> readProviderElement<State>(
     ProviderBase<State> provider,
@@ -604,6 +605,7 @@ final b = Provider((ref) => ref.watch(a), dependencies: [a]);
   }
 
   /// Traverse the [ProviderElementBase]s associated with this [ProviderContainer].
+  @internal
   Iterable<ProviderElementBase> getAllProviderElements() sync* {
     for (final reader in _stateReaders.values) {
       if (reader._element != null && reader.container == this) {
@@ -617,6 +619,7 @@ final b = Provider((ref) => ref.watch(a), dependencies: [a]);
   /// This is fairly expensive and should be avoided as much as possible.
   /// If you do not need for providers to be sorted, consider using [getAllProviderElements]
   /// instead, which returns an unsorted list and is significantly faster.
+  @internal
   Iterable<ProviderElementBase> getAllProviderElementsInOrder() sync* {
     final visitedNodes = HashSet<ProviderElementBase>();
     final queue = DoubleLinkedQueue<ProviderElementBase>();

--- a/packages/riverpod/lib/src/framework/element.dart
+++ b/packages/riverpod/lib/src/framework/element.dart
@@ -45,6 +45,7 @@ void Function()? debugCanModifyProviders;
 /// Do not use.
 /// {@endtemplate}
 @optionalTypeArgs
+@internal
 abstract class ProviderElementBase<StateT> implements Ref<StateT>, Node {
   /// {@macro riverpod.provider_element_base}
   ProviderElementBase(this._provider);

--- a/packages/riverpod/lib/src/framework/foundation.dart
+++ b/packages/riverpod/lib/src/framework/foundation.dart
@@ -244,6 +244,7 @@ abstract class ProviderSubscription<State> {
   ///
   /// This is typically a [ProviderElementBase] or a [ProviderContainer],
   /// but may be other values in the future.
+  @internal
   final Node source;
 
   /// Whether the subscription is closed.

--- a/packages/riverpod/lib/src/framework/provider_base.dart
+++ b/packages/riverpod/lib/src/framework/provider_base.dart
@@ -113,7 +113,7 @@ abstract class ProviderBase<StateT> extends ProviderOrFamily
   }
 
   /// An internal method that defines how a provider behaves.
-  @visibleForOverriding
+  @internal
   @internal
   ProviderElementBase<StateT> createElement();
 

--- a/packages/riverpod/lib/src/framework/provider_base.dart
+++ b/packages/riverpod/lib/src/framework/provider_base.dart
@@ -114,7 +114,6 @@ abstract class ProviderBase<StateT> extends ProviderOrFamily
 
   /// An internal method that defines how a provider behaves.
   @internal
-  @internal
   ProviderElementBase<StateT> createElement();
 
   @override

--- a/packages/riverpod/lib/src/framework/provider_base.dart
+++ b/packages/riverpod/lib/src/framework/provider_base.dart
@@ -114,6 +114,7 @@ abstract class ProviderBase<StateT> extends ProviderOrFamily
 
   /// An internal method that defines how a provider behaves.
   @visibleForOverriding
+  @internal
   ProviderElementBase<StateT> createElement();
 
   @override

--- a/packages/riverpod/lib/src/framework/ref.dart
+++ b/packages/riverpod/lib/src/framework/ref.dart
@@ -83,7 +83,7 @@ abstract class Ref<
   /// The listener will be called immediately after the provider completes building.
   ///
   /// As opposed to [listen], the listener will be called even if
-  /// [ProviderElementBase.updateShouldNotify] returns false, meaning that the previous
+  /// `updateShouldNotify` returns false, meaning that the previous
   /// and new value can potentially be identical.
   @Deprecated('Will be removed in 3.0. Use Notifier.listenSelf instead')
   void listenSelf(

--- a/packages/riverpod/lib/src/framework/selector.dart
+++ b/packages/riverpod/lib/src/framework/selector.dart
@@ -2,6 +2,7 @@ part of '../framework.dart';
 
 /// An abstraction of both [ProviderContainer] and [ProviderElement] used by
 /// [ProviderListenable].
+@internal
 abstract class Node {
   /// Starts listening to a listenable
   ProviderSubscription<State> listen<State>(

--- a/packages/riverpod/lib/src/framework/value_provider.dart
+++ b/packages/riverpod/lib/src/framework/value_provider.dart
@@ -28,6 +28,7 @@ class ValueProvider<State> extends ProviderBase<State>
   @override
   Set<ProviderOrFamily>? get allTransitiveDependencies => null;
 
+  @internal
   @override
   ValueProviderElement<State> createElement() {
     return ValueProviderElement(this);

--- a/packages/riverpod/lib/src/future_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/future_provider/auto_dispose.dart
@@ -74,6 +74,7 @@ class AutoDisposeFutureProvider<T> extends _FutureProviderBase<T>
 }
 
 /// The [ProviderElementBase] of [AutoDisposeFutureProvider]
+@internal
 class AutoDisposeFutureProviderElement<T> extends FutureProviderElement<T>
     with
         AutoDisposeProviderElementMixin<AsyncValue<T>>

--- a/packages/riverpod/lib/src/future_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/future_provider/auto_dispose.dart
@@ -45,6 +45,7 @@ class AutoDisposeFutureProvider<T> extends _FutureProviderBase<T>
   FutureOr<T> _create(AutoDisposeFutureProviderElement<T> ref) =>
       _createFn(ref);
 
+  @internal
   @override
   AutoDisposeFutureProviderElement<T> createElement() {
     return AutoDisposeFutureProviderElement(this);

--- a/packages/riverpod/lib/src/future_provider/base.dart
+++ b/packages/riverpod/lib/src/future_provider/base.dart
@@ -92,6 +92,7 @@ class FutureProvider<T> extends _FutureProviderBase<T>
 }
 
 /// The element of a [FutureProvider]
+@internal
 class FutureProviderElement<T> extends ProviderElementBase<AsyncValue<T>>
     with
         FutureHandlerProviderElementMixin<T>

--- a/packages/riverpod/lib/src/future_provider/base.dart
+++ b/packages/riverpod/lib/src/future_provider/base.dart
@@ -70,6 +70,7 @@ class FutureProvider<T> extends _FutureProviderBase<T>
   @override
   FutureOr<T> _create(FutureProviderElement<T> ref) => _createFn(ref);
 
+  @internal
   @override
   FutureProviderElement<T> createElement() => FutureProviderElement(this);
 

--- a/packages/riverpod/lib/src/notifier.dart
+++ b/packages/riverpod/lib/src/notifier.dart
@@ -27,7 +27,7 @@ abstract class NotifierBase<State> {
   /// The listener will be called immediately after the provider completes building.
   ///
   /// As opposed to [Ref.listen], the listener will be called even if
-  /// [ProviderElementBase.updateShouldNotify] returns false, meaning that the previous
+  /// [updateShouldNotify] returns false, meaning that the previous
   /// and new value can potentially be identical.
   /// {@endtemplate}
   void listenSelf(

--- a/packages/riverpod/lib/src/notifier/auto_dispose.dart
+++ b/packages/riverpod/lib/src/notifier/auto_dispose.dart
@@ -112,6 +112,7 @@ class AutoDisposeNotifierProviderImpl<NotifierT extends NotifierBase<T>, T>
 }
 
 /// The element of [AutoDisposeNotifierProvider]
+@internal
 class AutoDisposeNotifierProviderElement<NotifierT extends NotifierBase<T>, T>
     extends NotifierProviderElement<NotifierT, T>
     with

--- a/packages/riverpod/lib/src/notifier/auto_dispose.dart
+++ b/packages/riverpod/lib/src/notifier/auto_dispose.dart
@@ -82,6 +82,7 @@ class AutoDisposeNotifierProviderImpl<NotifierT extends NotifierBase<T>, T>
   @override
   late final Refreshable<NotifierT> notifier = _notifier<NotifierT, T>(this);
 
+  @internal
   @override
   AutoDisposeNotifierProviderElement<NotifierT, T> createElement() {
     return AutoDisposeNotifierProviderElement(this);

--- a/packages/riverpod/lib/src/notifier/auto_dispose_family.dart
+++ b/packages/riverpod/lib/src/notifier/auto_dispose_family.dart
@@ -64,6 +64,7 @@ class AutoDisposeFamilyNotifierProviderImpl<NotifierT extends NotifierBase<T>,
   @override
   late final Refreshable<NotifierT> notifier = _notifier<NotifierT, T>(this);
 
+  @internal
   @override
   AutoDisposeNotifierProviderElement<NotifierT, T> createElement() {
     return AutoDisposeNotifierProviderElement(this);

--- a/packages/riverpod/lib/src/notifier/base.dart
+++ b/packages/riverpod/lib/src/notifier/base.dart
@@ -185,6 +185,7 @@ class NotifierProviderImpl<NotifierT extends NotifierBase<T>, T>
 }
 
 /// The element of [NotifierProvider].
+@internal
 class NotifierProviderElement<NotifierT extends NotifierBase<T>, T>
     extends ProviderElementBase<T>
     implements

--- a/packages/riverpod/lib/src/notifier/base.dart
+++ b/packages/riverpod/lib/src/notifier/base.dart
@@ -150,6 +150,7 @@ class NotifierProviderImpl<NotifierT extends NotifierBase<T>, T>
   /// {@macro riverpod.family}
   static const family = NotifierProviderFamilyBuilder();
 
+  @internal
   @override
   NotifierProviderElement<NotifierT, T> createElement() {
     return NotifierProviderElement(this);

--- a/packages/riverpod/lib/src/notifier/family.dart
+++ b/packages/riverpod/lib/src/notifier/family.dart
@@ -71,6 +71,7 @@ class FamilyNotifierProviderImpl<NotifierT extends NotifierBase<T>, T, Arg>
   late final AlwaysAliveRefreshable<NotifierT> notifier =
       _notifier<NotifierT, T>(this);
 
+  @internal
   @override
   NotifierProviderElement<NotifierT, T> createElement() {
     return NotifierProviderElement(this);

--- a/packages/riverpod/lib/src/provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/provider/auto_dispose.dart
@@ -41,6 +41,7 @@ class AutoDisposeProvider<T> extends InternalProvider<T> {
   @override
   T _create(AutoDisposeProviderElement<T> ref) => _createFn(ref);
 
+  @internal
   @override
   AutoDisposeProviderElement<T> createElement() {
     return AutoDisposeProviderElement(this);

--- a/packages/riverpod/lib/src/provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/provider/auto_dispose.dart
@@ -67,6 +67,7 @@ class AutoDisposeProvider<T> extends InternalProvider<T> {
 }
 
 /// The element of [AutoDisposeProvider]
+@internal
 class AutoDisposeProviderElement<T> extends ProviderElement<T>
     with
         AutoDisposeProviderElementMixin<T>

--- a/packages/riverpod/lib/src/provider/base.dart
+++ b/packages/riverpod/lib/src/provider/base.dart
@@ -324,6 +324,7 @@ class Provider<State> extends InternalProvider<State>
 ///   when that provider is no longer listened to.
 /// - [Provider.family], to allow providers to create a value from external parameters.
 /// {@endtemplate}
+@internal
 class ProviderElement<State> extends ProviderElementBase<State>
     implements
         // ignore: deprecated_member_use_from_same_package

--- a/packages/riverpod/lib/src/provider/base.dart
+++ b/packages/riverpod/lib/src/provider/base.dart
@@ -58,6 +58,7 @@ class Provider<State> extends InternalProvider<State>
   @override
   State _create(ProviderElement<State> ref) => _createFn(ref);
 
+  @internal
   @override
   ProviderElement<State> createElement() => ProviderElement(this);
 

--- a/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
@@ -77,6 +77,7 @@ class AutoDisposeStateNotifierProvider<NotifierT extends StateNotifier<T>, T>
 }
 
 /// The element of [AutoDisposeStateNotifierProvider].
+@internal
 class AutoDisposeStateNotifierProviderElement<
         NotifierT extends StateNotifier<T>,
         T> extends StateNotifierProviderElement<NotifierT, T>

--- a/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/auto_dispose.dart
@@ -48,6 +48,7 @@ class AutoDisposeStateNotifierProvider<NotifierT extends StateNotifier<T>, T>
     return _createFn(ref);
   }
 
+  @internal
   @override
   AutoDisposeStateNotifierProviderElement<NotifierT, T> createElement() {
     return AutoDisposeStateNotifierProviderElement._(this);

--- a/packages/riverpod/lib/src/state_notifier_provider/base.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/base.dart
@@ -119,6 +119,7 @@ class StateNotifierProvider<NotifierT extends StateNotifier<T>, T>
     return _createFn(ref);
   }
 
+  @internal
   @override
   StateNotifierProviderElement<NotifierT, T> createElement() {
     return StateNotifierProviderElement._(this);

--- a/packages/riverpod/lib/src/state_notifier_provider/base.dart
+++ b/packages/riverpod/lib/src/state_notifier_provider/base.dart
@@ -149,6 +149,7 @@ class StateNotifierProvider<NotifierT extends StateNotifier<T>, T>
 }
 
 /// The element of [StateNotifierProvider].
+@internal
 class StateNotifierProviderElement<NotifierT extends StateNotifier<T>, T>
     extends ProviderElementBase<T>
     implements

--- a/packages/riverpod/lib/src/state_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_provider/auto_dispose.dart
@@ -78,6 +78,7 @@ class AutoDisposeStateProvider<T> extends _StateProviderBase<T> {
 }
 
 /// The element of [StateProvider].
+@internal
 class AutoDisposeStateProviderElement<T> extends StateProviderElement<T>
     with
         AutoDisposeProviderElementMixin<T>

--- a/packages/riverpod/lib/src/state_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/state_provider/auto_dispose.dart
@@ -42,6 +42,7 @@ class AutoDisposeStateProvider<T> extends _StateProviderBase<T> {
   @override
   T _create(AutoDisposeStateProviderElement<T> ref) => _createFn(ref);
 
+  @internal
   @override
   AutoDisposeStateProviderElement<T> createElement() {
     return AutoDisposeStateProviderElement._(this);

--- a/packages/riverpod/lib/src/state_provider/base.dart
+++ b/packages/riverpod/lib/src/state_provider/base.dart
@@ -84,6 +84,7 @@ class StateProvider<T> extends _StateProviderBase<T>
   @override
   T _create(StateProviderElement<T> ref) => _createFn(ref);
 
+  @internal
   @override
   StateProviderElement<T> createElement() => StateProviderElement._(this);
 

--- a/packages/riverpod/lib/src/state_provider/base.dart
+++ b/packages/riverpod/lib/src/state_provider/base.dart
@@ -120,6 +120,7 @@ class StateProvider<T> extends _StateProviderBase<T>
 }
 
 /// The element of [StateProvider].
+@internal
 class StateProviderElement<T> extends ProviderElementBase<T>
     implements
         // ignore: deprecated_member_use_from_same_package

--- a/packages/riverpod/lib/src/stream_notifier/auto_dispose.dart
+++ b/packages/riverpod/lib/src/stream_notifier/auto_dispose.dart
@@ -114,6 +114,7 @@ class AutoDisposeStreamNotifierProviderImpl<
 }
 
 /// The element of [AutoDisposeStreamNotifierProvider].
+@internal
 class AutoDisposeStreamNotifierProviderElement<
         NotifierT extends AsyncNotifierBase<T>,
         T> extends StreamNotifierProviderElement<NotifierT, T>

--- a/packages/riverpod/lib/src/stream_notifier/auto_dispose.dart
+++ b/packages/riverpod/lib/src/stream_notifier/auto_dispose.dart
@@ -83,6 +83,7 @@ class AutoDisposeStreamNotifierProviderImpl<
   @override
   late final Refreshable<Future<T>> future = _streamFuture<T>(this);
 
+  @internal
   @override
   AutoDisposeStreamNotifierProviderElement<NotifierT, T> createElement() {
     return AutoDisposeStreamNotifierProviderElement(this);

--- a/packages/riverpod/lib/src/stream_notifier/auto_dispose_family.dart
+++ b/packages/riverpod/lib/src/stream_notifier/auto_dispose_family.dart
@@ -63,6 +63,7 @@ class AutoDisposeFamilyStreamNotifierProviderImpl<
   @override
   late final Refreshable<Future<T>> future = _streamFuture<T>(this);
 
+  @internal
   @override
   AutoDisposeStreamNotifierProviderElement<NotifierT, T> createElement() {
     return AutoDisposeStreamNotifierProviderElement(this);

--- a/packages/riverpod/lib/src/stream_notifier/base.dart
+++ b/packages/riverpod/lib/src/stream_notifier/base.dart
@@ -137,6 +137,7 @@ class StreamNotifierProviderImpl<NotifierT extends AsyncNotifierBase<T>, T>
 }
 
 /// The element of [StreamNotifierProvider].
+@internal
 class StreamNotifierProviderElement<NotifierT extends AsyncNotifierBase<T>, T>
     extends AsyncNotifierProviderElementBase<NotifierT, T>
     implements

--- a/packages/riverpod/lib/src/stream_notifier/base.dart
+++ b/packages/riverpod/lib/src/stream_notifier/base.dart
@@ -106,6 +106,7 @@ class StreamNotifierProviderImpl<NotifierT extends AsyncNotifierBase<T>, T>
   // ignore: deprecated_member_use_from_same_package
   late final AlwaysAliveRefreshable<Future<T>> future = _streamFuture<T>(this);
 
+  @internal
   @override
   StreamNotifierProviderElement<NotifierT, T> createElement() {
     return StreamNotifierProviderElement(this);

--- a/packages/riverpod/lib/src/stream_notifier/family.dart
+++ b/packages/riverpod/lib/src/stream_notifier/family.dart
@@ -80,6 +80,7 @@ class FamilyStreamNotifierProviderImpl<NotifierT extends AsyncNotifierBase<T>,
   // ignore: deprecated_member_use_from_same_package
   late final AlwaysAliveRefreshable<Future<T>> future = _streamFuture<T>(this);
 
+  @internal
   @override
   StreamNotifierProviderElement<NotifierT, T> createElement() {
     return StreamNotifierProviderElement(this);

--- a/packages/riverpod/lib/src/stream_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/stream_provider/auto_dispose.dart
@@ -79,6 +79,7 @@ class AutoDisposeStreamProvider<T> extends _StreamProviderBase<T>
 }
 
 /// The element of [AutoDisposeStreamProvider].
+@internal
 class AutoDisposeStreamProviderElement<T> extends StreamProviderElement<T>
     with
         AutoDisposeProviderElementMixin<AsyncValue<T>>

--- a/packages/riverpod/lib/src/stream_provider/auto_dispose.dart
+++ b/packages/riverpod/lib/src/stream_provider/auto_dispose.dart
@@ -43,6 +43,7 @@ class AutoDisposeStreamProvider<T> extends _StreamProviderBase<T>
   @override
   Stream<T> _create(AutoDisposeStreamProviderElement<T> ref) => _createFn(ref);
 
+  @internal
   @override
   AutoDisposeStreamProviderElement<T> createElement() {
     return AutoDisposeStreamProviderElement(this);

--- a/packages/riverpod/lib/src/stream_provider/base.dart
+++ b/packages/riverpod/lib/src/stream_provider/base.dart
@@ -124,6 +124,7 @@ class StreamProvider<T> extends _StreamProviderBase<T>
   @override
   Stream<T> _create(StreamProviderElement<T> ref) => _createFn(ref);
 
+  @internal
   @override
   StreamProviderElement<T> createElement() => StreamProviderElement(this);
 

--- a/packages/riverpod/lib/src/stream_provider/base.dart
+++ b/packages/riverpod/lib/src/stream_provider/base.dart
@@ -147,6 +147,7 @@ class StreamProvider<T> extends _StreamProviderBase<T>
 }
 
 /// The element of [StreamProvider].
+@internal
 class StreamProviderElement<T> extends ProviderElementBase<AsyncValue<T>>
     with
         FutureHandlerProviderElementMixin<T>

--- a/packages/riverpod_annotation/CHANGELOG.md
+++ b/packages/riverpod_annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased minor
+
+- Upgrade to Dart 3.6.0
+- Marked various APIs as `@internal`
+
 ## 2.6.1 - 2024-10-22
 
 - `riverpod` upgraded to `2.6.1`

--- a/packages/riverpod_annotation/lib/riverpod_annotation.dart
+++ b/packages/riverpod_annotation/lib/riverpod_annotation.dart
@@ -24,7 +24,9 @@ export 'package:riverpod/src/internals.dart'
         AutoDisposeProviderFamily,
         // ignore: deprecated_member_use
         AutoDisposeProviderRef,
+        // ignore: invalid_use_of_internal_member
         ProviderElement,
+        // ignore: invalid_use_of_internal_member
         AutoDisposeProviderElement,
 
         // FutureProvider
@@ -36,7 +38,9 @@ export 'package:riverpod/src/internals.dart'
         AutoDisposeFutureProviderFamily,
         // ignore: deprecated_member_use
         AutoDisposeFutureProviderRef,
+        // ignore: invalid_use_of_internal_member
         FutureProviderElement,
+        // ignore: invalid_use_of_internal_member
         AutoDisposeFutureProviderElement,
 
         // StreamProvider
@@ -48,7 +52,9 @@ export 'package:riverpod/src/internals.dart'
         AutoDisposeStreamProviderFamily,
         // ignore: deprecated_member_use
         AutoDisposeStreamProviderRef,
+        // ignore: invalid_use_of_internal_member
         StreamProviderElement,
+        // ignore: invalid_use_of_internal_member
         AutoDisposeStreamProviderElement,
 
         // AsyncValue
@@ -61,7 +67,9 @@ export 'package:riverpod/src/internals.dart'
         // Notifier
         Notifier,
         AutoDisposeNotifier,
+        // ignore: invalid_use_of_internal_member
         NotifierProviderElement,
+        // ignore: invalid_use_of_internal_member
         AutoDisposeNotifierProviderElement,
         // ignore: invalid_use_of_internal_member
         NotifierProviderImpl,
@@ -81,7 +89,9 @@ export 'package:riverpod/src/internals.dart'
         // AsyncNotifier
         AsyncNotifier,
         AutoDisposeAsyncNotifier,
+        // ignore: invalid_use_of_internal_member
         AsyncNotifierProviderElement,
+        // ignore: invalid_use_of_internal_member
         AutoDisposeAsyncNotifierProviderElement,
         // ignore: invalid_use_of_internal_member
         AsyncNotifierProviderImpl,
@@ -101,7 +111,9 @@ export 'package:riverpod/src/internals.dart'
         // StreamNotifier
         StreamNotifier,
         AutoDisposeStreamNotifier,
+        // ignore: invalid_use_of_internal_member
         StreamNotifierProviderElement,
+        // ignore: invalid_use_of_internal_member
         AutoDisposeStreamNotifierProviderElement,
         // ignore: invalid_use_of_internal_member
         StreamNotifierProviderImpl,

--- a/packages/riverpod_annotation/pubspec.yaml
+++ b/packages/riverpod_annotation/pubspec.yaml
@@ -7,7 +7,7 @@ funding:
   - https://github.com/sponsors/rrousselGit/
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
   meta: ^1.7.0

--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased minor
+
+- Upgrade to Dart 3.6.0
+- Marked various APIs as `@internal`
+
+
 ## 2.6.5 - 2025-02-28
 
 - `riverpod_analyzer_utils` upgraded to `0.5.10`

--- a/packages/riverpod_generator/pubspec.yaml
+++ b/packages/riverpod_generator/pubspec.yaml
@@ -7,7 +7,7 @@ funding:
   - https://github.com/sponsors/rrousselGit/
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
   analyzer: ^7.0.0

--- a/packages/riverpod_generator/test/auto_dispose_test.dart
+++ b/packages/riverpod_generator/test/auto_dispose_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: omit_local_variable_types, unused_local_variable
+// ignore_for_file: omit_local_variable_types, unused_local_variable, invalid_use_of_internal_member
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Changelogs have been updated to reflect a transition to an "Unreleased minor" release with notes on the Dart 3.6.0 upgrade.
  
- **Chores**
  - Updated minimum Dart SDK requirements and various internal API markers.
  - Adjusted export guidelines and linting directives in test files to streamline development.

All public-facing functionalities remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->