### PR TITLE
Add website translation for zh-Hant (Traditional Chinese)

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,7 +9,7 @@ module.exports = {
   trailingSlash: false,
   i18n: {
     defaultLocale: "en",
-    locales: ["en", "fr", "ko", "ja", "es", "bn", "de", "it", "ru", "tr", "zh-Hans"],
+    locales: ["en", "fr", "ko", "ja", "es", "bn", "de", "it", "ru", "tr", "zh-Hans", "zh-Hant"],
   },
   themeConfig: {
     algolia: {

--- a/website/i18n/zh-Hant/code.json
+++ b/website/i18n/zh-Hant/code.json
@@ -1,0 +1,497 @@
+{
+  "home.shared_state_title": {
+    "message": "隨處宣告共享狀態"
+  },
+  "home.shared_state_body": {
+    "message": "無需在 {main} 和 UI 檔案之間來回切換。 {br}{br} 只要將共享狀態的程式碼放在它所屬位置上，無論是放在獨立的 package 中，還是需要它的 widget 旁，都不會丟失可測試性。",
+    "description": "The homepage input placeholder"
+  },
+  "home.recompute_title": {
+    "message": "按需更新狀態和重繪 UI"
+  },
+  "home.recompute_body": {
+    "message": "不必在 {build} 方法中執行列表排序或過濾，也不必依賴高階的快取機制。{br} {br} 使用組合提供者 {Provider} 和 {families} 方法，在你真正需要的時候才去發起 HTTP 請求或者排序列表。"
+  },
+  "home.refactors_title": {
+    "message": "透過重構簡化日常工作"
+  },
+  "home.refactors_body": {
+    "message": "Riverpod 提供了多種重構提示, 例如 \"Wrap widget in a Consumer\" 等等。 請參閱 {warnings}."
+  },
+  "home.refactors_list_link": {
+    "message": "重構提示列表"
+  },
+  "home.lint_title": {
+    "message": "使用 lint 規則保持程式碼可維護"
+  },
+  "home.lint_body": {
+    "message": "實現了 Riverpod 定製的 lint 新規則，並且還會不斷新增更多規則。這可確保您的程式碼保持最佳狀態。請參閱 {warnings}。"
+  },
+  "home.lint_rules_list_link": {
+    "message": "lint 規則列表"
+  },
+  "home.safe_read_title": {
+    "message": "安全的讀取 providers"
+  },
+  "home.safe_read_body": {
+    "message": "讀取 provider 永遠不會導致異常的狀態。如果你編寫了讀取一個 provider 所需的程式碼，你將得到一個符合預期的值。 {br} {br}這甚至適用於非同步載入的值。與 provider 相反，Riverpod 允許簡潔地處理 loading/error 狀態。"
+  },
+  "home.devtool_title": {
+    "message": "在 DevTools 中檢查你的狀態"
+  },
+  "home.devtool_body": {
+    "message": "使用了 Riverpod，你的狀態將可以在 Flutter 自帶的 DevTools 中一目瞭然。 {br} {br} 此外，一款全面的狀態檢查工具正在開發中……"
+  },
+  "homepage.declarative_title": {
+    "message": "宣告式程式設計"
+  },
+  "homepage.declarative_body": {
+    "message": "以類似於無狀態小部件的方式編寫業務邏輯。{br} 讓您的網路請求在必要時自動重新計算，並使您的邏輯易於重用、組合、維護。"
+  },
+  "homepage.common_ui_patterns_title": {
+    "message": "輕鬆實現常見的 UI 模式"
+  },
+  "homepage.common_ui_patterns_body": {
+    "message": "使用 Riverpod，只需幾行程式碼即可實現常見但複雜的 UI 模式，例如“下拉重新整理”、“即時搜尋”等。"
+  },
+  "homepage.tooling_ready_title": {
+    "message": "工具準備就緒"
+  },
+  "homepage.tooling_ready_body": {
+    "message": "Riverpod 透過將常見錯誤作為編譯錯誤來增強編譯器。 它還提供自定義 lint 規則和重構選項。 它甚至有一個用於生成文件的命令列。"
+  },
+  "homepage.features_title": {
+    "message": "特性"
+  },
+  "home.tagline": {
+    "message": "響應式快取和資料繫結框架"
+  },
+  "home.get_started": {
+    "message": "入門指南"
+  },
+  "home.create_provider": {
+    "message": "建立一個網路請求"
+  },
+  "home.consume_provider": {
+    "message": "在你的使用者介面監聽網路請求"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "此為 {siteTitle} {versionLabel} 版尚未發行的文件。",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "此為 {siteTitle} {versionLabel} 版的文件，現已不再積極維護。",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "最新的文件請參閱 {latestVersionLink} ({versionLabel})。",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "最新版本",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "custom.outdatedTranslations": {
+    "message": "該頁面的內容已經過期。 請前往 {englishLink} 檢視更多。",
+    "description": "The label used inside the outdated translation banner"
+  },
+  "custom.outdatedTranslationLink": {
+    "message": "英文版",
+    "description": "The link that redirects to the equivalent English doc"
+  },
+  "Code generation": {
+    "message": "程式碼生成"
+  },
+  "About code generation": {
+    "message": "關於程式碼生成"
+  },
+  "About hooks": {
+    "message": "關於鉤子"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "頁面已崩潰。",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.NotFound.title": {
+    "message": "找不到頁面",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "我們找不到您要找的頁面。",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "請聯絡原始連結來源網站的所有者，並告知他們連結已損壞。",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.admonition.note": {
+    "message": "備註",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "提示",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.danger": {
+    "message": "危險",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "資訊",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.caution": {
+    "message": "警告",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "回到頂部",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "歷史博文",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "歷史博文",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "博文列表分頁導航",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "較新的博文",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "較舊的博文",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "博文分頁導航",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "較新一篇",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "較舊一篇",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count} 篇博文",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} 含有標籤「{tagName}」",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "檢視所有標籤",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "切換淺色/暗黑模式（當前為{mode}）",
+    "description": "The ARIA label for the navbar color mode toggle"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "暗黑模式",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "淺色模式",
+    "description": "The name for the light color mode"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "頁面路徑",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription": {
+    "message": "{count} 個專案",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "文件分頁導航",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "上一頁",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "下一頁",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "{count} 篇文件帶有標籤",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} 帶 “{tagName}”",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "版本：{versionLabel}"
+  },
+  "theme.common.editThisPage": {
+    "message": "編輯此頁",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "跳轉到 {heading}",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": "於 {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": "由 {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "最後由 {byUser} 在 {atDate} 更新",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "選擇版本",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "標籤：",
+    "description": "The label alongside a tag list"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "關閉",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "部落格最近帖子的導航",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "複製成功",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "複製程式碼到剪貼簿",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "複製",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "切換自動換行",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+    "message": "開啟/關閉側邊欄選單“{label}”",
+    "description": "The ARIA label to toggle the collapsible sidebar category"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "主導航",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "選擇語言",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "目錄",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "閱讀更多",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "閱讀 {title} 的全文",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "閱讀至少需要 {readingTime} 分鐘",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "主頁",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "收起側邊欄",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "收起側邊欄",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "文件側邊欄",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "關閉導航欄",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← 回到主選單",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "切換導航欄",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "展開側邊欄",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "展開側邊欄",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "檢視所有 {count} 條結果"
+  },
+  "theme.SearchBar.label": {
+    "message": "搜尋",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "清除查詢",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "取消",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "最近搜尋",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "沒有最近搜尋",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "儲存這個搜尋",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "從歷史記錄中刪除這個搜尋",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "收藏",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "從收藏列表中刪除這個搜尋",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "無法獲取結果",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "你可能需要檢查網路連線。",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "選中",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter 鍵",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "選擇",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "向上鍵",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "向下鍵",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "關閉",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Esc 鍵",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "搜尋提供",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "沒有結果：",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "試試搜尋",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "認為這個查詢應該有結果？",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "請告知我們。",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "搜尋文件",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "找到 {count} 份檔案",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "“{query}”的搜尋結果",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "在文件中搜尋",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "在此輸入搜尋字詞",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "搜尋",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "透過 Algolia 搜尋",
+    "description": "The ARIA label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "未找到任何結果",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "正在獲取新的搜尋結果...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "再試一次",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "跳到主要內容",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "標籤",
+    "description": "The title of the tag list page"
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-blog/options.json
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "部落格",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "部落格",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "最近的文章",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,150 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.Sidebar.category.Introduction": {
+    "message": "介紹",
+    "description": "The label for category Introduction in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Riverpod for Provider Users": {
+    "message": "給 Provider 開發者的 Riverpod 指南",
+    "description": "The label for category Riverpod for Provider Users in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Essentials": {
+    "message": "要點",
+    "description": "The label for category Essentials in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Case studies": {
+    "message": "應用案例",
+    "description": "The label for category Case studies in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Advanced topics": {
+    "message": "進階內容",
+    "description": "The label for category Advanced topics in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Concepts": {
+    "message": "概念",
+    "description": "The label for category Concepts in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Migration guides": {
+    "message": "遷移指南",
+    "description": "The label for category Migration guides in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Official examples": {
+    "message": "官方示例",
+    "description": "The label for category Official examples in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Third party examples": {
+    "message": "第三方示例",
+    "description": "The label for category Third party examples in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Concepts (old)": {
+    "message": "概念（舊）",
+    "description": "The label for category Concepts (old) in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Modifiers": {
+    "message": "修飾符",
+    "description": "The label for category Modifiers in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.All Providers (old)": {
+    "message": "提供者程式型別（舊）",
+    "description": "The label for category All Providers (old) in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.category.Guides (old)": {
+    "message": "指南（舊）",
+    "description": "The label for category Guides (old) in sidebar Sidebar"
+  },
+  "sidebar.Sidebar.link.Counter": {
+    "message": "計數器",
+    "description": "The label for link Counter in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/counter"
+  },
+  "sidebar.Sidebar.link.Todo list": {
+    "message": "待辦清單",
+    "description": "The label for link Todo list in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/todos"
+  },
+  "sidebar.Sidebar.link.Pub.dev client": {
+    "message": "Pub.dev 客戶端",
+    "description": "The label for link Pub.dev client in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/pub"
+  },
+  "sidebar.Sidebar.link.Marvel API": {
+    "message": "Marvel API",
+    "description": "The label for link Marvel API in sidebar Sidebar, linking to https://github.com/rrousselGit/riverpod/tree/master/examples/marvel"
+  },
+  "sidebar.Sidebar.link.Android Launcher": {
+    "message": "Android 桌面",
+    "description": "The label for link Android Launcher in sidebar Sidebar, linking to https://github.com/lohanidamodar/fl_live_launcher"
+  },
+  "sidebar.Sidebar.link.Worldtime Clock": {
+    "message": "世界時鐘",
+    "description": "The label for link Worldtime Clock in sidebar Sidebar, linking to https://github.com/lohanidamodar/flutter_worldtime"
+  },
+  "sidebar.Sidebar.link.Dictionary App": {
+    "message": "詞典應用",
+    "description": "The label for link Dictionary App in sidebar Sidebar, linking to https://github.com/lohanidamodar/fl_dictio"
+  },
+  "sidebar.Sidebar.link.Time Tracking App (with Firebase)": {
+    "message": "時間追蹤應用（使用 Firebase）",
+    "description": "The label for link Time Tracking App (with Firebase) in sidebar Sidebar, linking to https://github.com/bizz84/starter_architecture_flutter_firebase"
+  },
+  "sidebar.Sidebar.link.Firebase Phone Authentication with Riverpod": {
+    "message": "使用 Riverpod 的 Firebase 手機號驗證",
+    "description": "The label for link Firebase Phone Authentication with Riverpod in sidebar Sidebar, linking to https://github.com/julienlebren/flutter_firebase_phone_auth_riverpod"
+  },
+  "sidebar.Sidebar.link.ListView paging with search": {
+    "message": "帶搜尋欄的列表分頁",
+    "description": "The label for link ListView paging with search in sidebar Sidebar, linking to https://github.com/tbm98/flutter_loadmore_search"
+  },
+  "sidebar.Sidebar.link.Resocoder's Weather Bloc to Weather Riverpod V2": {
+    "message": "Resocoder 的天氣應用遷移從 Bloc 到 Riverpod V2",
+    "description": "The label for link Resocoder's Weather Bloc to Weather Riverpod V2 in sidebar Sidebar, linking to https://github.com/coyksdev/flutter-bloc-library-v1-tutorial"
+  },
+  "sidebar.Sidebar.link.Blood Pressure Tracker App": {
+    "message": "血壓記錄應用",
+    "description": "The label for link Blood Pressure Tracker App in sidebar Sidebar, linking to https://github.com/UrosTodosijevic/blood_pressure_tracker"
+  },
+  "sidebar.Sidebar.link.Firebase Authentication with Riverpod Following Flutter DDD Architecture Pattern": {
+    "message": "使用 Riverpod 並遵循領域驅動開發（DDD）架構模式的 Firebase 驗證",
+    "description": "The label for link Firebase Authentication with Riverpod Following Flutter DDD Architecture Pattern in sidebar Sidebar, linking to https://github.com/pythonhubpy/firebase_authentication_flutter_DDD"
+  },
+  "sidebar.Sidebar.link.Todo App with Backup and Restore feature": {
+    "message": "具有備份和恢復功能的待辦清單應用",
+    "description": "The label for link Todo App with Backup and Restore feature in sidebar Sidebar, linking to https://github.com/TheAlphaApp/flutter_riverpod_todo_app"
+  },
+  "sidebar.Sidebar.link.Integrating Hive database with Riverpod (simple example)": {
+    "message": "將 Hive 資料庫與 Riverpod 整合（簡單示例）",
+    "description": "The label for link Integrating Hive database with Riverpod (simple example) in sidebar Sidebar, linking to https://github.com/GitGud31/theme_riverpod_hive"
+  },
+  "sidebar.Sidebar.link.Browser App with Riverpod": {
+    "message": "使用 Riverpod 的瀏覽器應用",
+    "description": "The label for link Browser App with Riverpod in sidebar Sidebar, linking to https://github.com/MarioCroSite/simple_browser_app"
+  },
+  "sidebar.Sidebar.link.GoRouter with Riverpod": {
+    "message": "將 GoRouter 與 Riverpod 整合",
+    "description": "The label for link GoRouter with Riverpod in sidebar Sidebar, linking to https://github.com/lucavenir/go_router_riverpod"
+  },
+  "sidebar.Sidebar.link.Piano Chords Test": {
+    "message": "鋼琴和絃測試應用",
+    "description": "The label for link Piano Chords Test in sidebar Sidebar, linking to https://github.com/akvus/piano_fun"
+  },
+  "sidebar.Sidebar.link.Movies API App with Caching & Pagination": {
+    "message": "帶快取和分頁功能的電影 API 應用",
+    "description": "The label for link Movies API App with Caching & Pagination in sidebar Sidebar, linking to https://github.com/Roaa94/movies_app"
+  },
+  "sidebar.Sidebar.link.AWS Amplify Storage Gallery App with Riverpod & Freezed": {
+    "message": "使用 Riverpod 和 Freezed 的 AWS Amplify 儲存圖片應用",
+    "description": "The label for link AWS Amplify Storage Gallery App with Riverpod & Freezed in sidebar Sidebar, linking to https://github.com/offlineprogrammer/amplify_storage_app"
+  },
+  "sidebar.Sidebar.link.Clean Architecture demonstration with Riverpod": {
+    "message": "Riverpod 實現 Clean 架構的示範",
+    "description": "The label for link Clean Architecture demonstration with Riverpod in sidebar Sidebar, linking to https://github.com/Uuttssaavv/flutter-clean-architecture-riverpod"
+  },
+  "sidebar.Sidebar.link.Delivery App with Google Maps and Live Tracking": {
+    "message": "具備谷歌地圖和線上追蹤功能的送貨應用",
+    "description": "The label for link Delivery App with Google Maps and Live Tracking in sidebar Sidebar, linking to https://github.com/AhmedLSayed9/deliverzler"
+  },
+  "sidebar.Sidebar.link.API reference": {
+    "message": "API 參考",
+    "description": "The label for link API reference in sidebar Sidebar, linking to https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/hooks_riverpod-library.html"
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/advanced/select.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/advanced/select.mdx
@@ -1,0 +1,129 @@
+---
+title: 效能最佳化
+---
+
+import { AutoSnippet } from "@site/src/components/CodeSnippet";
+import select from "/docs/advanced/select/select";
+
+import selectAsync from "/docs/advanced/select/select_async";
+
+<!---
+With everything we've seen so far, we can already build a fully functional
+application. However, you may have questions regarding performance.
+-->
+透過到目前為止我們所看到的一切，我們已經可以構建一個功能齊全的應用程式。
+但是，您可能對效能有疑問。
+
+<!---
+In this page, we will cover a few tips and tricks to possibly optimize your code.
+-->
+在本頁中，我們將介紹一些可能最佳化程式碼的提示和技巧。
+
+:::caution
+<!---
+Before doing any optimization, make sure to benchmark your application.
+The added complexity of the optimizations may not be worth minor gains.
+-->
+在進行任何最佳化之前，請確保對您的應用程式進行基準測試。
+最佳化所增加的複雜性可能不值得微小的收益。
+:::
+
+<!---
+## Filtering widget/provider rebuild using "select".
+-->
+## 使用 "select" 過濾小部件或提供者程式的重建。
+
+<!---
+You have have noticed that, by default, using `ref.watch` causes
+consumers/providers to rebuild whenever _any_ of the properties of an
+object changes.  
+For instance, watching a `User` and only using its "name" will still cause
+the consumer to rebuild if the "age" changes.
+-->
+您已經注意到，預設情況下，只要物件的任何屬性發生更改，
+使用 `ref.watch` 都會導致消費者程式或提供者程式進行重建。  
+例如，觀察 `User` 並僅使用其 "name"，
+如果 "age" 發生變化，仍然會導致消費者程式重建。
+
+<!---
+But in case you have a consumer using only a subset of the properties,
+you want to avoid rebuilding the widget when the other properties change.
+-->
+但如果您的使用者僅使用屬性的子集，
+您希望避免在其他屬性更改時重建小部件。
+
+<!---
+This can be achieved by using the `select` functionality of providers.  
+When doing so, `ref.watch` will no-longer return the full object,
+but rather the selected properties.  
+And your consumers/providers will now rebuild only if those selected
+properties change.
+-->
+這可以透過使用提供者程式的 `select` 功能來實現。  
+這樣做時，`ref.watch` 將不再返回完整物件，
+而是返回選定的屬性。  
+現在，僅當這些選定的屬性發生變化時，
+您的消費者程式或提供者程式才會重建。
+
+<AutoSnippet {...select} />
+
+:::info
+<!---
+It is possible to call `select` as many times as you wish.
+You are free to call it once per property you desire.
+-->
+您可以根據需要多次呼叫 `select`。
+您可以為您想要的每個屬性自由呼叫一次。
+:::
+
+:::caution
+<!---
+The selected properties are expected to be immutable.
+Returning a `List` and then mutating that list will not trigger a rebuild.
+-->
+所選屬性希望是不可變的物件。
+返回 `List` 然後改變該列表不會觸發重建。
+:::
+
+:::caution
+<!---
+Using `select` slightly slows down invididual read operations and
+increase a tiny bit the complexity of your code.  
+It may not be worth using it if those "other properties"
+rarely change.
+-->
+使用 `select` 會稍微減慢單個讀取操作的速度，
+並稍微增加程式碼的複雜性。  
+如果那些“其他屬性”很少改變，那麼可能不值得使用它。
+:::
+
+<!---
+### Selecting asynchronous properties
+-->
+### 選擇非同步屬性​
+
+<!---
+In case you are trying to optimize a provider listening to another provider,
+chances are that other provider is asynchronous.
+-->
+考慮一種情況，如果您嘗試最佳化一個監聽其他提供者程式的提供者程式，
+其他提供者程式很可能是非同步的。
+
+<!---
+Normally, you would `ref.watch(anotherProvider.future)` to get the value.  
+The issue is, `select` will apply on an `AsyncValue` – which is not something
+you can await.
+-->
+通常，您可以使用 `ref.watch(anotherProvider.future)` 來獲取該值。  
+問題是，`select` 將應用於 `AsyncValue` - 這不是您可以等待的事情。
+
+<!---
+For this purpose, you can instead use `selectAsync`. It is unique to asynchronous
+code, and enables performing a `select` operation on the data emitted by a provider.  
+Its usage is similar to that of `select`, but returns a `Future` instead:
+-->
+為此，您可以使用 `selectAsync`。它是非同步程式碼所獨有的，
+並且允許對提供者程式發出的資料執行 `select` 操作。  
+它的用法與 `select` 類似，但返回一個 `Future` 型別：
+
+<AutoSnippet {...selectAsync} />

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/case_studies/cancel.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/case_studies/cancel.mdx
@@ -1,0 +1,278 @@
+---
+title: 網路請求的去抖動或取消
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet, When } from "@site/src/components/CodeSnippet";
+import homeScreen from "!raw-loader!./cancel/home_screen.dart";
+import extension from "!raw-loader!./cancel/extension.dart";
+import detailScreen from "/docs/case_studies/cancel/detail_screen";
+import detailScreenCancel from "/docs/case_studies/cancel/detail_screen_cancel";
+import detailScreenDebounce from "/docs/case_studies/cancel/detail_screen_debounce";
+import providerWithExtension from "/docs/case_studies/cancel/provider_with_extension";
+
+<!---
+As applications grow in complexity, it's common to have multiple network requests
+in flight at the same time. For example, a user might be typing in a search box
+and triggering a new request for each keystroke. If the user types quickly, the
+application might have many requests in flight at the same time.
+-->
+隨著應用程式變得越來越複雜，同時處理多個網路請求是很常見的。
+例如，使用者可能在搜尋框中鍵入內容併為每次擊鍵觸發新的請求。
+如果使用者打字速度很快，應用程式可能會同時處理許多請求。
+
+<!---
+Alternatively, a user might trigger a request, then navigate to a different page
+before the request completes. In this case, the application might have a request
+in flight that is no longer needed.
+-->
+或者，使用者可能會觸發請求，然後在請求完成之前導航到不同的頁面。
+在這種情況下，應用程式可能有一個不再需要的正在執行的請求。
+
+<!---
+To optimize performance in those situations, there are a few techniques you can
+use:
+-->
+要在這些情況下最佳化效能，您可以使用以下幾種技術：
+
+<!---
+- "Debouncing" requests. This means that you wait until the user has stopped
+  typing for a certain amount of time before sending the request. This ensures
+  that you only send one request for a given input, even if the user types
+  quickly.
+- "Cancelling" requests. This means that you cancel a request if the user
+  navigates away from the page before the request completes. This ensures that
+  you don't waste time processing a response that the user will never see.
+-->
+- “去抖動”請求。這意味著您要等到使用者停止輸入一段時間後再發送請求。
+  這可確保即使使用者鍵入速度很快，您也只會針對給定輸入傳送一個請求。
+- “取消”請求。這意味著如果使用者在請求完成之前離開頁面，您將取消請求。
+  這可確保您不會浪費時間處理使用者永遠不會看到的響應。
+
+<!---
+In Riverpod, both of these techniques are can be implemented in a similar way.
+The key is to use `ref.onDispose` combined with "automatic disposal" or `ref.watch`
+to achieve the desired behavior.
+-->
+在 Riverpod 中，這兩種技術都可以以類似的方式實現。
+關鍵是使用 `ref.onDispose` 方法與“自動處置”或 `ref.watch`
+結合來實現所需的行為。
+
+<!---
+To showcase this, we will make a simple application with two pages:
+-->
+為了展示這一點，我們將製作一個包含兩個頁面的簡單應用程式：
+
+<!---
+- A home screen, with a button which opens a new page
+- A detail page, which displays a random activity from the [Bored API](https://www.boredapi.com/),
+  with the ability to refresh the activity.  
+  See <Link documentID="case_studies/pull_to_refresh" /> for information
+  on how to implement pull-to-refresh.
+-->
+- 主螢幕，帶有開啟新頁面的按鈕
+- 詳細資訊頁面，顯示來自 [Bored API](https://www.boredapi.com/)
+  的隨機活動，並且能夠重新整理活動。
+  有關如何實現下拉重新整理的資訊，
+  請參閱<Link documentID="case_studies/pull_to_refresh" />。
+
+<!---
+We will then implement the following behaviors:
+-->
+然後我們將實現以下行為：
+
+<!---
+- If the user opens the detail page and then navigates back immediately,
+  we will cancel the request for the activity.
+- If the user refreshes the activity multiple times in a row, we will debounce
+  the requests so that we only send one request after the user stops refreshing.
+-->
+- 如果使用者開啟詳細資訊頁面然後立即導航回來，
+  我們將取消該活動的請求。
+- 如果使用者連續多次重新整理活動，我們將對請求進行去抖動，
+  以便在使用者停止重新整理後僅傳送一個請求。
+
+<!---
+## The application
+-->
+## 應用​
+
+<!---
+<img
+  src="/img/case_studies/cancel/app.gif"
+  alt="Gif showcasing the application, opening the detail page and refreshing the activity."
+/>
+-->
+<img
+  src="/img/case_studies/cancel/app.gif"
+  alt="展示應用程式、開啟詳細頁面和重新整理活動的 Gif。"
+/>
+
+<!---
+First, let's create the application, without any debouncing or cancelling.  
+We won't use anything fancy here, and stick to a plain `FloatingActionButton` with
+a `Navigator.push` to open the detail page.
+-->
+首先，讓我們建立應用程式，不進行任何去抖動或取消操作。  
+我們不會在這裡使用任何花哨的東西，而是堅持使用普通的 `FloatingActionButton`
+和 `Navigator.push` 來開啟詳細資訊頁面。
+
+<!---
+First, let's start with defining our home screen. As usual,
+let's not forget to specify a `ProviderScope` at the root of our application.
+-->
+首先，讓我們從定義主螢幕開始。像往常一樣，
+我們不要忘記在應用程式的根元件上指定 `ProviderScope` 。
+
+<AutoSnippet title="lib/src/main.dart" raw={homeScreen} />
+
+<!---
+Then, let's define our detail page.
+To fetch the activity and implement pull-to-refresh, refer
+to the <Link documentID="case_studies/pull_to_refresh" /> case study.
+-->
+然後，讓我們定義我們的詳細資訊頁面。
+要獲取活動並實施下拉重新整理，
+請參閱<Link documentID="case_studies/pull_to_refresh" />應用案例。
+
+<AutoSnippet title="lib/src/detail_screen.dart" {...detailScreen} />
+
+<!---
+## Cancelling requests
+-->
+## 取消請求
+
+<!---
+Now that we have a working application, let's implement the cancellation logic.
+-->
+現在我們有了一個可以執行的應用程式，讓我們實現取消邏輯。
+
+<!---
+To do so, we will use `ref.onDispose` to cancel the request when the user
+navigates away from the page. For this to work, it is important that the
+automatic disposal of providers is enabled.
+-->
+為此，我們將在使用者離開頁面時使用 `ref.onDispose` 取消請求。
+為了使其運作，啟用提供者程式的自動處置非常重要。
+
+<!---
+The exact code needed to cancel the request will depend on the HTTP client.
+In this example, we will use `package:http`, but the same principle applies
+to other clients.
+-->
+取消請求所需的確切程式碼取決於 HTTP 客戶端。
+在此示例中，我們將使用 `package:http` ，
+但相同的原則也適用於其他客戶端。
+
+<!---
+The key here that `ref.onDispose` will be called when the user navigates away.
+That is because our provider is no-longer used, and therefore disposed
+thanks to automatic disposal.  
+We can therefore use this callback to cancel the request. When using `package:http`,
+this can be done by closing our HTTP client.
+-->
+這裡的關鍵點是當用戶離開時將呼叫 `ref.onDispose`。
+這是因為我們的提供者程式不再使用，因此透過自動處置進行了處置。  
+因此，我們可以使用此回撥來取消請求。
+當使用 `package:http` 時，可以透過關閉 HTTP 客戶端來完成。
+
+<AutoSnippet {...detailScreenCancel} />
+
+<!---
+## Debouncing requests
+-->
+## 請求​去抖
+
+<!---
+Now that we have implemented cancellation, let's implement debouncing.  
+At the moment, if the user refreshes the activity multiple times in a row,
+we will send a request for each refresh.
+-->
+現在我們已經實現了取消，讓我們實現去抖動。  
+目前，如果使用者連續多次重新整理活動，
+我們將為每次刷新發送一個請求。
+
+<!---
+Technically speaking, now that we have implemented cancellation, this is not
+a problem. If the user refreshes the activity multiple times in a row,
+the previous request will be cancelled, when a new request is made.
+-->
+從技術上來說，既然我們已經實行了取消，這就不成問題了。
+如果使用者連續多次重新整理活動，
+則當發出新請求時，先前的請求將被取消。
+
+<!---
+However, this is not ideal. We are still sending multiple requests, and
+wasting bandwidth and server resources.  
+What we could instead do is delay our requests until the user stops refreshing
+the activity for a fixed amount of time.
+-->
+然而，這並不理想。我們仍然傳送多個請求，
+浪費頻寬和伺服器資源。  
+相反，我們可以做的是延遲我們的請求，
+直到使用者在固定的時間內停止重新整理活動。
+
+<!---
+The logic here is very similar to the cancellation logic. We will again
+use `ref.onDispose`. However, the idea here is that instead of
+closing an HTTP client, we will rely on `onDispose` to abort the request
+before it starts.  
+We will then arbitrarily wait for 500ms before sending the request.
+Then, if the user refreshes the activity again before the 500ms have elapsed,
+`onDispose` will be invoked, aborting the request.
+-->
+這裡的邏輯和取消邏輯非常相似。
+我們將再次使用 `ref.onDispose`。然而，這裡的想法是，
+我們將依靠 `onDispose` 在請求開始之前中止請求，
+而不是關閉 HTTP 客戶端。  
+然後我們會任意等待 500ms，然後再發送請求。
+然後，如果使用者在 500 毫秒過去之前再次重新整理活動，
+將呼叫 `onDispose` 並中止請求。
+
+:::info
+<!---
+To abort requests, a common practice is to voluntarily throw.  
+It is safe to throw inside providers after the provider has been disposed.
+The exception will naturally be caught by Riverpod and be ignored.
+-->
+要中止請求，常見的做法是主動丟擲。  
+在提供者程式被處置後，將提供者程式內部丟擲異常是安全的。
+該異常自然會被 Riverpod 捕獲並被忽略。
+:::
+
+<AutoSnippet {...detailScreenDebounce} />
+
+<!---
+## Going further: Doing both at once
+-->
+## 更進一步：同時做這兩件事​
+
+<!---
+We now know how to debounce and cancel requests.  
+But currently, if we want to do another request, we need to copy-paste
+the same logic in multiple places. This is not ideal.
+-->
+我們現在知道如何取消和取消請求。  
+但目前，如果我們想做另一個請求，
+我們需要將相同的邏輯複製貼上到多個位置。這並不理想。
+
+<!---
+However, we can go further and implement a reusable utility to do both at once.
+-->
+然而，我們可以更進一步，實現一個可重用的實用程式來同時完成這兩個任務。
+
+<!---
+The idea here is to implement an extension method on `Ref` that will
+handle both cancellation and debouncing in a single method.
+-->
+這裡的想法是在 `Ref` 上實現一個擴充套件方法，
+該方法將在單個方法中處理取消和去抖。
+
+<AutoSnippet raw={extension} />
+
+<!---
+We can then use this extension method in our providers as followed:
+-->
+然後我們可以在我們的提供者程式中使用此擴充套件方法，如下所示：
+
+<AutoSnippet {...providerWithExtension} />

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/case_studies/cancel/extension.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/case_studies/cancel/extension.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+/* SNIPPET START */
+extension DebounceAndCancelExtension on Ref {
+  /// 等待 [duration]（預設為 500ms），
+  /// 然後返回一個 [http.Client]，用於發出請求。
+  ///
+  /// 當提供者程式被處置時，該客戶端將自動關閉。
+  Future<http.Client> getDebouncedHttpClient([Duration? duration]) async {
+    // 首先，我們要處理去抖問題。
+    var didDispose = false;
+    onDispose(() => didDispose = true);
+
+    // 我們將請求延遲 500 毫秒，以等待使用者停止重新整理。
+    await Future<void>.delayed(duration ?? const Duration(milliseconds: 500));
+
+    // 如果在延遲期間處理了提供者程式，則意味著使用者再次重新整理了請求。
+    // 我們會丟擲一個異常來取消請求。
+    // 在這裡使用異常是安全的，因為它會被 Riverpod 捕捉到。
+    if (didDispose) {
+      throw Exception('Cancelled');
+    }
+
+    // 現在我們建立客戶端，並在處理提供者程式時關閉客戶端。
+    final client = http.Client();
+    onDispose(client.close);
+
+    // 最後，我們返回客戶端，讓我們的提供者程式提出請求。
+    return client;
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/case_studies/cancel/home_screen.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/case_studies/cancel/home_screen.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'detail_screen/codegen.dart';
+
+/* SNIPPET START */
+void main() => runApp(const ProviderScope(child: MyApp()));
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      routes: {
+        '/detail-page': (_) => const DetailPageView(),
+      },
+      home: const ActivityView(),
+    );
+  }
+}
+
+class ActivityView extends ConsumerWidget {
+  const ActivityView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home screen')),
+      body: const Center(
+        child: Text('Click the button to open the detail page'),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Navigator.of(context).pushNamed('/detail-page'),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/case_studies/pull_to_refresh.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/case_studies/pull_to_refresh.mdx
@@ -1,0 +1,253 @@
+---
+title: 下拉重新整理
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet, When } from "@site/src/components/CodeSnippet";
+import activity from "/docs/case_studies/pull_to_refresh/activity";
+import fetchActivity from "/docs/case_studies/pull_to_refresh/fetch_activity";
+import displayActivity from "!!raw-loader!/docs/case_studies/pull_to_refresh/display_activity.dart";
+import displayActivity2 from "!!raw-loader!/docs/case_studies/pull_to_refresh/display_activity2.dart";
+import displayActivity3 from "!!raw-loader!/docs/case_studies/pull_to_refresh/display_activity3.dart";
+import displayActivity4 from "!!raw-loader!/docs/case_studies/pull_to_refresh/display_activity4.dart";
+import fullApp from "/docs/case_studies/pull_to_refresh/full_app";
+
+<!---
+Riverpod natively supports pull-to-refresh thanks to its declarative nature.
+-->
+由於其宣告性，Riverpod 本身就支援拉動重新整理。
+
+<!---
+In general, pull-to-refreshes can be complex due as there are multiple
+problems to solve:
+-->
+一般來說，拉動重新整理可能很複雜，因為有多個問題需要解決：
+
+<!---
+- Upon first entering a page, we want to show a spinner.
+  But during refresh, we want to show the refresh indicator instead.
+  We shouldn't show both the refresh indicator _and_ spinner.
+- While a refresh is pending, we want to show the previous data/error.
+- We need to show the refresh indicator for as long as the refresh is happening.
+-->
+- 第一次進入頁面時，我們想要顯示一個微調器（spinner）。
+  但在重重新整理期間，我們希望顯示重新整理指示器。
+  我們不應該同時顯示重新整理指示器_和_微調器。
+- 當重新整理掛起時，我們希望顯示以前的資料/錯誤。
+- 只要重刷新發生，我們就需要顯示重新整理指示器。
+
+<!---
+Let's see how to solve this using Riverpod.  
+For this, we will make a simple example which recommands a random activity to users.  
+And doing a pull-to-refresh will trigger a new suggestion:
+-->
+讓我們看看如何使用 Riverpod 解決這個問題。  
+為此，我們將製作一個簡單的示例，向用戶推薦隨機活動。  
+並且進行下拉重新整理將觸發新的建議：
+
+<!---
+<img
+  alt="A gif of the previously described application working"
+  src="/img/case_studies/pull_to_refresh/app.gif"
+/>
+-->
+<img
+  alt="上面描述的應用軟體工作時的 gif"
+  src="/img/case_studies/pull_to_refresh/app.gif"
+/>
+
+<!---
+## Making a bare-bones application.
+-->
+## 製作一個簡單的應用程式。​
+
+<!---
+Before implement a pull-to-refresh, we first need something to refresh.  
+We can make a simple application which uses [Bored API](https://www.boredapi.com/)
+to suggests a random activity to users.
+-->
+在實現下拉重新整理之前，我們首先需要重新整理一些東西。  
+我們可以製作一個簡單的應用程式，使用 [Bored API](https://www.boredapi.com/)
+向用戶建議隨機活動。
+
+<!---
+First, let's define an `Activity` class:
+-->
+首先，我們定義一個 `Activity` 類：
+
+<AutoSnippet {...activity} />
+
+<!---
+That class will be responsible for representing a suggested activity
+in a type-safe manner, and handle JSON encoding/decoding.  
+Using Freezed/json_serializable is not required, but it is recommended.
+-->
+該類將負責以型別安全的方式表示建議的活動，並處理 JSON 編碼/解碼。  
+使用 Freezed/json_serialized 不是必需的，但建議使用。
+
+<!---
+Now, we'll want to define a provider making a HTTP GET request to fetch
+a single activity:
+-->
+現在，我們要定義一個提供者程式發出 HTTP GET 請求來獲取單個活動：
+
+<AutoSnippet {...fetchActivity} />
+
+<!---
+We can now use this provider to display a random activity.  
+For now, we will not handle the loading/error state, and simply
+display the activity when available:
+-->
+我們現在可以使用此提供者程式來顯示隨機活動。  
+目前，我們不會處理載入/錯誤狀態，而只是在可用時顯示活動：
+
+<AutoSnippet raw={displayActivity} />
+
+<!---
+## Adding `RefreshIndicator`
+-->
+## 新增 `RefreshIndicator`
+
+<!---
+Now that we have a simple application, we can add a `RefreshIndicator` to it.  
+That widget is an official Material widget responsible for displaying a refresh indicator
+when the user pulls down the screen.
+-->
+現在我們有了一個簡單的應用程式，我們可以向它新增一個 `RefreshIndicator`。  
+該小部件是一個官方的 Material 小部件，負責在使用者下拉螢幕時顯示重新整理指示器。
+
+<!---
+Using `RefreshIndicator` requires a scrollable surface. But so far, we don't have
+any. We can fix that by using a `ListView`/`GridView`/`SingleChildScrollView`/etc:
+-->
+使用 `RefreshIndicator` 需要一個可滾動的表面。但到目前為止，我們還沒有。
+我們可以透過使用 `ListView`/`GridView`/`SingleChildScrollView` 等等來解決這個問題：
+
+<AutoSnippet raw={displayActivity2} />
+
+<!---
+Users can now pull down the screen. But our data isn't refreshed yet.
+-->
+使用者現在可以下拉螢幕。但我們的資料還沒有重新整理。
+
+<!---
+## Adding the refresh logic
+-->
+## 新增重新整理邏輯​
+
+<!---
+When users pull down the screen, `RefreshIndicator` will invoke
+the `onRefresh` callback. We can use that callback to refresh our data.
+In there, we can use `ref.refresh` to refresh the provider of our choice.
+-->
+當用戶下拉螢幕時，`RefreshIndicator` 將呼叫
+`onRefresh` 回撥。我們可以使用該回調來重新整理我們的資料。
+在那裡，我們可以使用 `ref.refresh` 重新整理我們選擇的提供者程式。
+
+<!---
+**Note**: `onRefresh` is expected to return a `Future`.
+And it is important for that future to complete when the refresh is done.
+-->
+**注意**：`onRefresh` 期望返回一個 `Future`。
+重新整理完成後，future 的完成非常重要。
+
+<!---
+To obtain such a future, we can read our provider's `.future` property.
+This will return a future which completes when our provider has resolved.
+-->
+為了獲得這樣的 future，我們可以讀取提供者程式的 `.future` 屬性。
+這將返回一個 future，該 future 在我們的提供者程式解決後完成。
+
+<!---
+We can therefore update our `RefreshIndicator` to look like this:
+-->
+因此，我們可以將 `RefreshIndicator` 更新為如下所示：
+
+<AutoSnippet raw={displayActivity3} />
+
+<!---
+## Showing a spinner only during initial load and handling errors.
+-->
+## 僅在初始載入和處理錯誤期間顯示微調器。
+
+<!---
+At the moment, our UI does not handle the error/loading states.  
+Instead the data magically pops up when the loading/refresh is done.
+-->
+目前，我們的 UI 不處理錯誤/載入狀態。  
+相反，當載入/重新整理完成時，資料會神奇地彈出。
+
+<!---
+Let's change this by gracefully handling those states. There are two
+cases:
+-->
+讓我們透過優雅地處理這些狀態來改變這一點。有兩種情況：
+
+<!---
+- During the initial load, we want to show a full-screen spinner.
+- During a refresh, we want to show the refresh indicator
+  and the previous data/error.
+-->
+- 在初始載入期間，我們希望顯示全屏微調器。
+- 在重新整理期間，我們希望顯示重新整理指示器和之前的資料/錯誤。
+
+<!---
+Fortunately, when listening to an asynchronous provider in Riverpod,
+Riverpod gives us an `AsyncValue`, which offers everything we need.
+-->
+幸運的是，當在 Riverpod 中監聽非同步提供者程式時，
+Riverpod 為我們提供了一個 `AsyncValue` ，它提供了我們需要的一切。
+
+<!---
+That `AsyncValue` can then be combined with Dart 3.0's pattern matching
+as followed:
+-->
+然後可以將 `AsyncValue` 與 Dart 3.0 的模式匹配結合起來，如下所示：
+
+<AutoSnippet raw={displayActivity4} />
+
+:::caution
+<!---
+We use `valueOrNull` here, as currently, using `value` throws
+if in error/loading state.
+-->
+我們在這裡使用 `valueOrNull`，就像目前一樣，
+如果處於錯誤/載入狀態，則使用 `value` 會丟擲異常。
+
+<!---
+Riverpod 3.0 will change this to have `value` behave like `valueOrNull`.
+But for now, let's stick to `valueOrNull`.
+-->
+Riverpod 3.0 將對此進行更改，使 `value` 的行為類似於 `valueOrNull`。
+但現在，讓我們堅持使用 `valueOrNull`。
+:::
+
+:::tip
+<!---
+Notice the usage of the `:final valueOrNull?` syntax in our pattern matching.
+This syntax can be used only because `activityProvider` returns a non-nullable
+`Activity`.
+-->
+請注意我們的模式匹配中 `:final valueOrNull?` 語法的使用。
+只能使用此語法，因為 `activityProvider` 返回不可為 null 的 `Activity`。
+
+<!---
+If your data can be `null`, you can instead use `AsyncValue(hasData: true, :final valueOrNull)`.
+This will correctly handle cases where the data is `null`, at the cost of
+a few extra characters.
+-->
+如果您的資料可以是 `null`，則可以使用 `AsyncValue(hasData: true, :final valueOrNull)`。
+這將正確處理資料為 `null` 的情況，但需要一些額外的字元。
+:::
+
+<!---
+## Wrapping up: full application
+-->
+## 總結：完整的應用
+
+<!---
+Here is the combined source of everything we've covered so far:
+-->
+以下是組合了我們迄今為止所涵蓋的所有內容的原始碼：
+
+<AutoSnippet {...fullApp} />

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/about_code_generation.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/about_code_generation.mdx
@@ -1,0 +1,488 @@
+---
+title: 關於程式碼生成
+version: 1
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+import fetchUser from "!!raw-loader!/docs/concepts/about_codegen/main.dart";
+import rawFetchUser from "!!raw-loader!/docs/concepts/about_codegen/raw.dart";
+import { Link } from "@site/src/components/Link";
+import { trimSnippet, CodeSnippet } from "@site/src/components/CodeSnippet";
+import syncFn from "!!raw-loader!/docs/concepts/about_codegen/provider_type/sync_fn.dart";
+import syncClass from "!!raw-loader!/docs/concepts/about_codegen/provider_type/sync_class.dart";
+import asyncFnFuture from "!!raw-loader!/docs/concepts/about_codegen/provider_type/async_fn_future.dart";
+import asyncClassFuture from "!!raw-loader!/docs/concepts/about_codegen/provider_type/async_class_future.dart";
+import asyncFnStream from "!!raw-loader!/docs/concepts/about_codegen/provider_type/async_fn_stream.dart";
+import asyncClassStream from "!!raw-loader!/docs/concepts/about_codegen/provider_type/async_class_stream.dart";
+import familyFn from "!!raw-loader!/docs/concepts/about_codegen/provider_type/family_fn.dart";
+import familyClass from "!!raw-loader!/docs/concepts/about_codegen/provider_type/family_class.dart";
+import provider from "!!raw-loader!/docs/concepts/about_codegen/provider_type/non_code_gen/provider.dart";
+import notifierProvider from "!!raw-loader!/docs/concepts/about_codegen/provider_type/non_code_gen/notifier_provider.dart";
+import futureProvider from "!!raw-loader!/docs/concepts/about_codegen/provider_type/non_code_gen/future_provider.dart";
+import asyncNotifierProvider from "!!raw-loader!/docs/concepts/about_codegen/provider_type/non_code_gen/async_notifier_provider.dart";
+import streamProvider from "!!raw-loader!/docs/concepts/about_codegen/provider_type/non_code_gen/stream_provider.dart";
+import streamNotifierProvider from "!!raw-loader!/docs/concepts/about_codegen/provider_type/non_code_gen/stream_notifier_provider.dart";
+import autoDisposeCodeGen from "!!raw-loader!/docs/concepts/about_codegen/provider_type/auto_dispose.dart";
+import autoDisposeNonCodeGen from "!!raw-loader!/docs/concepts/about_codegen/provider_type/non_code_gen/auto_dispose.dart";
+import familyCodeGen from "!!raw-loader!/docs/concepts/about_codegen/provider_type/family.dart";
+import familyNonCodeGen from "!!raw-loader!/docs/concepts/about_codegen/provider_type/non_code_gen/family.dart";
+const TRANSPARENT_STYLE = { backgroundColor: "transparent" };
+const RED_STYLE = { color: "indianred", fontWeight: "700" };
+const BLUE_STYLE = { color: "rgb(103, 134, 196)", fontWeight: "700" };
+const FONT_16_STYLE = {
+  fontSize: "16px",
+  fontWeight: "700",
+};
+const BLUE_20_STYLE = {
+  color: "rgb(103, 134, 196)",
+  fontSize: "20px",
+  fontWeight: "700",
+};
+const PROVIDER_STYLE = {
+  textAlign: "center",
+  fontWeight: "600",
+  maxWidth: "210px",
+};
+const BEFORE_STYLE = {
+  minWidth: "60px",
+  textAlign: "center",
+  fontWeight: "600",
+  color: "crimson",
+};
+const AFTER_STYLE = {
+  minWidth: "60px",
+  textAlign: "center",
+  fontWeight: "600",
+  color: "rgb(40,180,40)",
+};
+
+<!---
+Code generation is the idea of using a tool to generate code for us.
+In Dart, it comes with the downside of requiring an extra step to "compile"
+an application. Although this problem may be solved in the near future, as the
+Dart team is working on a potential solution to this problem.
+-->
+程式碼生成是使用工具為我們生成程式碼的想法。
+在 Dart 中，它的缺點是需要額外的步驟來“編譯”應用程式。
+儘管這個問題可能在不久的將來得到解決，
+但 Dart 團隊正在研究這個問題的潛在解決方案。
+
+<!---
+In the context of Riverpod, code generation is about slightly changing the syntax
+for defining a "provider". For example, instead of:
+-->
+在 Riverpod 的上下文中，程式碼生成是稍微改變定義 "provider" 的語法。例如，代替：
+
+<CodeBlock language="dart">{trimSnippet(rawFetchUser)}</CodeBlock>
+
+<!---
+Using code generation, we would write:
+-->
+使用程式碼生成，我們可以編寫：
+
+<CodeBlock language="dart">{trimSnippet(fetchUser)}</CodeBlock>
+
+<!---
+When using Riverpod, code generation is completely optional. It is entirely possible
+to use Riverpod without.
+At the same time, Riverpod embraces code generation and recommends using it.
+-->
+使用 Riverpod 時，程式碼生成是完全可選的。
+沒有的話完全可以使用 Riverpod。
+同時，Riverpod 支援程式碼生成並推薦使用它。
+
+<!---
+For information on how to install and use Riverpod's code generator, refer to
+the <Link documentID="introduction/getting_started"/> page. Make sure to enable code generation
+in the documentation's sidebar.
+-->
+有關如何安裝和使用 Riverpod 程式碼生成器的資訊，
+請參閱<Link documentID="introduction/getting_started"/>頁面。
+確保在文件的側欄中啟用程式碼生成。
+
+<!---
+## Should I use code generation?
+-->
+## 我應該使用程式碼生成嗎？​
+
+<!---
+Code generation is optional in Riverpod.
+With that in mind, you may wonder if you should use it or not.
+-->
+Riverpod 中的程式碼生成是可選的。
+考慮到這一點，您可能會想是否應該使用它。
+
+<!---
+The answer is: **Most likely Yes**.  
+Using code generation is the recommended way to use Riverpod. It
+is the more future-proof approach and will allow you to use Riverpod to its full
+potential.  
+At the same time, many applications already use code generation with packages such
+as [Freezed](https://pub.dev/packages/freezed) or [json_serializable](https://pub.dev/packages/json_serializable).
+In that case, your project probably is already set up for code generation, and
+using Riverpod should be simple.
+-->
+答案是：**很可能是的**。  
+使用程式碼生成是使用 Riverpod 的推薦方式。
+這是一種更面向未來的方法，可以讓您充分發揮 Riverpod 的潛力。  
+與此同時，許多應用程式已經使用
+[Freezed](https://pub.dev/packages/freezed) 或 [json_serializable](https://pub.dev/packages/json_serializable)
+等包來生成程式碼。在這種情況下，您的專案可能已經設定為程式碼生成，
+並且使用 Riverpod 應該很簡單。
+
+<!---
+Currently, code generation is optional because `build_runner` is disliked by many.
+But once [Static Metaprogramming](https://github.com/dart-lang/language/issues/1482)
+is available in Dart, `build_runner` will no longer be an issue. At that point,
+the code generation syntax will be the only syntax available in Riverpod.
+-->
+目前，程式碼生成是可選的，因為許多人不喜歡 `build_runner`。
+但是，一旦 Dart 中提供了[靜態超程式設計](https://github.com/dart-lang/language/issues/1482)，
+`build_runner` 將不再是問題。
+屆時，程式碼生成語法將是 Riverpod 中唯一可用的語法。
+
+<!---
+If using `build_runner` is a deal-breaker for you, then and only then you should
+consider not using code generation.
+But keep in mind that you will be missing out on some features, and that
+you will have to migrate to code generation in the future.  
+Although when that happens, Riverpod will provide a migration tool to make
+the transition as smoothly as possible.
+-->
+如果使用 `build_runner` 對您來說是一個破壞性的事情，
+那麼只有那時您才應該考慮不使用程式碼生成。
+但請記住，您將錯過一些功能，並且將來您將不得不遷移到程式碼生成。  
+儘管如此，當這種情況發生時，
+Riverpod 將提供一個遷移工具，以使過渡儘可能順利。
+
+<!---
+## What are the benefits of using code generation?
+-->
+## 使用程式碼生成有什麼好處？​
+
+<!---
+You may be wondering: "If code generation is optional in Riverpod, why use it?"
+-->
+您可能想知道：“如果 Riverpod 中程式碼生成是可選的，為什麼要使用它？”
+
+<!---
+As always with packages: To make your life easier.
+This includes but is not limited to:
+-->
+這和其他包的目的一樣：讓您的生活更輕鬆。這包括但不限於：
+
+<!---
+- better syntax, more readable/flexible, and with a reduced learning curve.
+  - No need to worry about the type of provider. Write your logic,
+    and Riverpod will pick the most suitable provider for you.
+  - The syntax no longer looks like we're defining a "dirty global variable".
+    Instead we are defining a custom function/class.
+  - Passing parameters to providers is now unrestricted. Instead of being limited to
+    using <Link documentID="concepts/modifiers/family"/> and passing a single positional parameter,
+    you can now pass any parameter. This includes named parameters, optional ones,
+    and even default values.
+- **stateful hot-reload** of the code written in Riverpod.
+- better debugging, through the generation of extra metadata that the debugger then picks up.
+- some Riverpod features will be available only with code generation.
+-->
+- 更好的語法，更具可讀性/靈活性，並且學習曲線更短。
+  - 無需擔心提供者程式的型別。寫下您的邏輯，Riverpod 將為您選擇最合適的提供者程式。
+  - 語法看起來不再像我們定義了“骯髒的全域性變數”。相反，我們定義了一個自定義函式/類。
+  - 向提供者程式傳遞引數現在不受限制。
+    您現在可以傳遞任何引數，而不是僅限於使用 `.family` 並傳遞單個位置引數。
+    這包括命名引數、可選引數，甚至預設值。
+- 用 Riverpod 編寫的程式碼的**有狀態熱過載**。
+- 透過生成偵錯程式隨後拾取的額外元資料來更好地進行除錯。
+- 某些 Riverpod 功能僅在程式碼生成時可用。
+
+<!---
+## The Syntax
+-->
+## 語法​
+
+<!---
+### Defining a provider:
+-->
+### 定義提供者程式：​
+
+<!---
+When defining a provider using code generation, it is helpful to keep in mind the following points:
+-->
+使用程式碼生成定義提供者程式時，記住以下幾點會很有幫助：
+
+<!---
+- Providers can be defined either as an annotated <span style={BLUE_STYLE}>function</span> or
+  as an annotated <span style={BLUE_STYLE}>class</span>. They are pretty much the same,
+  but Class-based provider has the advantage of including public methods that enable
+  external objects to modify the state of the provider (side-effects). Functional providers
+  are syntax sugar for writing a Class-based provider with nothing but a `build` method,
+  and as such cannot be modified by the UI.
+- All Dart <span style={RED_STYLE}>async</span> primitives (Future, FutureOr, and Stream) are supported.
+- When a function is marked as <span style={RED_STYLE}>async</span>, the provider automatically handles
+  errors/loading states and exposes an AsyncValue.
+-->
+- 提供者程式可以定義為帶註釋的<span style={BLUE_STYLE}>函式</span>或
+  帶註釋的<span style={BLUE_STYLE}>類</span>。它們幾乎相同，
+  但基於類的提供者程式的優點是包含公共方法，使
+  外部物件能夠修改提供者程式的狀態（副作用）。
+  函式提供者程式是用於編寫基於類的提供者程式的語法糖，只有 `build` 方法，
+  因此不能由 UI 修改。
+- 支援所有 Dart <span style={RED_STYLE}>非同步</span>原語（Future、FutureOr 和 Stream）。
+- 當函式被標記為<span style={RED_STYLE}>async</span>時，
+  提供者程式會自動處理錯誤/載入狀態並公開 AsyncValue。
+
+<table>
+  <colgroup></colgroup>
+  <tr>
+    <th></th>
+    <th style={{ textAlign: "center" }}>
+      <span style={BLUE_20_STYLE}>函式式的</span>
+      <br />
+      （不能使用公共方法執行副作用）
+    </th>
+    <th style={{ textAlign: "center" }}>
+      <span style={BLUE_20_STYLE}>基於類的</span>
+      <br />
+      （可以使用公共方法執行副作用）
+    </th>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td>
+      <span style={FONT_16_STYLE}>
+        <span style={RED_STYLE}>同步的</span>
+      </span>
+    </td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(syncFn)}</CodeBlock>
+    </td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(syncClass)}</CodeBlock>
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td>
+      <span style={FONT_16_STYLE}>
+        <span style={RED_STYLE}>非同步的 - Future</span>
+      </span>
+    </td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(asyncFnFuture)}</CodeBlock>
+    </td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(asyncClassFuture)}</CodeBlock>
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td>
+      <span style={FONT_16_STYLE}>
+        <span style={RED_STYLE}>非同步的 - Stream</span>
+      </span>
+    </td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(asyncFnStream)}</CodeBlock>
+    </td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(asyncClassStream)}</CodeBlock>
+    </td>
+  </tr>
+</table>
+
+<!---
+### Enabling/disable autoDispose:
+-->
+### 啟用/停用自動處置 autoDispose：​
+
+<!---
+When using code generation, providers are autoDispose by default. That means that they will automatically
+dispose of themselves when there are no listeners attached to them (ref.watch/ref.listen).  
+This default setting better aligns with Riverpod's philosophy. Initially with the non-code generation variant,
+autoDispose was off by default to accommodate users migrating from `package:provider`.
+-->
+使用程式碼生成時，提供者程式預設為 autoDispose。
+這意味著當沒有監聽器附加到它們（ref.watch/ref.listen）時，它們會自動處理掉自己。  
+此預設設定更符合 Riverpod 的理念。
+最初沒有使用程式碼生成變體時，預設情況下 autoDispose 處於關閉狀態，
+以適應從 `package:provider` 遷移的使用者。
+
+<!---
+If you want to disable autoDispose, you can do so by passing `keepAlive: true` to the annotation.
+-->
+如果您想停用 autoDispose，可以透過將 `keepAlive: true` 傳遞給註釋來實現。
+
+<CodeBlock language="dart">{trimSnippet(autoDisposeCodeGen)}</CodeBlock>
+
+<!---
+### Passing parameters to a provider (family):
+-->
+### 將引數傳遞給提供者程式（family）：​
+
+<!---
+When using code generation, we no-longer need to rely on the `family` modifier to pass parameters to a provider.
+Instead, the main function of our provider can accept any number of parameters, including named, optional, or default values.  
+Do note however that these parameters should have still have a consistent ==.
+Meaning either the values should be cached, or the parameters should override ==.
+-->
+使用程式碼生成時，我們不再需要依賴 `family` 修飾符將引數傳遞給提供者程式。
+相反，我們的提供者程式的主函式可以接受任意數量的引數，包括命名、可選或預設值。  
+但請注意，這些引數應該仍然具有 == 的一致性。
+這意味著要麼應該快取值，要麼應該覆蓋 == 引數。
+
+<table>
+  <colgroup>
+    <col style={{ minWidth: "400px" }} />
+    <col style={{ minWidth: "400px" }} />
+  </colgroup>
+  <tr>
+    <th style={{ textAlign: "center" }}>
+      <span style={BLUE_20_STYLE}>函式式的</span>
+    </th>
+    <th style={{ textAlign: "center" }}>
+      <span style={BLUE_20_STYLE}>基於類的</span>
+    </th>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(familyFn)}</CodeBlock>
+    </td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(familyClass)}</CodeBlock>
+    </td>
+  </tr>
+</table>
+
+<!---
+## Migrate from non-code-generation variant:
+-->
+## 從非程式碼生成變體遷移：​
+
+<!---
+When using non-code-generation variant, it is necessary to manually determine the type of your provider.
+The following are the corresponding options for transitioning into code-generation variant:
+-->
+使用非程式碼生成變體時，需要手動確定提供者程式的型別。
+以下是轉換為程式碼生成變體的相應選項：
+
+<table>
+  <colgroup></colgroup>
+  <tr>
+    <td style={PROVIDER_STYLE} colspan="2">
+      Provider
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={BEFORE_STYLE}>之前</td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(provider)}</CodeBlock>
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={AFTER_STYLE}>之後</td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(syncFn)}</CodeBlock>
+    </td>
+  </tr>
+  <colgroup></colgroup>
+  <tr>
+    <td style={PROVIDER_STYLE} colspan="2">
+      NotifierProvider
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={BEFORE_STYLE}>之前</td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(notifierProvider)}</CodeBlock>
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={AFTER_STYLE}>之後</td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(syncClass)}</CodeBlock>
+    </td>
+  </tr>
+  <colgroup></colgroup>
+  <tr>
+    <td style={PROVIDER_STYLE} colspan="2">
+      FutureProvider
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={BEFORE_STYLE}>之前</td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(futureProvider)}</CodeBlock>
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={AFTER_STYLE}>之後</td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(asyncFnFuture)}</CodeBlock>
+    </td>
+  </tr>
+  <colgroup></colgroup>
+  <tr>
+    <td style={PROVIDER_STYLE} colspan="2">
+      StreamProvider
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={BEFORE_STYLE}>之前</td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(streamProvider)}</CodeBlock>
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={AFTER_STYLE}>之後</td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(asyncFnStream)}</CodeBlock>
+    </td>
+  </tr>
+  <colgroup></colgroup>
+  <tr>
+    <td style={PROVIDER_STYLE} colspan="2">
+      AsyncNotifierProvider
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={BEFORE_STYLE}>之前</td>
+    <td>
+      <CodeBlock language="dart">
+        {trimSnippet(asyncNotifierProvider)}
+      </CodeBlock>
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={AFTER_STYLE}>之後</td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(asyncClassFuture)}</CodeBlock>
+    </td>
+  </tr>
+  <colgroup></colgroup>
+  <tr>
+    <td style={PROVIDER_STYLE} colspan="2">
+      StreamNotifierProvider
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={BEFORE_STYLE}>之前</td>
+    <td>
+      <CodeBlock language="dart">
+        {trimSnippet(streamNotifierProvider)}
+      </CodeBlock>
+    </td>
+  </tr>
+  <tr style={TRANSPARENT_STYLE}>
+    <td style={AFTER_STYLE}>之後</td>
+    <td>
+      <CodeBlock language="dart">{trimSnippet(asyncClassStream)}</CodeBlock>
+    </td>
+  </tr>
+</table>
+
+[hookwidget]: https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/HookWidget-class.html
+[statefulwidget]: https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html
+[riverpod]: https://github.com/rrousselgit/riverpod
+[hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
+[flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
+[flutter_hooks]: https://github.com/rrousselGit/flutter_hooks
+[build]: https://pub.dev/documentation/riverpod/latest/riverpod/Notifier/build.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/about_hooks.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/about_hooks.mdx
@@ -1,0 +1,570 @@
+---
+title: 關於 Hooks（鉤子）
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import hookAndConsumer from "!!raw-loader!/docs/concepts/about_hooks/hook_and_consumer.dart";
+import hookConsumer from "!!raw-loader!/docs/concepts/about_hooks/hook_consumer.dart";
+import hookConsumerWidget from "!!raw-loader!/docs/concepts/about_hooks/hook_consumer_widget.dart";
+import { CodeSnippet } from "@site/src/components/CodeSnippet";
+import { Link } from "@site/src/components/Link";
+
+<!---
+This page explains what are hooks and how they are related to Riverpod.
+-->
+本頁介紹了什麼是 Hooks 以及它們與 Riverpod 的關係。
+
+<!---
+"Hooks" are utilities common from a separate package, independent from Riverpod:
+[flutter_hooks].  
+Although [flutter_hooks] is a completely separate package and does not have anything
+to do with Riverpod (at least directly), it is common to pair Riverpod
+and [flutter_hooks] together.
+-->
+"Hooks" 是獨立於 Riverpod 的單獨包中常見的實用程式：[flutter_hooks]。  
+雖然 [flutter_hooks] 是一個完全獨立的包，
+並且與 Riverpod 沒有任何關係（至少沒有直接關係），
+但通常將 Riverpod 和 [flutter_hooks] 配對在一起。
+
+<!---
+## Should you use hooks?
+-->
+## 你應該使用 hooks 嗎？​
+
+<!---
+Hooks are a powerful tool, but they are not for everyone.  
+If you are a newcomer to Riverpod, you should probably avoid using hooks.
+-->
+Hooks 是一個強大的工具，但並不適合所有人。  
+如果您是 Riverpod 的新手，您可能應該避免使用 hooks。
+
+<!---
+Although useful, hooks are not necessary for Riverpod.  
+You shouldn't start using hooks because of Riverpod. Rather, you should start
+using hooks because you want to use hooks.
+-->
+雖然 hooks 很有用，但對於 Riverpod 來說並不是必需的。  
+您不應該為了 Riverpod 開始使用 hooks。
+相反，您開始使用 hooks，是因為您想使用 hooks。
+
+<!---
+Using hooks is a tradeoff. They can be great for producing robust and reusable
+code, but they are also a new concept to learn, and they can be confusing at first.
+Hooks aren't a core Flutter concept. As such, they will feel out of place in Flutter/Dart.
+-->
+使用 hooks 是一種權衡。它們非常適合生成健壯且可重用的程式碼，
+但它們也是一個需要學習的新概念，一開始可能會令人困惑。
+Hooks 不是 Flutter 的核心概念。因此，它們在 Flutter/Dart 中會感覺格格不入。
+
+<!---
+## What are hooks?
+-->
+## 什麼是 Hooks？​
+
+<!---
+Hooks are functions used inside widgets. They are designed as an alternative
+to [StatefulWidget]s, to make logic more reusable and composable.
+-->
+Hooks 是小部件內部使用的函式。它們被設計為 [StatefulWidget] 的替代品，
+以使邏輯更加可重用和可組合。
+
+<!---
+Hooks are a concept coming from [React](https://reactjs.org/), and [flutter_hooks]
+is merely a port of the React implementation to Flutter.  
+As such, yes, hooks may feel a bit out of place in Flutter. Ideally,
+in the future we would have a solution to the problem that hooks solves,
+designed specifically for Flutter.
+-->
+Hooks 是來自 [React](https://reactjs.org/) 的一個概念，[flutter_hooks]
+只是 React 實現到 Flutter 的一個埠。  
+因此，是的，hooks 在 Flutter 中可能感覺有點不合適。理想情況下，
+未來我們會有一個專門為 Flutter 設計的 Hooks 解決問題的解決方案。
+
+<!---
+If Riverpod's providers are for "global" application state, hooks are for
+local widget state. Hooks are typically used for dealing with stateful UI objects,
+such as [TextEditingController](https://api.flutter.dev/flutter/widgets/TextEditingController-class.html),
+[AnimationController](https://api.flutter.dev/flutter/animation/AnimationController-class.html).  
+They can also serve as a replacement to the "builder" pattern, replacing widgets
+such as [FutureBuilder](https://api.flutter.dev/flutter/widgets/FutureBuilder-class.html)/[TweenAnimatedBuilder](https://api.flutter.dev/flutter/widgets/TweenAnimationBuilder-class.html)
+by an alterative that does not invole "nesting" – drastically improving readability.
+-->
+如果 Riverpod 的提供者程式用於“全域性”應用程式狀態，則 Hooks 用於本地小部件狀態。
+Hooks 通常用於處理有狀態的 UI 物件，例如 [TextEditingController](https://api.flutter.dev/flutter/widgets/TextEditingController-class.html)、
+[AnimationController](https://api.flutter.dev/flutter/animation/AnimationController-class.html)。  
+它們還可以作為“構建器”模式的替代品，用不涉及“巢狀”的替代方案替換諸如
+[FutureBuilder](https://api.flutter.dev/flutter/widgets/FutureBuilder-class.html)/[TweenAnimatedBuilder](https://api.flutter.dev/flutter/widgets/TweenAnimationBuilder-class.html)
+之類的小部件，從而大大提高可讀性。
+
+<!---
+In general, hooks are helpful for:
+-->
+一般來說，鉤子有助於：
+
+<!---
+- forms
+- animations
+- reacting to user events
+- ...
+-->
+- 表單
+- 動畫
+- 對使用者事件做出反應
+- ……
+
+<!---
+As an example, we could use hooks to manually implement a fade-in animation,
+where a widget starts invisible and slowly appears.
+-->
+例如，我們可以使用鉤子手動實現淡入動畫，其中小部件開始不可見並慢慢出現。
+
+<!---
+If we were to use [StatefulWidget], the code would look like this:
+-->
+如果我們使用 [StatefulWidget]，程式碼將如下所示：
+
+```dart
+class FadeIn extends StatefulWidget {
+  const FadeIn({Key? key, required this.child}) : super(key: key);
+
+  final Widget child;
+
+  @override
+  State<FadeIn> createState() => _FadeInState();
+}
+
+class _FadeInState extends State<FadeIn> with SingleTickerProviderStateMixin {
+  late final AnimationController animationController = AnimationController(
+    vsync: this,
+    duration: const Duration(seconds: 2),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    animationController.forward();
+  }
+
+  @override
+  void dispose() {
+    animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: animationController,
+      builder: (context, child) {
+        return Opacity(
+          opacity: animationController.value,
+          child: widget.child,
+        );
+      },
+    );
+  }
+}
+```
+
+<!---
+Using hooks, the equivalent would be:
+-->
+使用 hooks，相當於：
+
+```dart
+class FadeIn extends HookWidget {
+  const FadeIn({Key? key, required this.child}) : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    // 建立一個 AnimationController。
+    // 解除安裝 widget 時，控制器將自動處置。
+    final animationController = useAnimationController(
+      duration: const Duration(seconds: 2),
+    );
+
+    // useEffect 相當於 initState + didUpdateWidget + dispose。
+    // 傳給 useEffect 的回撥會在第一次呼叫鉤子時執行，
+    // 然後每當作為第二個引數傳遞的列表發生變化時也會執行。
+    // 由於我們在這裡傳遞的是一個空的常量列表，
+    // 因此嚴格意義上等同於 `initState`。
+    useEffect(() {
+      // 在首次呈現 widget 時啟動動畫。
+      animationController.forward();
+      // 我們可以選擇在這裡返回一些“處置”邏輯
+      return null;
+    }, const []);
+
+    // 告訴 Flutter 在動畫更新時重建此部件。
+    // 這相當於 AnimatedBuilder
+    useAnimation(animationController);
+
+    return Opacity(
+      opacity: animationController.value,
+      child: child,
+    );
+  }
+}
+```
+
+<!---
+There are a few interesting things to note in this code:
+-->
+這段程式碼中有一些有趣的事情需要注意：
+
+<!---
+- There is no memory leak. This code does not recreate a new `AnimationController` whenever the
+  widget rebuild, and the controller is correctly released when the widget is unmounted.
+-->
+- 不存在記憶體洩漏。每當小部件重建時，此程式碼都不會重新建立新的 `AnimationController`，
+  並且在解除安裝小部件時正確處置控制器。
+
+<!---
+- It is possible to use hooks as many time as we want within the same widget.
+  As such, we can create multiple `AnimationController` if we want:
+
+  ```dart
+  @override
+  Widget build(BuildContext context) {
+    final animationController = useAnimationController(
+      duration: const Duration(seconds: 2),
+    );
+    final anotherController = useAnimationController(
+      duration: const Duration(seconds: 2),
+    );
+
+    ...
+  }
+  ```
+
+  This creates two controllers, without any sort of negative consequence.
+-->
+- 在同一個小部件中可以根據需要多次使用鉤子。
+  因此，如果我們願意，我們可以建立多個 `AnimationController`：
+
+  ```dart
+  @override
+  Widget build(BuildContext context) {
+    final animationController = useAnimationController(
+      duration: const Duration(seconds: 2),
+    );
+    final anotherController = useAnimationController(
+      duration: const Duration(seconds: 2),
+    );
+
+    ...
+  }
+  ```
+
+  這會建立兩個控制器，不會產生任何負面後果。
+
+<!---
+- If we wanted, we could refactor this logic into a separate reusable function:
+
+  ```dart
+  double useFadeIn() {
+    final animationController = useAnimationController(
+      duration: const Duration(seconds: 2),
+    );
+    useEffect(() {
+      animationController.forward();
+      return null;
+    }, const []);
+    useAnimation(animationController);
+    return animationController.value;
+  }
+  ```
+
+  We could then use this function inside our widgets, as long as that widget is a [HookWidget]:
+
+  ```dart
+  class FadeIn extends HookWidget {
+    const FadeIn({Key? key, required this.child}) : super(key: key);
+
+    final Widget child;
+
+    @override
+    Widget build(BuildContext context) {
+      final fade = useFadeIn();
+
+      return Opacity(opacity: fade, child: child);
+    }
+  }
+  ```
+
+  Note how our `useFadeIn` function is completely independent from our
+  `FadeIn` widget.  
+  If we wanted, we could use that `useFadeIn` function in a completely different
+  widget, and it would still work!
+-->
+- 如果我們願意，我們可以將此邏輯重構為一個單獨的可重用函式：
+
+  ```dart
+  double useFadeIn() {
+    final animationController = useAnimationController(
+      duration: const Duration(seconds: 2),
+    );
+    useEffect(() {
+      animationController.forward();
+      return null;
+    }, const []);
+    useAnimation(animationController);
+    return animationController.value;
+  }
+  ```
+
+  然後我們可以在我們的小部件中使用這個函式，只要該小部件是 [HookWidget]：
+
+  ```dart
+  class FadeIn extends HookWidget {
+    const FadeIn({Key? key, required this.child}) : super(key: key);
+
+    final Widget child;
+
+    @override
+    Widget build(BuildContext context) {
+      final fade = useFadeIn();
+
+      return Opacity(opacity: fade, child: child);
+    }
+  }
+  ```
+
+  請注意我們的 `useFadeIn` 函式是如何完全獨立於我們的 `FadeIn` 小部件的。  
+  如果我們願意，我們可以在完全不同的小部件中使用該 `useFadeIn` 函式，並且它仍然可以工作！
+
+<!---
+## The rules of hooks
+-->
+## hooks 的規則​
+
+<!---
+Hooks comes with unique constraints:
+-->
+Hooks 具有獨特的約束：
+
+<!---
+- They can only be used within the `build` method of a widget that extends [HookWidget]:
+
+  **Good**:
+
+  ```dart
+  class Example extends HookWidget {
+    @override
+    Widget build(BuildContext context) {
+      final controller = useAnimationController();
+      ...
+    }
+  }
+  ```
+
+  **Bad**:
+
+  ```dart
+  // Not a HookWidget
+  class Example extends StatelessWidget {
+    @override
+    Widget build(BuildContext context) {
+      final controller = useAnimationController();
+      ...
+    }
+  }
+  ```
+
+  **Bad**:
+
+  ```dart
+  class Example extends HookWidget {
+    @override
+    Widget build(BuildContext context) {
+      return ElevatedButton(
+        onPressed: () {
+          // Not _actually_ inside the "build" method, but instead inside
+          // a user interaction lifecycle (here "on pressed").
+          final controller = useAnimationController();
+        },
+        child: Text('click me'),
+      );
+    }
+  }
+  ```
+-->
+- 它們只能在擴充套件 [HookWidget] 的小部件的 `build` 方法中使用：
+
+  **好**:
+
+  ```dart
+  class Example extends HookWidget {
+    @override
+    Widget build(BuildContext context) {
+      final controller = useAnimationController();
+      ...
+    }
+  }
+  ```
+
+  **壞**:
+
+  ```dart
+  // 不是 HookWidget
+  class Example extends StatelessWidget {
+    @override
+    Widget build(BuildContext context) {
+      final controller = useAnimationController();
+      ...
+    }
+  }
+  ```
+
+  **壞**:
+
+  ```dart
+  class Example extends HookWidget {
+    @override
+    Widget build(BuildContext context) {
+      return ElevatedButton(
+        onPressed: () {
+          // _實際上_不是在 "build" 方法中，
+          // 而是在使用者互動生命週期中（這裡是 "按下時"）。
+          final controller = useAnimationController();
+        },
+        child: Text('click me'),
+      );
+    }
+  }
+  ```
+
+<!---
+- They cannot be used conditionally or in a loop.
+
+  **Bad**:
+
+  ```dart
+  class Example extends HookWidget {
+    const Example({required this.condition, super.key});
+    final bool condition;
+    @override
+    Widget build(BuildContext context) {
+      if (condition) {
+        // Hooks should not be used inside "if"s/"for"s, ...
+        final controller = useAnimationController();
+      }
+      ...
+    }
+  }
+  ```
+-->
+- 它們不能在條件語句或在迴圈語句中使用。
+
+  **壞**:
+
+  ```dart
+  class Example extends HookWidget {
+    const Example({required this.condition, super.key});
+    final bool condition;
+    @override
+    Widget build(BuildContext context) {
+      if (condition) {
+        // 不應該在 "if"/"for"/... 中使用 Hooks
+        final controller = useAnimationController();
+      }
+      ...
+    }
+  }
+  ```
+
+<!---
+For more information about hooks, see [flutter_hooks].
+-->
+有關鉤子的更多資訊，請參閱 [flutter_hooks]。
+
+<!---
+## Hooks and Riverpod
+-->
+## Hooks 和 Riverpod
+
+<!---
+### Installation
+-->
+### 安裝
+
+<!---
+Since hooks are independent from Riverpod, it is necessary to install hooks
+separately. If you want to use them, installing [hooks_riverpod] is not
+enough. You will still need to add [flutter_hooks] to your dependencies.
+See <Link documentID="introduction/getting_started" hash="installing-the-package" />) for more information.
+-->
+由於 Hooks 與 Riverpod 是獨立的，因此需要單獨安裝 Hooks。
+如果你想使用它們，安裝 [hooks_riverpod] 是不夠的。
+您仍然需要將 [flutter_hooks] 新增到您的依賴項中。
+請參閱 <Link documentID="introduction/getting_started" hash="installing-the-package" /> 瞭解更多資訊。
+
+<!---
+### Usage
+-->
+### 用途​
+
+<!---
+In some cases, you may want to write a Widget that uses both hooks and Riverpod.
+But as you may have already noticed, both hooks and Riverpod provide their
+own custom widget base type: [HookWidget] and [ConsumerWidget].  
+But classes can only extend one superclass at a time.
+-->
+在某些情況下，您可能想要編寫一個同時使用 hooks 和 Riverpod 的 Widget。
+但您可能已經注意到，Hooks 和 Riverpod 都提供了自己的
+自定義小部件基本型別：[HookWidget] 和 [ConsumerWidget]。  
+但類一次只能擴充套件一個父類。
+
+<!---
+To solve this problem, you can use the [hooks_riverpod] package.
+This package provides a [HookConsumerWidget] class that combines both
+[HookWidget] and [ConsumerWidget] into a single type.  
+You can therefore subclass [HookConsumerWidget] instead of [HookWidget]:
+-->
+為了解決這個問題，你可以使用 [hooks_riverpod] 包。
+該包提供了一個 [HookConsumerWidget] 類，
+它將 [HookWidget] 和 [ConsumerWidget] 組合成一個型別。  
+因此，您可以繼承 [HookConsumerWidget] 而不是 [HookWidget]：
+
+<CodeSnippet snippet={hookConsumerWidget}></CodeSnippet>
+
+<!---
+Alternatively, you can use the "builders" provided by both packages.  
+For example, we could stick to using `StatelessWidget`, and use both
+`HookBuilder` and `Consumer`.
+-->
+或者，您可以使用兩個包提供的“構建器 builder”。  
+例如，我們可以堅持使用 `StatelessWidget`，
+並同時使用 `HookBuilder` 和 `Consumer`。
+
+<CodeSnippet snippet={hookAndConsumer}></CodeSnippet>
+
+:::note
+<!---
+This approach would work without using [hooks_riverpod]. Only [flutter_riverpod]
+is needed.
+-->
+這種方法無需使用 `hooks_riverpod` 即可工作。只需要 `flutter_riverpod`。
+:::
+
+<!---
+If you like this approach, [hooks_riverpod] streamlines it by providing [HookConsumer],
+which is the combination of both builders in one:
+-->
+如果您喜歡這種方法，[hooks_riverpod] 透過提供 [HookConsumer] 來簡化它，
+它是兩個構建器的組合：
+
+<CodeSnippet snippet={hookConsumer}></CodeSnippet>
+
+[hookwidget]: https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/HookWidget-class.html
+[hookconsumer]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/HookConsumer-class.html
+[hookconsumerwidget]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/HookConsumerWidget-class.html
+[consumerwidget]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ConsumerWidget-class.html
+[statefulwidget]: https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html
+[riverpod]: https://github.com/rrousselgit/riverpod
+[hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
+[flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
+[flutter_hooks]: https://github.com/rrousselGit/flutter_hooks

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/async_initialization.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/async_initialization.dart
@@ -1,0 +1,58 @@
+// ignore_for_file: omit_local_variable_types, prefer_final_locals
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LoadingScreen extends StatelessWidget {
+  const LoadingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const CircularProgressIndicator();
+  }
+}
+
+/* SNIPPET START */
+// We'd like to obtain an instance of shared preferences synchronously in a provider
+final countProvider = StateProvider<int>((ref) {
+  final preferences = ref.watch(sharedPreferencesProvider);
+  final currentValue = preferences.getInt('count') ?? 0;
+  ref.listenSelf((prev, curr) {
+    preferences.setInt('count', curr);
+  });
+  return currentValue;
+});
+
+// We don't have an actual instance of SharedPreferences, and we can't get one except asynchronously
+final sharedPreferencesProvider =
+    Provider<SharedPreferences>((ref) => throw UnimplementedError());
+
+Future<void> main() async {
+  // Show a loading indicator before running the full app (optional)
+  // The platform's loading screen will be used while awaiting if you omit this.
+  runApp(const LoadingScreen());
+
+  // Get the instance of shared preferences
+  final prefs = await SharedPreferences.getInstance();
+  return runApp(
+    ProviderScope(
+      overrides: [
+        // Override the unimplemented provider with the value gotten from the plugin
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+      child: const MyApp(),
+    ),
+  );
+}
+
+class MyApp extends ConsumerWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Use the provider without dealing with async issues
+    final count = ref.watch(countProvider);
+    return Text('$count');
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/combining_providers.mdx
@@ -1,0 +1,214 @@
+---
+title: Combining Provider States
+---
+
+import charactersProvider from "/docs/concepts/combining_provider_states/characters_provider";
+import cityProvider from "/docs/concepts/combining_provider_states/city_provider";
+import filteredTodoListProvider from "/docs/concepts/combining_provider_states/filtered_todo_list_provider";
+import readInProvider from "/docs/concepts/combining_provider_states/read_in_provider";
+import selectAsyncProvider from "/docs/concepts/combining_provider_states/select_async_provider";
+import todoListProvider from "/docs/concepts/combining_provider_states/todo_list_provider";
+import weatherProvider from "/docs/concepts/combining_provider_states/weather_provider";
+import wholeObjectProvider from "/docs/concepts/combining_provider_states/whole_object_provider";
+import { Link } from "@site/src/components/Link";
+import {
+  trimSnippet,
+  AutoSnippet,
+  When,
+} from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+Make sure to read <Link documentID="concepts/providers"/> first.  
+In this guide, we will learn about combining provider states.
+
+## Combining provider states
+
+We've previously seen how to create a simple provider. But the reality is,
+in many situations a provider will want to read the state of another provider.
+
+To do that, we can use the [ref] object passed to the callback of our provider,
+and use its [watch] method.
+
+As an example, consider the following provider:
+
+<AutoSnippet language="dart" {...cityProvider}></AutoSnippet>
+
+We can now create another provider that will consume our `cityProvider`:
+
+<AutoSnippet language="dart" {...weatherProvider}></AutoSnippet>
+
+That's it. We've created a provider that depends on another provider.
+
+## FAQ
+
+### What if the value being listened to changes over time?
+
+Depending on the provider that you are listening to, the value obtained may
+change over time.
+For example, you may be listening to a [NotifierProvider], or the provider
+being listened to may have been forced to refresh through the use of
+[ProviderContainer.refresh]/[ref.refresh].
+
+When using [watch], Riverpod is able to detect that the value being listened to changed
+and will _automatically_ re-execute the provider's creation callback when needed.
+
+This can be useful for computed states.
+For example, consider a <Link documentID="providers/notifier_provider"/> that exposes a todo-list:
+
+<AutoSnippet language="dart" {...todoListProvider}></AutoSnippet>
+
+A common use-case would be to have the UI filter the list of todos to show
+only the completed/uncompleted todos.
+
+An easy way to implement such a scenario would be to:
+
+- create a [StateProvider], which exposes the currently selected filter method:
+
+  ```dart
+  enum Filter {
+    none,
+    completed,
+    uncompleted,
+  }
+
+  final filterProvider = StateProvider((ref) => Filter.none);
+  ```
+
+- make a separate provider which combines the filter method and the todo-list
+  to expose the filtered todo-list:
+
+  <AutoSnippet language="dart" {...filteredTodoListProvider}></AutoSnippet>
+
+Then, our UI can listen to `filteredTodoListProvider` to listen to the filtered todo-list.  
+Using such an approach, the UI will automatically update when either the filter
+or the todo-list changes.
+
+To see this approach in action, you can look at the source code of the [Todo List
+example](https://github.com/rrousselGit/riverpod/tree/master/examples/todos).
+
+:::info
+This behavior is not specific to [Provider], and works with all providers.
+
+For example, you could combine [watch] with [FutureProvider] to implement a search
+feature that supports live-configuration changes:
+
+<AutoSnippet language="dart" {...charactersProvider}></AutoSnippet>
+
+This code will fetch a list of characters from the service, and automatically
+re-fetch the list whenever the configurations change or when the search query changes.
+:::
+
+### Can I read a provider without listening to it?
+
+Sometimes, we want to read the content of a provider, but without re-creating
+the value exposed when the value obtained changes.
+
+An example would be a `Repository`, which reads from another provider the user token
+for authentication.  
+We could use [watch] and create a new `Repository` whenever the user token changes,
+but there is little to no use in doing that.
+
+In this situation, we can use [read], which is similar to [watch], but will not
+cause the provider to recreate the value it exposes when the value obtained changes.
+
+In that case, a common practice is to pass the provider's `Ref` to the object created.
+The object created will then be able to read providers whenever it wants.
+
+```dart
+final userTokenProvider = StateProvider<String>((ref) => null);
+
+final repositoryProvider = Provider(Repository.new);
+
+class Repository {
+  Repository(this.ref);
+
+  final Ref ref;
+
+  Future<Catalog> fetchCatalog() async {
+    String token = ref.read(userTokenProvider);
+
+    final response = await dio.get('/path', queryParameters: {
+      'token': token,
+    });
+
+    return Catalog.fromJson(response.data);
+  }
+}
+```
+
+:::danger **DON'T** call [read] inside the body of a provider
+
+<AutoSnippet language="dart" {...readInProvider}></AutoSnippet>
+
+If you used [read] as an attempt to avoid unwanted rebuilds of your object,
+refer to [My provider updates too often, what can I do?](#my-provider-updates-too-often-what-can-i-do)
+:::
+
+### How to test an object that receives [ref] as a parameter of its constructor?
+
+If you are using the pattern described in [Can I read a provider without listening to it?](#can-i-read-a-provider-without-listening-to-it),
+you may be wondering how to write tests for your object.
+
+In this scenario, consider testing the provider directly instead of the raw object.
+You can do so by using the [ProviderContainer] class:
+
+```dart
+final repositoryProvider = Provider((ref) => Repository(ref));
+
+test('fetches catalog', () async {
+  final container = ProviderContainer();
+  addTearDown(container.dispose);
+
+  Repository repository = container.read(repositoryProvider);
+
+  await expectLater(
+    repository.fetchCatalog(),
+    completion(Catalog()),
+  );
+});
+```
+
+### My provider updates too often, what can I do?
+
+If your object is re-created too often your provider is likely listening
+to objects that it doesn't care about.
+
+For example, you may be listening to a `Configuration` object, but only use the `host`
+property.  
+By listening to the entire `Configuration` object, if a property other than `host`
+changes, this still causes your provider to be re-evaluated – which may be
+undesired.
+
+The solution to this problem is to create a separate provider that exposes _only_
+what you need in `Configuration` (so `host`):
+
+**AVOID** listening to the entire object:
+
+<AutoSnippet language="dart" {...wholeObjectProvider}></AutoSnippet>
+
+**PREFER** using select when you only need a single property of an object:
+
+<AutoSnippet language="dart" {...selectAsyncProvider}></AutoSnippet>
+
+This will only rebuild the `productsProvider` when the `host` changes.
+
+[provider]: ../providers/provider
+[stateprovider]: ../providers/state_provider
+[futureprovider]: ../providers/future_provider
+[statenotifierprovider]: ../providers/state_notifier_provider
+[notifierProvider]: ../providers/notifier_provider
+[ref]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref-class.html
+[watch]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/watch.html
+[read]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/read.html
+[providercontainer.refresh]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer/refresh.html
+[ref.refresh]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/WidgetRef/refresh.html
+[providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/modifiers/auto_dispose.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/modifiers/auto_dispose.mdx
@@ -1,0 +1,141 @@
+---
+title: .autoDispose
+---
+
+:::caution
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+:::
+
+A common use case is to destroy the state of a provider
+when it is no-longer used.
+
+There are multiple reasons for doing so, such as:
+
+- When using Firebase, to close the connection and avoid unnecessary cost.
+- To reset the state when the user leaves a screen and re-enters it.
+
+Providers come with built-in support for this use case, through the `.autoDispose`
+modifier.
+
+## Usage
+
+To tell Riverpod to destroy the state of a provider when it is no longer used,
+simply append `.autoDispose` to your provider:
+
+```dart
+final userProvider = StreamProvider.autoDispose<User>((ref) {
+
+});
+```
+
+That's it. Now, the state of `userProvider` will automatically be destroyed
+when it is no longer used.
+
+Note how the generic parameters are passed after `autoDispose` instead of before –
+`autoDispose` is not a named constructor.
+
+:::note
+You can combine `.autoDispose` with other modifiers if you need to:
+
+```dart
+final userProvider = StreamProvider.autoDispose.family<User, String>((ref, id) {
+
+});
+```
+
+:::
+
+### ref.keepAlive
+
+Marking a provider with `autoDispose` also adds an extra method on `ref`: `keepAlive`.
+
+The `keepAlive` function is used to tell Riverpod that the state of the provider
+should be preserved even if no longer listened to.
+
+A use-case would be to set this flag to `true` after an HTTP request has
+completed:
+
+```dart
+final myProvider = FutureProvider.autoDispose((ref) async {
+  final response = await httpClient.get(...);
+  ref.keepAlive();
+  return response;
+});
+```
+
+This way, if the request fails and the user leaves the screen then re-enters
+it, then the request will be performed again.
+But if the request completed successfully, the state will be preserved
+and re-entering the screen will not trigger a new request.
+
+:::info
+In version 1.0.x, the equivalent of `keepAlive` is the property called `maintainState`.
+:::
+
+## Example: Canceling HTTP requests when no longer used
+
+The `autoDispose` modifier could be combined with [FutureProvider] and `ref.onDispose`
+to easily cancel HTTP requests when they are no longer needed.
+
+The goal is:
+
+- Start an HTTP request when the user enters a screen
+- if the user leaves the screen before the request completed, cancel the HTTP request
+- if the request succeeded, leaving and re-entering the screen does not start a new request
+
+In code, this would be:
+
+```dart
+final myProvider = FutureProvider.autoDispose((ref) async {
+  // An object from package:dio that allows cancelling http requests
+  final cancelToken = CancelToken();
+  // When the provider is destroyed, cancel the http request
+  ref.onDispose(() => cancelToken.cancel());
+
+  // Fetch our data and pass our `cancelToken` for cancellation to work
+  final response = await dio.get('path', cancelToken: cancelToken);
+  // If the request completed successfully, keep the state
+  ref.keepAlive();
+  return response;
+});
+```
+
+## The argument type 'AutoDisposeProvider' can't be assigned to the parameter type 'AlwaysAliveProviderBase'
+
+When using `.autoDispose`, you may find yourself in a situation where your
+application does not compile with an error similar to:
+
+> The argument type 'AutoDisposeProvider' can't be assigned to the parameter
+> type 'AlwaysAliveProviderBase'
+
+Don't worry! This error is voluntary. It happens because you most likely
+have a bug:
+
+You tried to listen to a provider marked with `.autoDispose` in a provider that
+is **not** marked with `.autoDispose`, such as:
+
+```dart
+final firstProvider = Provider.autoDispose((ref) => 0);
+
+final secondProvider = Provider((ref) {
+  // The argument type 'AutoDisposeProvider<int>' can't be assigned to the
+  // parameter type 'AlwaysAliveProviderBase<Object, Null>'
+  ref.watch(firstProvider);
+});
+```
+
+This is undesired, as it would cause `firstProvider` to never be disposed.
+
+To fix this, consider marking `secondProvider` with `.autoDispose` too:
+
+```dart
+final firstProvider = Provider.autoDispose((ref) => 0);
+
+final secondProvider = Provider.autoDispose((ref) {
+  ref.watch(firstProvider);
+});
+```
+
+[futureprovider]: ../../providers/future_provider

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/modifiers/family.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/modifiers/family.mdx
@@ -1,0 +1,192 @@
+---
+title: .family
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import { Link } from "@site/src/components/Link";
+
+:::caution
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+:::
+
+Before reading this, consider reading about <Link documentID="concepts/providers"/> and <Link documentID="concepts/reading"/>.
+In this part, we will talk in detail about the `.family` provider modifier.
+
+The `.family` modifier has one purpose: Getting a unique provider based on external parameters.
+
+Some common use-cases for `family` would be:
+
+- Combining [FutureProvider] with `.family` to fetch a `Message` from its ID
+- Passing the current `Locale` to a provider, so that we can handle translations
+
+## Usage
+
+The way families works is by adding an extra parameter to the provider.
+This parameter can then be freely used in our provider to create some state.
+
+For example, we can combine `family` with [FutureProvider] to fetch
+a `Message` from its ID:
+
+```dart
+final messagesFamily = FutureProvider.family<Message, String>((ref, id) async {
+  return dio.get('http://my_api.dev/messages/$id');
+});
+```
+
+When using our `messagesFamily` provider, the syntax is slightly different.  
+The usual syntax will not work anymore:
+
+```dart
+Widget build(BuildContext context, WidgetRef ref) {
+  // Error – messagesFamily is not a provider
+  final response = ref.watch(messagesFamily);
+}
+```
+
+Instead, we need to pass a parameter to `messagesFamily`:
+
+```dart
+Widget build(BuildContext context, WidgetRef ref) {
+  final response = ref.watch(messagesFamily('id'));
+}
+```
+
+:::info
+It is possible to use a family with different parameters simultaneously.  
+For example, we could use a `titleFamily` to read both the French and English
+translations at the same time:
+
+```dart
+@override
+Widget build(BuildContext context, WidgetRef ref) {
+  final frenchTitle = ref.watch(titleFamily(const Locale('fr')));
+  final englishTitle = ref.watch(titleFamily(const Locale('en')));
+
+  return Text('fr: $frenchTitle en: $englishTitle');
+}
+```
+
+:::
+
+## Parameter restrictions
+
+For families to work correctly, it is critical for the parameter passed to
+a provider to have a consistent `hashCode` and `==`.
+
+Ideally, the parameter should either be a primitive (bool/int/double/String),
+a constant (providers), or an immutable object that overrides `==` and `hashCode`.
+
+### _PREFER_ using `autoDispose` when the parameter is not constant:
+
+You may want to use families to pass the input of a search field to your provider.
+But that value can change often and never be reused.  
+This could cause memory leaks as, by default, a provider is never destroyed even
+if no longer used.
+
+Using both `.family` and `.autoDispose` fixes that memory leak:
+
+```dart
+final characters = FutureProvider.autoDispose.family<List<Character>, String>((ref, filter) async {
+  return fetchCharacters(filter: filter);
+});
+```
+
+## Passing multiple parameters to a family
+
+Families have no built-in support for passing multiple values to a provider.
+
+On the other hand, that value could be _anything_ (as long as it matches with
+the restrictions mentioned previously).
+
+This includes:
+
+- A tuple from [tuple](http://pub.dev/packages/tuple)
+- Objects generated with [Freezed] or [built_value](https://pub.dev/packages/built_value)
+- Objects using [equatable](https://pub.dev/packages/equatable)
+
+Here's an example of using [Freezed] or [equatable] for multiple parameters:
+
+<Tabs
+  groupId="family"
+  defaultValue="freezed"
+  values={[
+    { label: 'Freezed', value: 'freezed', },
+    { label: 'Equatable', value: 'equatable', },
+  ]}
+>
+
+<TabItem value="freezed">
+
+```dart
+@freezed
+abstract class MyParameter with _$MyParameter {
+  factory MyParameter({
+    required int userId,
+    required Locale locale,
+  }) = _MyParameter;
+}
+
+final exampleProvider = Provider.autoDispose.family<Something, MyParameter>((ref, myParameter) {
+  print(myParameter.userId);
+  print(myParameter.locale);
+  // Do something with userId/locale
+});
+
+@override
+Widget build(BuildContext context, WidgetRef ref) {
+  int userId; // Read the user ID from somewhere
+  final locale = Localizations.localeOf(context);
+
+  final something = ref.watch(
+    exampleProvider(MyParameter(userId: userId, locale: locale)),
+  );
+
+  ...
+}
+```
+
+</TabItem>
+<TabItem value="equatable">
+
+```dart
+class MyParameter extends Equatable  {
+  MyParameter({
+    required this.userId,
+    required this.locale,
+  });
+
+  final int userId;
+  final Locale locale;
+
+  @override
+  List<Object> get props => [userId, locale];
+}
+
+final exampleProvider = Provider.family<Something, MyParameter>((ref, myParameter) {
+  print(myParameter.userId);
+  print(myParameter.locale);
+  // Do something with userId/locale
+});
+
+@override
+Widget build(BuildContext context, WidgetRef ref) {
+  int userId; // Read the user ID from somewhere
+  final locale = Localizations.localeOf(context);
+
+  final something = ref.watch(
+    exampleProvider(MyParameter(userId: userId, locale: locale)),
+  );
+
+  ...
+}
+```
+
+</TabItem>
+</Tabs>
+
+[freezed]: https://pub.dev/packages/freezed
+[equatable]: https://pub.dev/packages/equatable
+[futureprovider]: ../../providers/future_provider

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/provider_lifecycles.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/provider_lifecycles.mdx
@@ -1,0 +1,112 @@
+---
+title: Provider Lifecycles
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import onDispose from "/docs/concepts/lifecycle_on_dispose";
+import { trimSnippet, When, AutoSnippet } from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+## When does my Provider get created and disposed?
+
+The states that all different types of providers can go through are the same:
+
+- Uninitialized
+- Alive
+- Paused
+- Disposed
+
+### Disposed / Uninitialized
+
+An **Uninitialized** or **Disposed** provider does not take up any memory since its state is not initialized.
+Essentially it is just a definition of how to create the provider's state when you need it.
+It will stay that way until an **Alive** provider or a [WidgetRef] from the UI reads, watches, or listens to it.
+
+### Creating -> Alive
+
+When an **Uninitialized** provider is read, listened to or watched it's state will be created.
+
+During creation your provider's build function will be run. 
+Any providers that you read or watch using the `ref` exposed by the callback will be created as needed and their state will be retrieved.
+
+If there are any circular dependencies during this creation process Riverpod will throw an error.
+The best way to fix this error is to redesign your dependencies to have a uni-directional dataflow.
+
+The provider's state is stored in a [ProviderContainer]. In a Flutter app this container is in a [ProviderScope] widget.
+
+As such, even though the definition of how to create the state (the provider) is global, the state is actually local,
+and can be different in different portions of your UI using nested [ProviderScope] widgets and overrides.
+
+This is very similar to how flutter widgets work. You only pay for the definition once, but can reuse the state in different parts of the tree as needed.
+
+### Alive
+
+When your provider is **Alive**, changes to its state will cause dependent providers and/or the dependent UI to rebuild.
+
+From the other perspective, as a reactive framework, you can watch other providers to have the provider recreate itself whenever one of it's dependencies changes.
+
+If you need to have some long-lived state that depends on other state you can use Ref's [listen] method to subscribe for changes on another provider without causing a rebuild of the provider.
+
+If you need to use the state from another provider in a side-effect, you can use Ref's [read] method to obtain the current state from another provider.
+
+Typically when constructing a [StateNotifier] or [ChangeNotifier] class you should pass in the `ref` to allow the Notifier to obtain the current value of dependencies as needed. By using the new [Notifier] and [AsyncNotifier] classes from Riverpod 2.0, the ref is already available as an instance member of the class.
+
+### Alive -> Paused
+When an **Alive** provider is no longer listened to by other providers or the UI, it goes into a **Paused** state. 
+This means that it no longer will react to changes on providers it is listening to.
+This is an optimization, as if you are not listening to the provider, there is no need to keep it alive. 
+Every provider not being used will be returned to a **Paused** state, reducing the computational burden of your app.
+
+If you need to keep a provider alive for side-effects, make sure to listen to it in an appropriate place in the UI where it should be kept alive.
+
+If you need to perform some action when a provider is paused use the ref's [onCancel] method to register callbacks.
+
+If you need to perform some action when a provider resumes to an Alive state from a paused state, use the ref's [onResume] method to register callbacks.
+
+If you want the state to be disposed, so that in addition to taking no computational resources, it also disposes of the memory of the state, use the `.autoDispose` modifier on your provider definition.
+This will cause it to transition to a **Disposed** state instead of **Paused** when it is no longer being used.
+
+### Alive -> Disposing
+
+There are a few reasons for a provider to be disposed.
+
+- When defined using the `.autoDispose` modifier and no longer being watched by the UI or another provider
+- When the provider is being manually refreshed or invalidated
+- When the provider is being recreated due to one of it's watched dependencies changing
+
+Refreshing causes the provider to immediately go through the creation process again, whereas invalidating causes the next read / watch of the provider to cause the provider to be rebuilt.
+
+## Performing actions before the state destruction
+If you need to perform some action when a provider is disposed, use the ref's [onDispose] method to register callbacks.
+
+The following example uses onDispose to close a StreamController:
+
+<AutoSnippet {...onDispose}></AutoSnippet>
+
+:::note
+Depending on the provider used, it may already take care of the clean-up process.
+For example, [StateNotifierProvider] will call the `dispose` method of the returned [StateNotifier].
+:::
+
+[onDispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
+[listen]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/listen.html
+[onCancel]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onCancel.html
+[onResume]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onResume.html
+[ProviderContainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
+[Notifier]: https://pub.dev/documentation/riverpod/latest/riverpod/Notifier-class.html
+[AsyncNotifier]: https://pub.dev/documentation/riverpod/latest/riverpod/AsyncNotifier-class.html
+[ProviderScope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
+[WidgetRef]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/WidgetRef-class.html
+[StateNotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html
+[StateNotifierProvider]: https://pub.dev/documentation/riverpod/latest/riverpod/StateNotifierProvider-class.html
+[StreamController]: https://api.dart.dev/stable/2.15.1/dart-async/StreamController-class.html
+[ChangeNotifier]: https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/provider_observer.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/provider_observer.mdx
@@ -1,0 +1,53 @@
+---
+title: ProviderObserver
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import logger from "!!raw-loader!/docs/concepts/provider_observer_logger.dart";
+import { trimSnippet } from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+[ProviderObserver] listens to the changes of a ProviderContainer.
+
+To use it, extend the class ProviderObserver and override the method you want to use.
+
+[ProviderObserver] has three methods :
+
+- `didAddProvider` is called every time a provider was initialized, and the value exposed is `value`.
+- `didDisposeProvider` is called every time a provider was disposed.
+- `didUpdateProvider` is called every time by providers when they emit a notification.
+
+### Usage :
+
+A simple use case for [ProviderObserver] is to log the changes in providers by overriding the `didUpdateProvider` method.
+
+<CodeBlock>{trimSnippet(logger)}</CodeBlock>
+
+Now, every time the value of our provider is updated, the logger will log it:
+
+```
+I/flutter (16783): {
+I/flutter (16783):   "provider": "counter",
+I/flutter (16783):   "newValue": "1"
+I/flutter (16783): }
+```
+
+:::note:
+For states that are mutable such as [StateController] (the state of [StateProvider.state]) and
+[ChangeNotifier] the previousValue and newValue will be the same
+:::
+since they reference the same `StateController` / `ChangeNotifier`.
+
+[providerobserver]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderObserver-class.html
+[statecontroller]: https://pub.dev/documentation/riverpod/latest/riverpod/StateController-class.html
+[stateprovider.state]: https://pub.dev/documentation/riverpod/latest/riverpod/StateProvider/state.html
+[changenotifier]: https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
@@ -1,0 +1,61 @@
+// ignore_for_file: use_key_in_widget_constructors, avoid_print
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+// A Counter example implemented with riverpod with Logger
+
+class Logger extends ProviderObserver {
+  @override
+  void didUpdateProvider(
+    ProviderBase<Object?> provider,
+    Object? previousValue,
+    Object? newValue,
+    ProviderContainer container,
+  ) {
+    print('''
+{
+  "provider": "${provider.name ?? provider.runtimeType}",
+  "newValue": "$newValue"
+}''');
+  }
+}
+
+void main() {
+  runApp(
+    // Adding ProviderScope enables Riverpod for the entire project
+    // Adding our Logger to the list of observers
+    ProviderScope(observers: [Logger()], child: const MyApp()),
+  );
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(home: Home());
+  }
+}
+
+final counterProvider = StateProvider((ref) => 0, name: 'counter');
+
+class Home extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(counterProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Counter example')),
+      body: Center(
+        child: Text('$count'),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => ref.read(counterProvider.notifier).state++,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/providers.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/providers.mdx
@@ -1,0 +1,185 @@
+---
+title: Providers
+---
+
+import creatingProvider from "/docs/concepts/providers/creating_a_provider";
+import declaringManyProviders from "/docs/concepts/providers/declaring_many_providers";
+import {
+  AutoSnippet,
+} from "@site/src/components/CodeSnippet";
+import { Link } from "@site/src/components/Link";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+Now that we have installed [Riverpod], let's talk about "providers".
+
+Providers are the most important part of a [Riverpod] application.
+A provider is an object that encapsulates a piece of state and allows listening
+to that state.
+
+## Why use providers?
+
+Wrapping a piece of state in a provider:
+
+- Allows easily accessing that state in multiple locations.
+  Providers are a complete replacement for patterns like Singletons,
+  Service Locators, Dependency Injection or InheritedWidgets.
+
+- Simplifies combining this state with others.
+  Ever struggled to merge multiple objects into one? This scenario is built
+  directly inside providers.
+
+- Enables performance optimizations.
+  Whether for filtering widget rebuilds or for caching expensive state computations;
+  providers ensure that only what is impacted by a state change is recomputed.
+
+- Increases the testability of your application.
+  With providers, you do not need complex `setUp`/`tearDown` steps. Furthermore,
+  any provider can be overridden to behave differently during a test, which
+  allows easily testing a very specific behavior.
+
+- Allows easy integration with advanced features, such as logging or
+  pull-to-refresh.
+
+## Creating a provider
+
+Providers come in many variants, but they all work the same way.
+
+The most common usage is to declare them as global constants like so:
+
+<AutoSnippet language="dart" {...creatingProvider}></AutoSnippet>
+
+:::note
+Do not be frightened by the global aspect of providers.
+Providers are fully immutable. Declaring a provider is no different from declaring
+a function, and providers are testable and maintainable.
+:::
+
+This snippet consists of three components:
+
+- `final myProvider`, the declaration of a variable.
+  This variable is what we will use in the future to read the state of our provider.
+  Providers should always be `final`.
+
+- `Provider`, the provider that we decided to use.
+  [Provider] is the most basic of all providers. It exposes an object that never
+  changes.
+  We could replace [Provider] with other providers like [StreamProvider] or
+  [NotifierProvider], to change how the value is interacted with.
+
+- A function that creates the shared state.
+  That function will always receive an object called `ref` as a parameter. This object
+  allows us to read other providers, perform some operations when the state
+  of our provider will be destroyed, and much more.
+
+The type of the object returned by the function passed to a provider depends on
+the provider used.
+For example, the function of a [Provider] can create any object.
+On the other hand, [StreamProvider]'s callback will be expected to return a [Stream].
+
+:::info
+You can declare as many providers as you want without limitations.
+As opposed to when using `package:provider`, [Riverpod] allows creating multiple
+providers exposing a state of the same "type":
+
+<AutoSnippet language="dart" {...declaringManyProviders}></AutoSnippet>
+
+The fact that both providers create a `String` does not cause any problem.
+:::
+
+:::caution
+For providers to work, you must add [ProviderScope] at the root of your
+Flutter applications:
+
+```dart
+void main() {
+  runApp(ProviderScope(child: MyApp()));
+}
+```
+
+:::
+
+## Different Types of Providers
+
+There are multiple types of providers for multiple different use cases.
+
+With all of these providers available, it is sometimes difficult to understand when to use one provider type over another.
+Use the table below to choose a provider that fits what you want to provide to the widget tree.
+
+| Provider Type            | Provider Create Function              | Example Use Case                                                                                      |
+| ------------------------ | ------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [Provider]               | Returns any type                      | A service class / computed property (filtered list)                                                   |
+| [StateProvider]          | Returns any type                      | A filter condition / simple state object                                                              |
+| [FutureProvider]         | Returns a Future of any type          | A result from an API call                                                                             |
+| [StreamProvider]         | Returns a Stream of any type          | A stream of results from an API                                                                       |
+| [NotifierProvider]       | Returns a subclass of (Async)Notifier | A complex state object that is immutable except through an interface                                  |
+| [StateNotifierProvider]  | Returns a subclass of StateNotifier   | A complex state object that is immutable except through an interface. Prefer using a notifierProvider |
+| [ChangeNotifierProvider] | Returns a subclass of ChangeNotifier  | A complex state object that requires mutability                                                       |
+
+:::caution
+While all providers have their purpose, [ChangeNotifierProvider]s are not recommended for scalable applications. See <Link documentID="concepts/why_immutability" />. It exists in the
+`flutter_riverpod` package to provide an easy migration path from
+`package:provider`, and allows for some flutter specific use-cases such as
+integration with some Navigator 2 packages. :::
+
+## Provider Modifiers
+
+All Providers have a built-in way to add extra functionalities to your different providers.
+
+They may add new features to the `ref` object or change slightly how the provider
+is consumed.
+Modifiers can be used on all providers, with a syntax similar to named constructor:
+
+```dart
+final myAutoDisposeProvider = StateProvider.autoDispose<int>((ref) => 0);
+final myFamilyProvider = Provider.family<String, int>((ref, id) => '$id');
+```
+
+At the moment, there are two modifiers available:
+
+- <Link documentID="concepts/modifiers/auto_dispose" />, which will make the
+  provider automatically destroy its state when it is no longer being listened
+  to.
+- <Link documentID="concepts/modifiers/family" />, which allows creating a
+  provider from external parameters.
+
+:::note
+A provider can use multiple modifiers at once:
+
+```dart
+final userProvider = FutureProvider.autoDispose.family<User, int>((ref, userId) async {
+  return fetchUser(userId);
+});
+```
+
+:::
+
+That's it for this guide!
+
+You can continue with <Link documentID="concepts/reading"/>.
+Alternatively, you can see <Link documentID="concepts/combining_providers"/>.
+
+[get_it]: http://pub.dev/packages/get_it
+[inheritedwidget]: https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html
+[stream]: https://api.dart.dev/stable/2.8.4/dart-async/Stream-class.html
+[ondispose]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/onDispose.html
+[riverpod]: https://github.com/rrousselgit/riverpod
+[hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
+[flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
+[flutter_hooks]: https://github.com/rrousselGit/flutter_hooks
+[provider]: /docs/providers/provider
+[streamprovider]: /docs/providers/stream_provider
+[futureprovider]: /docs/providers/future_provider
+[stateprovider]: /docs/providers/state_provider
+[statenotifierprovider]: /docs/providers/state_notifier_provider
+[notifierProvider]: /docs/providers/notifier_provider
+[changenotifierprovider]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ChangeNotifierProvider-class.html
+[providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/reading.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/reading.mdx
@@ -1,0 +1,464 @@
+---
+title: Reading a Provider
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import counter from "/docs/concepts/reading/counter";
+import consumerWidget from "/docs/concepts/reading/consumer_widget";
+import consumerStatefulWidget from "/docs/concepts/reading/consumer_stateful_widget";
+import consumerHook from "!!raw-loader!/docs/concepts/reading/consumer_hook.dart";
+import watch from "/docs/concepts/reading/watch";
+import watchBuild from "/docs/concepts/reading/watch_build";
+import listen from "/docs/concepts/reading/listen";
+import listenBuild from "/docs/concepts/reading/listen_build";
+import read from "/docs/concepts/reading/read";
+import readBuild from "/docs/concepts/reading/read_build";
+import readNotifierBuild from "/docs/concepts/reading/read_notifier_build";
+import watchNotifierBuild from "/docs/concepts/reading/watch_notifier_build";
+import provider from "/docs/concepts/reading/provider";
+import {
+  trimSnippet,
+  AutoSnippet,
+  When,
+} from "@site/src/components/CodeSnippet";
+import { Link } from "@site/src/components/Link";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+Before reading this guide, make sure to <Link documentID="concepts/providers"/> first.
+
+In this guide, we will see how to consume a provider.
+
+## Obtaining a "ref" object
+
+First and foremost, before reading a provider, we need to obtain a "ref" object.
+
+This object is what allows us to interact with providers, be it from a widget
+or another provider.
+
+### Obtaining a "ref" from a provider
+
+All providers receive a "ref" as a parameter:
+
+<AutoSnippet language="dart" {...provider}></AutoSnippet>
+
+This parameter is safe to pass to the value exposed by the provider.
+
+<When codegen={false}>
+
+A common use-case is to pass the provider's "ref" to a `StateNotifier`
+
+</When>
+
+<AutoSnippet language="dart" {...counter}></AutoSnippet>
+
+Doing so allows our `Counter` class to read providers.
+
+### Obtaining a "ref" from a widget
+
+Widgets naturally do not have a ref parameter. But [Riverpod] offers multiple
+solutions to obtain one from widgets.
+
+<When>
+
+#### Extending ConsumerWidget instead of StatelessWidget
+
+The most common way to obtain a ref in the widget tree is
+to replace [StatelessWidget] with [ConsumerWidget].
+
+[ConsumerWidget] is identical in use to [StatelessWidget], with the only
+difference being that it has an extra parameter on its build method: the "ref" object.
+
+A typical [ConsumerWidget] looks like:
+
+<AutoSnippet language="dart" {...consumerWidget}></AutoSnippet>
+
+#### Extending ConsumerStatefulWidget+ConsumerState instead of StatefulWidget+State
+
+Similar to [ConsumerWidget], [ConsumerStatefulWidget] and [ConsumerState] are the equivalent of a
+[StatefulWidget] with its [State], with the difference that the state has a "ref" object.
+
+This time, the "ref" isn't passed as parameter of the build method, but is
+a property of the [ConsumerState] object:
+
+<AutoSnippet language="dart" {...consumerStatefulWidget}></AutoSnippet>
+
+</When>
+
+<When hooks>
+
+#### Extending HookConsumerWidget instead of HookWidget
+
+This option is for [flutter_hooks] users. Since [flutter_hooks] requires
+extending [HookWidget] to work, widgets that use hooks are unable to extend
+[ConsumerWidget].
+
+The package [hooks_riverpod] exposes a new widget called [HookConsumerWidget].
+[HookConsumerWidget] acts as both a [ConsumerWidget] and a [HookWidget]. This
+allows a widget to both listen to providers and use hooks.
+
+An example would be:
+
+<AutoSnippet language="dart" {...consumerWidget}></AutoSnippet>
+
+#### Extending StatefulHookConsumerWidget instead of HookWidget
+
+This option is for [flutter_hooks] users, who need to use [StatefulWidget] lifecycle methods in addition to hooks.
+
+An example would be:
+
+<AutoSnippet language="dart" {...consumerStatefulWidget}></AutoSnippet>
+
+#### Consumer and HookConsumer widgets
+
+A final way to obtain a "ref" inside widgets is to rely on [Consumer]/
+[HookConsumer].
+
+These classes are widgets that can be used to obtain a "ref" in a builder callback, with the same
+properties as [ConsumerWidget]/[HookConsumerWidget].
+
+As such, these widgets are a way to obtain a "ref" without having to define a class.
+An example would be:
+
+<CodeBlock>{trimSnippet(consumerHook)}</CodeBlock>
+
+</When>
+
+## Using ref to interact with providers
+
+Now that we have a "ref", we can start using it.
+
+There are three primary usages for "ref":
+
+- obtaining the value of a provider and listening to changes, such that when
+  this value changes, this will rebuild the widget or provider that subscribed
+  to the value.
+  This is done using `ref.watch`
+- adding a listener on a provider, to execute an action such as navigating to a new
+  page or showing a modal whenever that provider changes.  
+  This is done using `ref.listen`.
+- obtaining the value of a provider while ignoring changes.
+  This is useful when we need the value of a provider in an event
+  such as "on click".
+  This is done using `ref.read`.
+
+:::note
+Whenever possible, prefer using `ref.watch` over `ref.read` or `ref.listen` to
+implement a feature.  
+By relying on `ref.watch`, your application becomes both reactive
+and declarative, which makes it more maintainable.
+:::
+
+### Using ref.watch to observe a provider
+
+`ref.watch` is used inside the `build` method of a widget or
+inside the body of a provider to have the widget/provider listen to a provider:
+
+For example, a provider could use `ref.watch` to combine multiple providers
+into a new value.
+
+An example would be filtering a todo-list.
+We could have two providers:
+
+- `filterTypeProvider`, a provider that exposes the current type of filter
+  (none, show only completed tasks, ...)
+- `todosProvider`, a provider that exposes the entire list of tasks
+
+And by using `ref.watch`, we could make a third provider that combines both providers to
+create a filtered list of tasks:
+
+<AutoSnippet language="dart" {...watch}></AutoSnippet>
+
+With this code, `filteredTodoListProvider` now exposes the filtered list of tasks.
+
+The filtered list will also automatically update if either the filter or the list of tasks
+changed. At the same time, the filtered list will not be recomputed if
+neither the filter nor the list of tasks changed.
+
+Similarly, a widget can use `ref.watch` to show
+the content from a provider and update the user interface whenever that content changes:
+
+<AutoSnippet language="dart" {...watchBuild}></AutoSnippet>
+
+This snippet shows a widget that listens to a provider which stores a `count`.
+And if that `count` changes, the widget will rebuild and the UI will update
+to show the new value.
+
+:::caution
+The `watch` method should not be called asynchronously,
+like inside an `onPressed` of an [ElevatedButton]. Nor should it be used
+inside `initState` and other [State] life-cycles.
+
+In those cases, consider using `ref.read` instead.
+:::
+
+### Using ref.listen to react to a provider change
+
+Similarly to `ref.watch`, it is possible to use `ref.listen` to observe a provider.
+
+The main difference between them is that, rather than rebuilding the widget/provider
+if the listened to provider changes, using `ref.listen` will instead call a custom function.
+
+That can be useful for performing actions when a certain change happens, such
+as showing a snackbar when an error happens.
+
+The `ref.listen` method needs 2 positional arguments, the first one is the Provider and the second one is the callback function that we want to execute when the state changes.
+The callback function when called will be passed 2 values, the value of the previous State and the value of the new State.
+
+The `ref.listen` method can be used inside the body of a provider:
+
+<AutoSnippet language="dart" {...listen}></AutoSnippet>
+
+or inside the `build` method of a widget:
+
+<AutoSnippet language="dart" {...listenBuild}></AutoSnippet>
+
+:::caution
+The `listen` method should not be called asynchronously,
+like inside an `onPressed` of an [ElevatedButton]. Nor should it be used
+inside `initState` and other [State] life-cycles.
+:::
+
+### Using ref.read to obtain the state of a provider
+
+The `ref.read` method is a way to obtain the state of a provider without listening to it.
+
+It is commonly used inside functions triggered by user interactions.
+For example, we can use `ref.read` to increment a counter when a user clicks a button:
+
+<AutoSnippet language="dart" {...read}></AutoSnippet>
+
+:::note
+Using `ref.read` should be avoided as much as possible because it is not reactive.
+
+It exists for cases where using `watch` or `listen` would cause issues.
+If you can, it is almost always better to use `watch`/`listen`, especially `watch`.
+:::
+
+#### **DON'T** use `ref.read` inside the build method
+
+You might be tempted to use `ref.read` to optimize the performance of a widget
+by doing:
+
+<AutoSnippet language="dart" {...readBuild}></AutoSnippet>
+
+But this is a very bad practice and can cause bugs that are difficult to track.
+
+Using `ref.read` this way is commonly associated with the thought "The value
+exposed by a provider never changes so using 'ref.read' is safe". The problem
+with this assumption is that, while today that provider may indeed never update
+its value, there is no guarantee that tomorrow will be the same.
+
+Software tends to change a lot, and it is likely that in the future, a value
+that previously never changed will need to change.  
+If you use `ref.read`, when that value needs to change, you have
+to go through your entire codebase to change `ref.read` into `ref.watch` –
+which is error prone and you are likely to forget some cases.
+
+If you use `ref.watch` to begin with, you will have fewer problems when refactoring.
+
+**_But I wanted to use `ref.read` to reduce the number of times my widget rebuilds_**
+
+While the goal is commendable, it is important to note that you can achieve the
+exact same effect (reducing the number of builds) using `ref.watch` instead.
+
+Providers offer various ways to obtain a value while reducing the number of
+rebuilds, which you could use instead.
+
+For example instead of
+
+<AutoSnippet language="dart" {...readNotifierBuild}></AutoSnippet>
+
+we could do:
+
+<AutoSnippet language="dart" {...watchNotifierBuild}></AutoSnippet>
+
+Both snippets achieve the same effect: our button will not rebuild when the
+counter increments.
+
+On the other hand, the second approach supports cases where the counter is reset.
+For example, another part of the application could call:
+
+```dart
+ref.refresh(counterProvider);
+```
+
+<When codegen={false}>
+  
+which would recreate the `StateController` object.
+
+If we used `ref.read` here, our button would still use the previous
+`StateController` instance, which was disposed and should no-longer be used.
+Whereas using `ref.watch` correctly rebuilds the button to use the new
+`StateController`.
+
+</When>
+
+<When codegen>
+
+which would recreate the `Counter` object.
+
+If we used `ref.read` here, our button would still use the previous `Counter`
+instance, which was disposed and should no-longer be used. Whereas using
+`ref.watch` correctly rebuilds the button to use the new `Counter`.
+
+</When>
+
+## Deciding what to read
+
+Depending on the provider you want to listen to, you may have multiple possible
+values that you can listen to.
+
+As an example, consider the following [StreamProvider]:
+
+```dart
+final userProvider = StreamProvider<User>(...);
+```
+
+When reading this `userProvider`, you can:
+
+- synchronously read the current state by listening to `userProvider` itself:
+
+  ```dart
+  Widget build(BuildContext context, WidgetRef ref) {
+    AsyncValue<User> user = ref.watch(userProvider);
+
+    return switch (user) {
+      AsyncData(:final value) => Text(value.name),
+      AsyncError(:final error) => const Text('Oops $error'),
+      _ => const CircularProgressIndicator(),
+    };
+  }
+  ```
+
+- obtain the associated [Stream], by listening to `userProvider.stream`:
+
+  ```dart
+  Widget build(BuildContext context, WidgetRef ref) {
+    Stream<User> user = ref.watch(userProvider.stream);
+  }
+  ```
+
+- obtain a [Future] that resolves with the latest value emitted, by listening to `userProvider.future`:
+
+  ```dart
+  Widget build(BuildContext context, WidgetRef ref) {
+    Future<User> user = ref.watch(userProvider.future);
+  }
+  ```
+
+Other providers may offer different alternative values.  
+For more information, refer to the documentation of each provider by
+consulting the [API reference](https://pub.dev/documentation/riverpod/latest/riverpod/riverpod-library.html).
+
+## Using "select" to filter rebuilds
+
+One final feature to mention related to reading providers is the ability to
+reduce the number of times a widget/provider rebuilds from `ref.watch`, or how often `ref.listen`
+executes a function.
+
+This is important to keep in mind as, by default, listening to a provider
+listens to the entire object state. But sometimes, a widget/provider may only
+care about changes to some properties instead of the whole object.
+
+For example, a provider may expose a `User`:
+
+```dart
+abstract class User {
+  String get name;
+  int get age;
+}
+```
+
+But a widget may only use the user name:
+
+```dart
+Widget build(BuildContext context, WidgetRef ref) {
+  User user = ref.watch(userProvider);
+  return Text(user.name);
+}
+```
+
+If we naively used `ref.watch`, this would rebuild the widget when the user's
+`age` changes.
+
+The solution is to use `select` to explicitly tell Riverpod that we only
+want to listen to the name property of the `User`.
+
+The updated code would be:
+
+```dart
+Widget build(BuildContext context, WidgetRef ref) {
+  String name = ref.watch(userProvider.select((user) => user.name));
+  return Text(name);
+}
+```
+
+By using `select`, we are able to specify a function
+that returns the property that we care about.
+
+Whenever the `User` changes, Riverpod will call this function and
+compare the previous and new result. If they are different (such as when the name
+changed), Riverpod will rebuild the widget.  
+However, if they are equal (such as when the age changed), Riverpod will not
+rebuild the widget.
+
+:::info
+It is also possible to use `select` with `ref.listen`:
+
+```dart
+ref.listen<String>(
+  userProvider.select((user) => user.name),
+  (String? previousName, String newName) {
+    print('The user name changed $newName');
+  }
+);
+```
+
+Doing so will call the listener only when the name changes.
+:::
+
+:::tip
+You don't have to return a property of the object. Any value that
+overrides == will work. For example you could do:
+
+```dart
+final label = ref.watch(userProvider.select((user) => 'Mr ${user.name}'));
+```
+
+:::
+
+[stateprovider]: ../providers/state_provider
+[providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
+[providerlistener]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderListener-class.html
+[providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
+[consumer]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/Consumer-class.html
+[consumerwidget]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ConsumerWidget-class.html
+[consumerstate]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ConsumerStatefulWidget-class.html
+[consumerstatefulwidget]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ConsumerState-class.html
+[useprovider]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ref.watch(.html
+[elevatedbutton]: https://api.flutter.dev/flutter/material/ElevatedButton-class.html
+[streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html
+[riverpod]: https://github.com/rrousselgit/riverpod
+[text]: https://api.flutter.dev/flutter/widgets/Text-class.html
+[hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
+[future]: https://api.dart.dev/stable/2.13.4/dart-async/Future-class.html
+[stream]: https://api.dart.dev/stable/2.13.4/dart-async/Stream-class.html
+[hookwidget]: https://pub.dev/documentation/flutter_hooks/latest/flutter_hooks/HookWidget-class.html
+[hookconsumerwidget]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/HookConsumerWidget-class.html
+[hookconsumer]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/HookConsumer-class.html
+[flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
+[flutter_hooks]: https://github.com/rrousselGit/flutter_hooks
+[statenotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html
+[streamprovider]: ../providers/stream_provider
+[statelesswidget]: https://api.flutter.dev/flutter/widgets/StatelessWidget-class.html
+[statefulwidget]: https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html
+[state]: https://api.flutter.dev/flutter/widgets/State-class.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/reading/consumer_hook.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/reading/consumer_hook.dart
@@ -1,0 +1,29 @@
+// ignore_for_file: unused_local_variable
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'counter/raw.dart';
+
+class HomeView extends HookConsumerWidget {
+  const HomeView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return
+/* SNIPPET START */
+        Scaffold(
+      body: HookConsumer(
+        builder: (context, ref, child) {
+          // Like HookConsumerWidget, we can use hooks inside the builder
+          final state = useState(0);
+
+          // We can also use the ref parameter to listen to providers.
+          final counter = ref.watch(counterProvider);
+          return Text('$counter');
+        },
+      ),
+    );
+/* SNIPPET END */
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/scopes.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/scopes.mdx
@@ -1,0 +1,171 @@
+---
+title: Scopes
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import asyncInitialization from "!!raw-loader!/docs/concepts/async_initialization.dart";
+import themeScope from "!!raw-loader!/docs/concepts/theme_scope.dart";
+import subtreeScope from "!!raw-loader!/docs/concepts/subtree_scope.dart";
+import { trimSnippet } from "@site/src/components/CodeSnippet";
+import { Link } from "@site/src/components/Link";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+Scoping in Riverpod is a very powerful feature, but like all powerful features, it should be used wisely and intentionally.
+
+A few of the things that scoping enables are:
+
+- Override the state of providers for a specific subtree (similar to how theming and `InheritedWidgets` work in flutter) [(see example)](#subtree-scope)
+- Creating synchronous providers for normally async APIs [(see example)](#initialization-of-synchronous-provider-for-async-apis)
+- Allowing `Dialog`s and `Overlay`s to inherit the state of providers from the widget subtree that cause them to be shown [(see example)](#showing-dialogs)
+- Optimizing rebuilds of widgets by removing parameters from Widget constructors allowing you to make them `const`
+
+If you are wanting to use scope for the first point, chances are you can use families instead.
+Families have the advantages of allowing you to access each of those instances of the state from anywhere in the widget tree rather than just the state scoped to the specific subtree that you are in.
+
+Using scope to create multiple instances of a provider's state is similar to how `package:provider` works.
+
+However, using scope to accomplish that task, is more restrictive, as you cannot decide to access other instances from that scope.
+
+As such, before scoping every provider you use, consider carefully why you want to scope the provider.
+
+## ProviderScope and ProviderContainer
+
+A scope is introduced by a [ProviderContainer]. This container holds the current state of all of your providers.
+It manages the lookup and subscriptions between providers.
+
+In Flutter you should use the [ProviderScope] widget, which contains a [ProviderContainer]
+internally, and provides a way to access that container to the rest of the widget tree.
+
+```dart
+final valueProvider = StateProvider((ref) => 0);
+
+// DO this
+void main() {
+  runApp(ProviderScope(child: MyApp()));
+}
+
+//DON'T do this:
+final myProviderContainer = ProviderContainer();
+void main(){
+  runApp(MyApp());
+}
+```
+
+:::warning
+Do not use multiple [ProviderContainer]s, without an understanding of how they work.
+Each will have it's own separate thread of states, which will not be able to access each other.
+Tests are an example of when you might want to use separate [ProviderContainer]s
+in order to make each test's state independent of the others.
+:::
+
+Only create a [ProviderContainer] without a [ProviderScope] for testing and dart-only usage.
+
+## How Riverpod Finds a Provider
+
+When a widget or provider requests the value of a provider, Riverpod looks up the state of that provider in the nearest
+[ProviderScope] widget. If neither the provider nor one of it's explicitly listed dependencies is overridden in that scope Riverpod continues it's lookup up the widget tree.
+If the provider has not been overridden in any Widget subtrees the lookup defaults to the [ProviderContainer] in the root [ProviderScope].
+
+Once this process locates the scope in which the provider should reside it determines if the provider has been created yet.
+If so, it will return the state of the provider.
+However, if the provider has been invalidated or is not currently initialized it will create the state using the provider's build method.
+
+## Initialization of Synchronous Provider for Async APIs
+
+Often you might have some async initialization of a dependency such as `SharedPreferences` or `FirebaseApp`.
+Many other providers might rely on this, and dealing with the error / loading states in each of those providers is redundant.
+
+You might be able to guarantee that those providers will not have errors and will load quickly when the app is started.
+
+So how do you makes these sorts of provider states available synchronously?
+
+Here is an example that shows how scoping allows you override a dummy provider when your asynchronous API is ready.
+
+<CodeBlock>{trimSnippet(asyncInitialization)}</CodeBlock>
+
+## Subtree Scoping
+
+Scoping allows you to override the state of a provider for a specific subtree of your widget tree.
+In this way it can provide a similar mechanism to `InheritedWidget` from flutter, or the providers from `package:provider`.
+
+For example, in flutter you can override the `Theme` for a particular subtree of your widget tree, by wrapping it in a `Theme` widget.
+
+<CodeBlock>{trimSnippet(themeScope)}</CodeBlock>
+
+Under the hood, `Theme` is an `InheritedWidget` and when widgets look up the `Theme` they get the `Theme` from the nearest `Theme` widget above it in the widget tree.
+
+Riverpod works differently, since all of the state of your application is typically stored in a root [ProviderScope] widget.
+Don't worry, this doesn't cause your whole application to rebuild when the state changes, it just allows you to access the state from anywhere in your widget tree.
+
+What if you want different providers depending on which page you are in?
+
+The first thing that you should consider is whether the provided behavior will differ in any way.
+
+If so -> just create a new provider with a different name and use it in that page
+
+If not -> Consider using a <Link documentID="concepts/modifiers/family"/>.
+
+Often you start by thinking that you only need a provider on a particular page, but end up wanting to use it in another page later on.
+Families protect you against this eventuality, and are a major difference in how you should adjust your thinking if you are coming from `package:provider`.
+
+If families really do not fit your use case, the following example shows you how to override a provider for a particular subtree.
+
+<CodeBlock>{trimSnippet(subtreeScope)}</CodeBlock>
+
+## When to choose Scoped Providers or Families
+
+While scopes are important to understand, it is easy to get carried away when using scopes.
+
+If you want a different instance of a provider's state depending on where it is in the widget tree you have a few alternatives available to you: `Scoping`, `Families`, or a combination.
+The appropriate choice depends on your use case.
+
+Families:
+
+- Pro: You can show multiple of the states no matter which subtree you are in
+- Pro: This makes it a more flexible and scalable solution for many use cases
+
+Scoping:
+
+- Con: You end up with more nesting of [ProviderScope] widgets in your widget tree
+- Con: You can only access the one override in your section of the widget tree
+- Con: You end up having to explicitly list the dependencies of most of your providers
+- Pro: You can reduce the number of parameters in your widget constructors
+- Pro: You get a slight performance advantage, and can potentially make some of your widget constructors `const`
+
+Using a combination of the two approaches, you can get the pros of both approaches, but you still have to deal with the cons of scoping.
+
+:::warning
+Remember that scopes introduce a new instance of the state of every provider that is overridden or has listed a dependency on a provider that was overridden.
+If you override with the same parameter in a different subtree of the app, it will **not** be the same instance of the provider's state.
+Families are more flexible in general, and with the upcoming code generation feature it is easy to use multiple parameters for a family.
+Often a good combination is to use both families and scoping. Use a family to provide general access to a piece of state anywhere in your app, and then use scoping to
+provide a specific instance of the family's state depending on where you are in the widget tree.
+:::
+
+### Less common usages of Scopes
+
+Sometimes you may want to override a whole set of providers in a specific subtree of your app.
+By listing a common provider in the dependencies list of each of those providers, you can easily create new states for all of them at once, by overriding the common one.
+
+Note that if you try to use families for this, you will end up with many families that all have the same parameter, and you could end up passing that parameter all over the widget tree.
+In this case it is also acceptable to use scopes.
+
+:::warning
+Once you start using scope, make sure to always list your dependencies and keep them up to date, to prevent runtime exceptions.
+To help with this we have created [riverpod_lint] which will warn you if there is a missing dependency.
+Additionally with [riverpod_generator] the code generator automatically generates the dependency list.
+:::
+
+[ProviderContainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
+[ProviderScope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
+[riverpod_lint]: https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod_lint
+[riverpod_generator]: https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod_generator

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/subtree_scope.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/subtree_scope.dart
@@ -1,0 +1,78 @@
+// ignore_for_file: omit_local_variable_types, prefer_final_locals
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+/// A counter that is being incremented by each [CounterDisplay]'s ElevatedButton
+final counterProvider = StateProvider(
+  (ref) => 0,
+);
+
+final adjustedCountProvider = Provider(
+  (ref) => ref.watch(counterProvider) * 2,
+  // Note that if a provider depends on a provider that is overridden for a subtree,
+  // you must explicitly list that provider in your dependencies list.
+  dependencies: [counterProvider],
+);
+
+class Home extends ConsumerWidget {
+  const Home({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+        body: Column(
+      children: [
+        ProviderScope(
+          /// Just specify which provider you want to have a copy of in the subtree
+          ///
+          /// Note that dependant providers such as [adjustedCountProvider] will
+          /// also be copied for this subtree. If that is not the behavior you want,
+          /// consider using families instead
+          overrides: [counterProvider],
+          child: const CounterDisplay(),
+        ),
+        ProviderScope(
+          // You can change the provider's behavior in a particular subtree
+          overrides: [counterProvider.overrideWith((ref) => 1)],
+          child: const CounterDisplay(),
+        ),
+        ProviderScope(
+          overrides: [
+            counterProvider,
+            // You can also change dependent provider's behaviors
+            adjustedCountProvider.overrideWith(
+              (ref) => ref.watch(counterProvider) * 3,
+            ),
+          ],
+          child: const CounterDisplay(),
+        ),
+        // This particular display will use the provider state from the root ProviderScope
+        const CounterDisplay(),
+      ],
+    ));
+  }
+}
+
+class CounterDisplay extends ConsumerWidget {
+  const CounterDisplay({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(counterProvider);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('$count'),
+        ElevatedButton(
+          onPressed: () {
+            ref.read(counterProvider.notifier).state++;
+          },
+          child: const Text('Increment Count'),
+        ),
+      ],
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/theme_scope.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/theme_scope.dart
@@ -1,0 +1,68 @@
+// ignore_for_file: omit_local_variable_types, prefer_final_locals
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+void main() {
+  runApp(
+    ProviderScope(
+      child: MaterialApp(
+        theme: ThemeData(primaryColor: Colors.blue),
+        home: const Home(),
+      ),
+    ),
+  );
+}
+
+// Have a counter that is being incremented
+final counterProvider = StateProvider(
+  (ref) => 0,
+);
+
+class Home extends ConsumerWidget {
+  const Home({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+        body: Column(
+      children: [
+        // This counter will have a primary color of green
+        Theme(
+          data: Theme.of(context).copyWith(primaryColor: Colors.green),
+          child: const CounterDisplay(),
+        ),
+        // This counter will have a primary color of blue
+        const CounterDisplay(),
+        ElevatedButton(
+          onPressed: () {
+            ref.read(counterProvider.notifier).state++;
+          },
+          child: const Text('Increment Count'),
+        ),
+      ],
+    ));
+  }
+}
+
+class CounterDisplay extends ConsumerWidget {
+  const CounterDisplay({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(counterProvider);
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          '$count',
+          style: theme.textTheme.displayMedium
+              ?.copyWith(color: theme.primaryColor),
+        ),
+      ],
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/why_immutability.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/concepts/why_immutability.mdx
@@ -1,0 +1,98 @@
+---
+title: Why Immutability
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import whyImmutability from "/docs/concepts/why_immutability"
+import {
+  trimSnippet,
+  AutoSnippet,
+  When,
+} from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+## What is Immutability?
+
+Immutability is when all fields of an `Object` are final or late final.
+They are set exactly once upon construction.
+
+Immutability is desireable for many different reasons
+
+- Value equality rather than reference equality
+- Local reasoning about a piece of code
+  - A far distant piece of code can't obtain a reference and change the object from underneath you
+- Easier to reason about for asynchronous and parallel tasks
+  - Other code can't mutate your object in between operations
+- Safety of APIs
+  - What you pass into a method cannot be changed by the callee / caller
+
+A copyWith method helps with reducing verbosity when creating a new object with just a few things changed.
+
+Copying is more efficient than you might think, since dart can reuse any references to sub-objects that have not changed.
+:::warning
+Make sure your objects are deeply immutable, otherwise you'll have to implement some sort of deep copy mechanism.
+:::
+
+## Best Practices
+
+You can use any package you want to create immutable state.
+
+For immutable objects:
+
+- [package:freezed](https://pub.dev/packages/freezed)
+- [package:built_value](https://pub.dev/packages/built_value)
+
+For immutable collections (Map, Set, List):
+
+- [package:fast_immutable_collections](https://pub.dev/packages/fast_immutable_collections)
+- [package:built_collection](https://pub.dev/packages/built_collection)
+- [package:kt_dart](https://pub.dev/packages/kt_dart)
+- [package:dartz](https://pub.dev/packages/dartz)
+
+It is highly recommended to use [freezed],
+since it has several nice additions beyond just making immutable objects including:
+
+- A generated copyWith method
+- Deep copy (copyWith on nested freezed objects)
+- Union types
+- Union mapping functions
+
+You do not need to use code generation to work with immutable state, but it makes it much easier.
+
+:::warning
+If you want to use the built-in collections, make sure to enforce a discipline of making copies of collections when updating them.
+The issue with not copying a collection is that riverpod determines whether to emit a new state based on whether the reference to the object has changed.
+If you just call a method that mutates an object, the reference is the same.
+:::
+
+### Using immutable state
+
+Immutable state is best fit for using a [Notifier] <When codegen={false}> in combination with [NotifierProvider] </When>.
+A [Notifier] allows you to expose an interface through which you can 'mutate' the state.
+You cannot mutate the state from outside the class you define that extends [Notifier].
+This enforces a separation of concerns and keeps business logic outside of your UI.
+
+Here is an example of a simple immutable settings class for changing an app theme.
+
+<AutoSnippet language="dart" {...whyImmutability}></AutoSnippet>
+
+To use this code, remember to import `freezed_annotation`, add the part directive and run [build_runner] to generate the freezed classes!
+
+[changenotifier]: https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html
+[statenotifier]: https://pub.dev/documentation/riverpod/latest/riverpod/StateNotifier-class.html
+[statenotifierprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/StateNotifierProvider-class.html
+[notifier]: https://pub.dev/documentation/riverpod/latest/riverpod/Notifier-class.html
+[notifierprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/NotifierProvider.html
+[asyncvalue]: https://pub.dev/documentation/riverpod/latest/riverpod/AsyncValue-class.html
+[freezed]: https://pub.dev/packages/freezed
+[build_runner]: https://pub.dev/packages/build_runner

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/search_as_we_type.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/search_as_we_type.mdx
@@ -1,0 +1,148 @@
+---
+title: Search as we type
+---
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+A real world example could be to use `FutureProvider` to implement a searchbar.
+
+## Usage example: "Search as we type" searchbar
+
+Implementing a "search as we type" can seem daunting at first when using
+conventional means.  
+There are lots of moving parts, such as:
+
+- handling errors.
+- debouncing the user input to avoid making network requests on every keystroke.
+- cancelling previously pending network requests when the search field changes.
+
+But the combination of `FutureProvider` and the power of [ref.watch] can
+significantly simplify this task.
+
+A common pattern wanting to perform an asynchronous requests
+is to split it into multiple providers:
+
+- a [StateNotifierProvider] or `StateProvider` for the parameters of your request
+  (or alternatively use [family])
+- a `FutureProvider`, which will do the request by reading the parameters from
+  the other providers/[family].
+
+The first step would be to store the user input somewhere. For this example,
+we will use `StateProvider` (as the search state is only a single `String`):
+
+```dart
+final searchInputProvider = StateProvider<String>((ref) => '');
+```
+
+We can then connect this provider to a [TextField] by doing:
+
+```dart
+Consumer(
+  builder: (context, ref, child) {
+    return TextField(
+      onChanged: (value) => ref.read(searchInputProvider.notifier).state = value,
+    );
+  },
+)
+```
+
+Then, we can create our `FutureProvider` which will take care of the request:
+
+```dart
+final searchProvider = FutureProvider<
+
+
+<!--
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+final searchFieldProvider = StateProvider<String>((ref) => '');
+final questionsProvider = FutureProvider<List>((ref) async {
+  final client = http.Client();
+  ref.onDispose(client.close);
+
+  final search = ref.watch(searchFieldProvider);
+
+  Uri uri;
+
+  if (search.isEmpty) {
+    uri = Uri.parse(
+      'https://api.stackexchange.com/2.3/questions?order=desc&sort=activity&site=stackoverflow',
+    );
+  } else {
+    final encodedQuery = Uri.encodeComponent(search);
+    uri = Uri.parse(
+      'https://api.stackexchange.com/2.3/search?order=desc&sort=activity&intitle=$encodedQuery&site=stackoverflow',
+    );
+  }
+
+  final response = await client.get(uri);
+  final questions = jsonDecode(response.body);
+
+  return questions['items'].map((question) => question['title']).toList();
+});
+
+void main() => runApp(const ProviderScope(child: MyApp()));
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(home: MyHomePage());
+  }
+}
+
+class MyHomePage extends ConsumerWidget {
+  const MyHomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final questions = ref.watch(questionsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Questions')),
+      body: Column(
+        children: [
+          TextField(
+            onChanged: (value) =>
+                ref.read(searchFieldProvider.notifier).state = value,
+          ),
+          Expanded(
+            child: switch (questions) {
+              AsyncData(:final value) => ListView.builder(
+                  itemCount: value.length,
+                  itemBuilder: (context, index) {
+                    final question = value[index];
+
+                    return ListTile(
+                      title: Text(
+                        question.toString(),
+                      ),
+                    );
+                  },
+                );,
+              AsyncError(:final error) => Center(child: Text('Error $error')),
+              _ => const Center(child: CircularProgressIndicator()),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+```

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing.mdx
@@ -1,0 +1,169 @@
+---
+title: Testing
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+import testingOriginalTestFlutter from "!!raw-loader!/docs/cookbooks/testing_original_test_flutter.dart";
+import testingOriginalTestDart from "!!raw-loader!/docs/cookbooks/testing_original_test_dart.dart";
+import repositorySnippet from "!!raw-loader!/docs/cookbooks/testing_repository.dart";
+import testFlutter from "!!raw-loader!/docs/cookbooks/testing_flutter.dart";
+import testDart from "!!raw-loader!/docs/cookbooks/testing_dart.dart";
+import testFull from "!!raw-loader!/docs/cookbooks/testing_full.dart";
+import testOverrideInfo from "!!raw-loader!/docs/cookbooks/testing_override_info.dart";
+import { trimSnippet } from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+For any medium to large-scale applications, it is critical to test the application.
+
+To successfully test our application, we will want the following things:
+
+- No state should be preserved between `test`/`testWidgets`.  
+  That means no global state in the application, or all global states should reset after each test.
+
+- Being able to force our providers to have a specific state, either through
+  mocking or by manipulating them until we reach the desired state.
+
+Let's see one by one how [Riverpod] helps you with these.
+
+## No state should be preserved between `test`/`testWidgets`.
+
+Since providers are usually declared as global variables, you might worry about
+that one.  
+After all, global state makes testing very difficult, because it can require
+lengthy `setUp`/`tearDown`.
+
+But the reality is: While providers are declared as globals, the state of a provider
+is **not** global.
+
+Instead, it is stored in an object named [ProviderContainer], which you may have
+seen if you looked at the dart-only examples.  
+If you haven't, know that this [ProviderContainer] object is implicitly created
+by [ProviderScope], the widget that enables [Riverpod] on our project.
+
+Concretely what this means is, two `testWidgets` using providers do not share
+any state.  
+As such, there is no need for any `setUp`/`tearDown` at all.
+
+But an example is better than lengthy explanations:
+
+<Tabs
+  defaultValue="testWidgets"
+  values={[
+    { label: 'testWidgets (Flutter)', value: 'testWidgets', },
+    { label: 'test (Dart only)', value: 'test', },
+  ]}
+>
+<TabItem value="testWidgets">
+
+<CodeBlock>{trimSnippet(testingOriginalTestFlutter)}</CodeBlock>
+
+</TabItem>
+<TabItem value="test">
+
+<CodeBlock>{trimSnippet(testingOriginalTestDart)}</CodeBlock>
+
+</TabItem>
+</Tabs>
+
+As you can see, while `counterProvider` was declared as a global, no state was
+shared between tests.  
+As such, we do not have to worry about our tests potentially behaving differently
+if executed in a different order, since they are running in complete isolation.
+
+## Overriding the behavior of a provider during tests.
+
+A common real-world application may have the following objects:
+
+- It will have a `Repository` class, which provides a type-safe and simple API
+  to perform HTTP requests.
+
+- An object that manages the application state, and may use `Repository` to perform
+  HTTP requests based on different factors.
+  This may be a `ChangeNotifier`, `Bloc`, or even a provider.
+
+Using [Riverpod], this may be represented as follows:
+
+<CodeBlock>{trimSnippet(repositorySnippet)}</CodeBlock>
+
+In this situation, when making a unit/widget test, we will typically want to
+replace our `Repository` instance with a fake implementation that returns
+a pre-defined response instead of making a real HTTP request.
+
+We will then want our `todoListProvider` or equivalent to use the mocked implementation
+of `Repository`.
+
+To achieve this, we can use the `overrides` parameter of [ProviderScope]/[ProviderContainer]
+to override the behavior of `repositoryProvider`:
+
+<Tabs
+  defaultValue="ProviderScope"
+  values={[
+    { label: 'ProviderScope (Flutter)', value: 'ProviderScope', },
+    { label: 'ProviderContainer (Dart only)', value: 'ProviderContainer', },
+  ]}
+>
+<TabItem value="ProviderScope">
+
+<CodeBlock>{trimSnippet(testFlutter)}</CodeBlock>
+
+</TabItem>
+<TabItem value="ProviderContainer">
+
+<CodeBlock>{trimSnippet(testDart)}</CodeBlock>
+
+</TabItem>
+</Tabs>
+
+As you can see by the highlighted code, [ProviderScope]/[ProviderContainer]
+allows replacing the implementation of a provider with a different behavior.
+
+:::info
+Some providers expose simplified ways to override their behavior.  
+For example, [FutureProvider] allows overriding the provider with an `AsyncValue`:
+
+<CodeBlock>{trimSnippet(testOverrideInfo)}</CodeBlock>
+
+**Note**: As part of the 2.0.0 release, `overrideWithValue` methods are temporarily
+removed. They will be added back in later versions.
+
+:::
+
+:::info
+The syntax for overriding a provider with the `family` modifier is slightly different.
+
+If you used a provider like this:
+
+```dart
+final response = ref.watch(myProvider('12345'));
+```
+
+You could override the provider as:
+
+```dart
+myProvider('12345').overrideWithValue(...));
+```
+
+:::
+
+## Full widget test example
+
+Wrapping up, here is the entire full code for our Flutter test.
+
+<CodeBlock>{trimSnippet(testFull)}</CodeBlock>
+
+[riverpod]: https://github.com/rrousselgit/riverpod
+[providerscope]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderScope-class.html
+[providercontainer]: https://pub.dev/documentation/riverpod/latest/riverpod/ProviderContainer-class.html
+[futureprovider]: ../providers/future_provider
+[zone]: https://api.flutter.dev/flutter/dart-async/Zone-class.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_dart.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_dart.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeRepository {}
+
+final repositoryProvider = Provider((ref) => FakeRepository());
+
+abstract class Todo {
+  String get id;
+  String get label;
+  bool get completed;
+}
+
+final todoListProvider = FutureProvider<List<Todo>>((ref) => []);
+
+void main() {
+/* SNIPPET START */
+
+test('override repositoryProvider', () async {
+  final container = ProviderContainer(
+    overrides: [
+      // Override the behavior of repositoryProvider to return
+      // FakeRepository instead of Repository.
+      /* highlight-start */
+      repositoryProvider.overrideWithValue(FakeRepository())
+      /* highlight-end */
+      // We do not have to override `todoListProvider`, it will automatically
+      // use the overridden repositoryProvider
+    ],
+  );
+
+  // The first read if the loading state
+  expect(
+    container.read(todoListProvider),
+    const AsyncValue<List<Todo>>.loading(),
+  );
+
+  /// Wait for the request to finish
+  await container.read(todoListProvider.future);
+
+  // Exposes the data fetched
+  expect(container.read(todoListProvider).value, [
+    isA<Todo>()
+        .having((s) => s.id, 'id', '42')
+        .having((s) => s.label, 'label', 'Hello world')
+        .having((s) => s.completed, 'completed', false),
+  ]);
+});
+
+/* SNIPPET END */
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_flutter.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_flutter.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class MyApp extends StatelessWidget {
+  // ignore: prefer_const_constructors_in_immutables
+  MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
+final repositoryProvider = Provider((ref) => FakeRepository());
+
+class FakeRepository {}
+
+void main() {
+/* SNIPPET START */
+
+testWidgets('override repositoryProvider', (tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        // Override the behavior of repositoryProvider to return
+        // FakeRepository instead of Repository.
+        /* highlight-start */
+        repositoryProvider.overrideWithValue(FakeRepository())
+        /* highlight-end */
+        // We do not have to override `todoListProvider`, it will automatically
+        // use the overridden repositoryProvider
+      ],
+      child: MyApp(),
+    ),
+  );
+});
+
+/* SNIPPET END */
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_full.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_full.dart
@@ -1,0 +1,99 @@
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class Repository {
+  Future<List<Todo>> fetchTodos() async => [];
+}
+
+class Todo {
+  Todo({
+    required this.id,
+    required this.label,
+    required this.completed,
+  });
+
+  final String id;
+  final String label;
+  final bool completed;
+}
+
+// We expose our instance of Repository in a provider
+final repositoryProvider = Provider((ref) => Repository());
+
+/// The list of todos. Here, we are simply fetching them from the server using
+/// [Repository] and doing nothing else.
+final todoListProvider = FutureProvider((ref) async {
+  // Obtains the Repository instance
+  final repository = ref.read(repositoryProvider);
+
+  // Fetch the todos and expose them to the UI.
+  return repository.fetchTodos();
+});
+
+/// A mocked implementation of Repository that returns a pre-defined list of todos
+class FakeRepository implements Repository {
+  @override
+  Future<List<Todo>> fetchTodos() async {
+    return [
+      Todo(id: '42', label: 'Hello world', completed: false),
+    ];
+  }
+}
+
+class TodoItem extends StatelessWidget {
+  const TodoItem({super.key, required this.todo});
+  final Todo todo;
+  @override
+  Widget build(BuildContext context) {
+    return Text(todo.label);
+  }
+}
+
+void main() {
+  testWidgets('override repositoryProvider', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          repositoryProvider.overrideWithValue(FakeRepository())
+        ],
+        // Our application, which will read from todoListProvider to display the todo-list.
+        // You may extract this into a MyApp widget
+        child: MaterialApp(
+          home: Scaffold(
+            body: Consumer(builder: (context, ref, _) {
+              final todos = ref.watch(todoListProvider);
+              // The list of todos is loading or in error
+              if (todos.asData == null) {
+                return const CircularProgressIndicator();
+              }
+              return ListView(
+                children: [
+                  for (final todo in todos.asData!.value) TodoItem(todo: todo)
+                ],
+              );
+            }),
+          ),
+        ),
+      ),
+    );
+
+    // The first frame is a loading state.
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    // Re-render. TodoListProvider should have finished fetching the todos by now
+    await tester.pump();
+
+    // No longer loading
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    // Rendered one TodoItem with the data returned by FakeRepository
+    expect(tester.widgetList(find.byType(TodoItem)), [
+      isA<TodoItem>()
+          .having((s) => s.todo.id, 'todo.id', '42')
+          .having((s) => s.todo.label, 'todo.label', 'Hello world')
+          .having((s) => s.todo.completed, 'todo.completed', false),
+    ]);
+  });
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_original_test_dart.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_original_test_dart.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:riverpod/riverpod.dart';
+
+/* SNIPPET START */
+
+// A Counter implemented and tested with Dart only (no dependency on Flutter)
+
+// We declared a provider globally, and we will use it in two tests, to see
+// if the state correctly resets to `0` between tests.
+
+final counterProvider = StateProvider((ref) => 0);
+
+// Using mockito to keep track of when a provider notify its listeners
+class Listener extends Mock {
+  void call(int? previous, int value);
+}
+
+void main() {
+  test('defaults to 0 and notify listeners when value changes', () {
+    // An object that will allow us to read providers
+    // Do not share this between tests.
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final listener = Listener();
+
+    // Observe a provider and spy the changes.
+    container.listen<int>(
+      counterProvider,
+      listener.call,
+      fireImmediately: true,
+    );
+
+    // the listener is called immediately with 0, the default value
+    verify(listener(null, 0)).called(1);
+    verifyNoMoreInteractions(listener);
+
+    // We increment the value
+    container.read(counterProvider.notifier).state++;
+
+    // The listener was called again, but with 1 this time
+    verify(listener(0, 1)).called(1);
+    verifyNoMoreInteractions(listener);
+  });
+
+  test('the counter state is not shared between tests', () {
+    // We use a different ProviderContainer to read our provider.
+    // This ensure that no state is reused between tests
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final listener = Listener();
+
+    container.listen<int>(
+      counterProvider,
+      listener.call,
+      fireImmediately: true,
+    );
+
+    // The new test correctly uses the default value: 0
+    verify(listener(null, 0)).called(1);
+    verifyNoMoreInteractions(listener);
+  });
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_original_test_flutter.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_original_test_flutter.dart
@@ -1,0 +1,56 @@
+// ignore_for_file: use_key_in_widget_constructors
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/* SNIPPET START */
+
+// A Counter implemented and tested using Flutter
+
+// We declared a provider globally, and we will use it in two tests, to see
+// if the state correctly resets to `0` between tests.
+
+final counterProvider = StateProvider((ref) => 0);
+
+// Renders the current state and a button that allows incrementing the state
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Consumer(builder: (context, ref, _) {
+        final counter = ref.watch(counterProvider);
+        return ElevatedButton(
+          onPressed: () => ref.read(counterProvider.notifier).state++,
+          child: Text('$counter'),
+        );
+      }),
+    );
+  }
+}
+
+void main() {
+  testWidgets('update the UI when incrementing the state', (tester) async {
+    await tester.pumpWidget(ProviderScope(child: MyApp()));
+
+    // The default value is `0`, as declared in our provider
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
+
+    // Increment the state and re-render
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pump();
+
+    // The state have properly incremented
+    expect(find.text('1'), findsOneWidget);
+    expect(find.text('0'), findsNothing);
+  });
+
+  testWidgets('the counter state is not shared between tests', (tester) async {
+    await tester.pumpWidget(ProviderScope(child: MyApp()));
+
+    // The state is `0` once again, with no tearDown/setUp needed
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
+  });
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
@@ -1,0 +1,43 @@
+// ignore_for_file: avoid_unused_constructor_parameters
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+extension on ProviderBase<Object?> {
+  // ignore: unused_element
+  Override overrideWithValue(Object? value) => throw UnimplementedError();
+}
+
+class Todo {
+  Todo({
+    required String id,
+    required String label,
+    required bool completed,
+  });
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
+/* SNIPPET START */
+
+final todoListProvider = FutureProvider((ref) async => <Todo>[]);
+// ...
+/* SKIP */
+final foo =
+/* SKIP END */
+    ProviderScope(
+  overrides: [
+    /// Allows overriding a FutureProvider to return a fixed value
+    todoListProvider.overrideWithValue(
+      AsyncValue.data([Todo(id: '42', label: 'Hello', completed: true)]),
+    ),
+  ],
+  child: const MyApp(),
+);

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_repository.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/cookbooks/testing_repository.dart
@@ -1,0 +1,22 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class Todo {}
+
+/* SNIPPET START */
+
+class Repository {
+  Future<List<Todo>> fetchTodos() async => [];
+}
+
+// We expose our instance of Repository in a provider
+final repositoryProvider = Provider((ref) => Repository());
+
+/// The list of todos. Here, we are simply fetching them from the server using
+/// [Repository] and doing nothing else.
+final todoListProvider = FutureProvider((ref) async {
+  // Obtains the Repository instance
+  final repository = ref.watch(repositoryProvider);
+
+  // Fetch the todos and expose them to the UI.
+  return repository.fetchTodos();
+});

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/auto_dispose.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/auto_dispose.mdx
@@ -1,0 +1,306 @@
+---
+title: 清除快取並對狀態處置做出反應
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet, When } from "@site/src/components/CodeSnippet";
+import onDisposeExample from "/docs/essentials/auto_dispose/on_dispose_example";
+import codegenKeepAlive from "!!raw-loader!/docs/essentials/auto_dispose/codegen_keep_alive.dart";
+import rawAutoDispose from "!!raw-loader!/docs/essentials/auto_dispose/raw_auto_dispose.dart";
+import invalidateExample from "!!raw-loader!/docs/essentials/auto_dispose/invalidate_example.dart";
+import keepAlive from "/docs/essentials/auto_dispose/keep_alive";
+import cacheForExtension from "!!raw-loader!/docs/essentials/auto_dispose/cache_for_extension.dart";
+import cacheForUsage from "/docs/essentials/auto_dispose/cache_for_usage";
+import invalidateFamilyExample from '/docs/essentials/auto_dispose/invalidate_family_example'
+
+<!---
+So far, we've seen how to create/update some state.
+But we have yet to talk about when state destruction occurs.
+-->
+到目前為止，我們已經瞭解瞭如何建立/更新某些狀態。
+但我們還沒有談論狀態處置何時發生。
+
+<!---
+Riverpod offers various ways to interact with state disposal.
+This ranges from delaying the disposal of state to reacting to destruction.
+-->
+Riverpod 提供了多種與狀態處置進行互動的方法。
+這包括從延遲處置狀態到對處置做出反應。
+
+<!---
+## When is state destroyed and how to change this?
+-->
+## 何時狀態被處置，如何改變這一點？
+
+<When codegen={true}>
+
+<!---
+When using code-generation, by default, the state is destroyed when
+the provider stops being listened to.  
+This happens when a listener has no active listener for a full frame.
+When that happens, the state is destroyed.
+-->
+使用程式碼生成時，預設情況下，當提供者程式停止被監聽時，狀態將被處置。  
+當監聽器在整個幀中沒有活動的監聽器時，會發生這種情況。
+當這種情況發生時，狀態將被處置。
+
+<!---
+This behavior can be opted out by using `keepAlive: true`.  
+Doing so will prevent the state from getting destroyed when all listeners
+are removed.
+-->
+可以使用 `keepAlive: true` 選擇停用此行為。  
+這樣做可以防止在刪除所有監聽器時狀態被處置。
+
+<AutoSnippet raw={codegenKeepAlive} />
+
+</When>
+
+<When codegen={false}>
+
+<!---
+When not using code-generation, by default the state isn't destroyed
+when the provider stops being listened.
+-->
+不使用程式碼生成時，預設情況下，當提供者程式停止監聽時，狀態不會被處置。
+
+<!---
+You can optionally change this behavior and use automatic disposal.
+When doing so, Riverpod will track whether a provider has listeners or not.
+Then, if the provider has no listeners for a full frame, the state will be destroyed.
+-->
+您可以選擇更改此行為並使用自動處置。
+執行此操作時，Riverpod 將跟蹤提供者程式是否有監聽器。
+然後，如果一幀的時間內提供者程式沒有監聽器，則狀態將被處置。
+
+<!---
+To enable automatic disposal, you can use `.autoDispose` next to the provider type:
+-->
+若要啟用自動處置，可以在提供者程式型別旁邊使用 `.autoDispose`：
+
+<AutoSnippet raw={rawAutoDispose} />
+
+</When>
+
+:::note
+<!---
+Enabling/disabling automatic disposal has no impact on whether or not
+the state is destroyed when the provider is recomputed.  
+The state will always be destroyed when the provider is recomputed.
+-->
+啟用/停用自動處置在重新計算提供者程式時，對於是否處置狀態沒有影響。  
+重新計算提供者程式時，狀態將始終被處置。
+:::
+
+:::caution
+<!---
+When providers receive parameters, it is recommended to enable automatic disposal.
+That is because otherwise, one state per parameter combination will be created,
+which can lead to memory leaks.
+-->
+當提供者程式收到引數時，建議啟用自動處置。
+這是因為否則，將為每個引數組合建立一個狀態，這可能會導致記憶體洩漏。
+:::
+
+<!---
+## Reacting to state disposal
+-->
+## 對狀態處置做出反應
+
+<!---
+In Riverpod, there are a few built-in ways for state to be destroyed:
+-->
+在 Riverpod 中，有幾種內建的處置狀態的方法：
+
+<!---
+- The provider is no longer used and is in "auto dispose" mode (more on that later).
+  In this case, all associated state with the provider is destroyed.
+- The provider is recomputed, such as with `ref.watch`.
+  In that case, the previous state is disposed, and a new state is created.
+-->
+- 提供者程式不再使用，並且處於“自動處置”模式（稍後會詳細介紹）。
+  在這種情況下，與提供者程式的所有關聯狀態都將被處置。
+- 提供者程式將重新計算，例如 `ref.watch`。
+  在這種情況下，將處置以前的狀態，並建立一個新狀態。
+
+<!---
+In both cases. you may want to execute some logic when that happens.  
+This can be achieved with `ref.onDispose`. This methods enables
+registering a listener to whenever the state is destroyed.
+-->
+在這兩種情況下。發生這種情況時，您可能希望執行一些邏輯。  
+這可以透過 `ref.onDispose` 實現。
+此方法允許註冊監聽器，當狀態被處置時回撥。
+
+<!---
+For example, you may want use it to close any active `StreamController`:
+-->
+例如，您可能希望使用它來關閉任何活動 `StreamController`：
+
+<AutoSnippet {...onDisposeExample} />
+
+:::caution
+<!---
+The callback of `ref.onDispose` must not trigger side-effects.
+Modifying providers inside `onDispose` could lead to unexpected behavior.
+-->
+不得觸發副作用的 `ref.onDispose` 回撥。
+修改提供者程式內部的 `onDispose` 可能會導致意外行為。
+:::
+
+:::info
+<!---
+There are other useful life-cycles such as:
+-->
+還有其他有用的生命週期，例如：
+
+<!---
+- `ref.onCancel` which is called when the last listener of a provider is removed.
+- `ref.onResume` which is called when a new listener is added after `onCancel` was invoked.
+-->
+- `ref.onCancel` 當刪除提供者程式的最後一個監聽器時呼叫。
+- `ref.onResume` 當 `onCancel` 呼叫之後新增新的監聽器時呼叫。
+
+:::
+
+:::info
+<!---
+You can call `ref.onDispose` as many times as you wish.
+Feel free to call it once per disposable object in your provider. This practice
+makes it easier to spot when we forget to dispose of something.
+-->
+您可以根據需要多次呼叫 `ref.onDispose`。
+在提供者程式中，每個可處置的物件可隨意呼叫一次。
+這種做法使我們更容易發現我們何時忘記處置某些東西。
+:::
+
+<!---
+## Manually forcing the destruction of a provider, using `ref.invalidate`
+-->
+## 手動強制處置提供者程式，使用 `ref.invalidate`
+
+<!---
+Sometimes, you may want to force the destruction of a provider.
+This can be done by using `ref.invalidate`, which can be called from another
+provider or a widget.
+-->
+有時，您可能希望強制處置提供者程式。
+這可以透過使用 `ref.invalidate` 來完成，
+它可以從另一個提供者程式或小部件呼叫。
+
+<!---
+Using `ref.invalidate` will destroy the current provider state.
+There are then two possible outcomes:
+-->
+使用 `ref.invalidate` 將處置當前提供者程式狀態。
+然後有兩種可能的結果：
+
+<!---
+- If the provider is listened, a new state will be created.
+- If the provider is not listened, the provider will be fully destroyed.
+-->
+- 如果監聽提供者程式，則將建立一個新狀態。
+- 如果提供者程式未被監聽，則提供者程式將被完全處置。
+
+<AutoSnippet raw={invalidateExample} />
+
+:::info
+<!---
+It is possible for providers to invalidate themselves by using `ref.invalidateSelf`.
+Although in this case, this will always result in a new state being created.
+-->
+提供者程式可以使用 `ref.invalidateSelf` 使自己失效。
+儘管在這種情況下，這始終會導致建立新狀態。
+:::
+
+:::tip
+<!---
+When trying to invalidate a provider which receives parameters,
+it is posible to either invalidate one specific parameter combination,
+or all parameter combinations at once:
+-->
+當嘗試使接收引數的提供者程式失效時，
+可能會使一個特定的引數組合失效，
+也可以同時使所有引數組合失效：
+
+<AutoSnippet {...invalidateFamilyExample} />
+:::
+
+<!---
+## Fine-tuned disposal with `ref.keepAlive`
+-->
+## 使用 `ref.keepAlive` 微調處置
+
+<!---
+As mentioned above, when automatic disposal is enabled, the state is destroyed
+when the provider has no listeners for a full frame.
+-->
+如上所述，當自動處置啟用時，如果在完整的一幀時間裡提供者程式沒有監聽器，狀態將被處置。
+
+<!---
+But you may want to have more control over this behavior. For instance,
+you may want to keep the state of successful network requests,
+but not cache failed requests.
+-->
+但您可能希望對此行為有更多的控制權。例如，
+您可能希望保留成功網路請求的狀態，但不快取失敗的請求。
+
+<!---
+This can be achieved with `ref.keepAlive`, after enabling automatic disposal.
+Using it, you can decide _when_ the state stops being automatically disposed.
+-->
+這可以在啟用自動處置後，使用透過 `ref.keepAlive` 來實現。
+使用它，您可以決定_何時_停止自動處置狀態。
+
+<AutoSnippet {...keepAlive} />
+
+:::note
+<!---
+If the provider is recomputed, automatic disposal will be re-enabled.
+-->
+如果重新計算提供者程式，將重新啟用自動處置。
+
+<!---
+It is also possible to use the return value of `ref.keepAlive` to
+revert to automatic disposal.
+-->
+也可以使用 `ref.keepAlive` 的返回值使其恢復到自動處置狀態。
+:::
+
+<!---
+## Example: keeping state alive for a specific amount of time
+-->
+## 示例：在一段特定時間內保持狀態
+
+<!---
+Currently, Riverpod does not offer a built-in way to keep state alive
+for a specific amount of time.  
+But implementing such a feature is easy and reusable with the tools we've seen so far.
+-->
+目前，Riverpod 不提供在特定時間內保持狀態的內建方法。  
+但是，使用我們目前看到的工具，實現這樣的功能很容易且可重用。
+
+<!---
+By using a `Timer` + `ref.keepAlive`, we can keep the state alive for a specific amount of time.
+To make this logic reusable, we could implement it in an extension method:
+-->
+透過使用 `Timer` + `ref.keepAlive`，我們可以在特定的時間內保持狀態。
+為了使這個邏輯可重用，我們可以在擴充套件方法中實現它：
+
+<AutoSnippet raw={cacheForExtension} />
+
+<!---
+Then, we can use it like so:
+-->
+然後，我們可以這樣使用它：
+
+<AutoSnippet {...cacheForUsage} />
+
+<!---
+This logic can be tweaked to fit your needs. 
+For example, you could use `ref.onCancel`/`ref.onResume` to destroy the state
+only if a provider hasn't been listened to for a specific amount of time.
+-->
+可以調整此邏輯以滿足您的需求。
+例如，僅當提供者程式在特定時間內未被監聽時，
+才可以使用 `ref.onCancel`/`ref.onResume` 處置狀態。

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/combining_requests.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/combining_requests.mdx
@@ -1,0 +1,275 @@
+---
+title: 組合請求
+version: 1
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet } from "@site/src/components/CodeSnippet";
+import functionalRef from "/docs/essentials/combining_requests/functional_ref";
+import notifierRef from "/docs/essentials/combining_requests/notifier_ref";
+import watchExample from "/docs/essentials/combining_requests/watch_example";
+import watchPlacement from "/docs/essentials/combining_requests/watch_placement";
+import listenExample from "/docs/essentials/combining_requests/listen_example";
+import readExample from '/docs/essentials/combining_requests/read_example'
+
+<!---
+Up until now, we've only seen cases were requests are independent from each
+other. But a common use-case is to have to trigger a request based on the
+result of another request.
+-->
+到目前為止，我們只看到請求彼此獨立的案例。
+但一個常見的用例是必須根據另一個請求的結果觸發請求。
+
+<!---
+We _could_ be using the <Link documentID="essentials/passing_args" /> mechanism to
+do that, by passing the result of a provider as parameter to another a provider.
+-->
+我們可以使用<Link documentID="essentials/passing_args" />機制來做到這一點，
+方法是將一個提供者程式的結果作為引數傳遞給另一個提供者程式。
+
+<!---
+But this approach has a few downsides:
+-->
+但這種方法有一些缺點：
+
+<!---
+- This leaks implementation details.
+  Now, your UI needs to know about all the providers that are used
+  your other provider.
+- Whenever the parameter change, a brand new state will be made.
+  By passing parameters, there are no way to keep the previous state
+  when the parameter changes.
+- It makes combining requests harder.
+- This makes tooling less useful. A devtool wouldn't
+  know about the relationship between providers.
+-->
+- 這洩露了實現細節。
+  現在，UI 需要了解所有被其他提供者程式使用的提供者程式。
+- 每當引數發生變化時，都會產生一個全新的狀態。
+  透過傳遞引數，當引數更改時，無法保持以前的狀態。
+- 它使合併請求變得更加困難。
+- 這使得開發工具的用處降低。devtool 不會知道提供者程式之間的關係。
+
+<!---
+To improve this, Riverpod offers a different approach to combining requests.
+-->
+為了改善這一點，Riverpod 提供了一種不同的方法來合併請求。
+
+<!---
+## The basics: Obtaining a "ref"
+-->
+## 基礎知識：獲取 "ref"
+
+<!---
+All possible ways of combining requests have one thing in common:
+They are all based on the `Ref` object.
+-->
+組合請求的所有可能方法都有一個共同點：它們都基於 `Ref` 物件。
+
+<!---
+The `Ref` object is an object which all providers have access to.
+It grants them access to various life-cycle listeners, but also
+various methods to combine providers.
+-->
+該 `Ref` 物件是所有提供者程式都有權訪問的物件。
+它允許他們訪問各種生命週期監聽器，
+還可以使用各種方法來組合提供者程式。
+
+<!---
+The place where `Ref` can be obtained depends on the type of provider.
+-->
+可以獲取的位置 `Ref` 取決於提供者程式的型別。
+
+<!---
+In functional providers, the `Ref` is passed as parameter to the
+provider's function:
+-->
+在函式提供者程式中，將 `Ref` 作為引數傳遞給提供者程式的函式：
+
+<AutoSnippet {...functionalRef} />
+
+<!---
+In class variants, the `Ref` is a property of the Notifier class:
+-->
+在類變體中，`Ref` 是通知者程式類的一個屬性：
+
+<AutoSnippet {...notifierRef} />
+
+<!---
+## Using ref to read a provider.
+-->
+## 使用 ref 讀取提供者程式。
+
+<!---
+### The `ref.watch` method.
+-->
+### `ref.watch` 方法。
+
+<!---
+Now that we've obtained a `Ref`, we can use it to combine requests.
+The main way to do so is by using `ref.watch`.  
+It is generally recommended to architecture your code such that you
+can use `ref.watch` over other options, as it is generally easier to maintain.
+-->
+現在我們已經獲得了一個 `Ref`，我們可以用它來組合請求。
+執行此操作的主要方法是使用 `ref.watch`。  
+通常建議對程式碼進行架構設計，
+以便可以使用 `ref.watch` 的其他選項，因為它通常更易於維護。
+
+<!---
+The `ref.watch` method takes a provider, and returns its current state.
+Then, whenever the listened provider changes, our provider will be
+invalidated and rebuilt next frame or on next read.
+-->
+該 `ref.watch` 方法採用提供者程式，並返回其當前狀態。
+然後，每當監聽的提供者程式發生更改時，我們的提供者程式將在
+下一幀或下一次讀取時失效並重新生成。
+
+<!---
+By using `ref.watch`, your logic becomes both "reactive" and "declarative".  
+Meaning that your logic will automatically recompute when needed.
+And that the update mechanism doesn't rely on side-effects, such as an "on change".
+This is similar to how StatelessWidgets behave.
+-->
+透過使用 `ref.watch`，您的邏輯變得既是“反應式”又是“宣告式”。  
+這意味著您的邏輯將在需要時自動重新計算。
+並且更新機制不依賴於副作用，例如“更改”。
+這類似於 StatelessWidgets 的行為方式。
+
+<!---
+As an example, we could define a provider that listens to the user's location.
+Then, we could use this location to fetch the list of restaurants near the user.
+-->
+例如，我們可以定義一個監聽使用者位置的提供者程式。
+然後，我們可以使用這個位置來獲取使用者附近的餐館列表。
+
+<AutoSnippet {...watchExample} />
+
+:::info
+<!---
+When the listened provider changes and our request recomputes, the previous
+state is kept until the new request completes.  
+At the same time, while the request is pending, the "isLoading" and "isReloading"
+flags will be set.
+-->
+當監聽的提供者程式發生更改並且我們的請求重新計算時，將保留以前的狀態，直到新請求完成。  
+同時，當請求處於掛起狀態時，將設定 "isLoading" 和 "isReloading" 標誌。
+
+<!---
+This enables UI to either show the previous state, or a loading indicator,
+or even both.
+-->
+這使 UI 能夠顯示以前的狀態或載入指示器，甚至兩者兼而有之。
+:::
+
+:::info
+<!---
+Notice how we used `ref.watch(locationProvider.future)` instead of `ref.watch(locationProvider)`.
+That is because our `locationProvider` is asynchronous. As such, we want to
+await for an initial value to be available.
+-->
+請注意我們如何使用 `ref.watch(locationProvider.future)` 來替代 `ref.watch(locationProvider)`。
+那是因為我們 `locationProvider` 是非同步的。因此，我們希望等待初始值可用。
+
+<!---
+If we omit that `.future`, we would receive an `AsyncValue`, which is a snapshot
+of the current state of the `locationProvider`. But if no location is available yet,
+we wouldn't be able to do anything.
+-->
+如果我們省略了這一點 `.future`，我們將收到一個 `AsyncValue`，
+它是 `locationProvider` 當前狀態的快照。但是，如果還沒有可用的位置，
+我們將無能為力。
+:::
+
+:::caution
+<!---
+It is considered bad practice to call `ref.watch` inside code that is executed
+"imperatively". Meaning any code that is possibly not executed during the build
+phase of the provider. This includes "listener" callbacks or methods on Notifiers:
+-->
+呼叫 `ref.watch` “命令式”執行的內部程式碼被認為是不好的做法。
+這意味著在提供者程式的構建階段可能未執行的任何程式碼。
+這包括通告程式上的“監聽器”回撥或方法：
+
+<AutoSnippet {...watchPlacement} />
+:::
+
+<!---
+## The `ref.listen`/`listenSelf` methods.
+-->
+### `ref.listen`/`listenSelf` 方法。
+
+<!---
+The `ref.listen` method is an alternative to `ref.watch`.  
+It is similar to your traditional "listen"/"addListener" method. It takes a provider
+and a callback, and will invoke said callback whenever the content of the provider
+changes.
+-->
+該 `ref.listen` 方法是 `ref.watch` 的替代方法。  
+它類似於傳統的 "listen"/"addListener" 方法。
+它接受一個提供者程式和一個回撥，
+並在提供者程式的內容發生更改時呼叫該回調。
+
+<!---
+Refactoring your code such that you can use `ref.watch` instead of `ref.listen`
+is generally recommended, as the latter is more error-prone due to its imperative nature.  
+But `ref.listen` can be helpful to add some quick logic without having to do
+significant refactor.
+-->
+通常建議重構程式碼，您可以使用 `ref.watch` 替代 `ref.listen`，
+因為後者由於其命令性質而更容易出錯。  
+但是 `ref.listen` 可以有助於新增一些快速邏輯而不必進行重大重構。
+
+<!---
+We could rewrite the `ref.watch` example to use `ref.listen` instead
+-->
+我們可以重寫 `ref.watch` 示例並使用 `ref.listen` 代替
+
+<AutoSnippet {...listenExample} />
+
+:::info
+<!---
+It is entirely safe to use `ref.listen` during the build phase of a provider.
+If the provider somehow is recomputed, previous listeners will be removed.
+-->
+在提供者程式的構建階段使用 `ref.listen` 是完全安全的。
+如果以某種方式重新計算提供者程式，則以前的監聽器將被刪除。
+
+<!---
+Alternatively, you can use the return value of `ref.listen` to remove the listener
+manually when you wish.
+-->
+或者，您可以根據需要使用 `ref.listen` 的返回值手動刪除監聽器。
+:::
+
+<!---
+## The `ref.read` method.
+-->
+### `ref.read` 方法
+
+<!---
+The last option available is `ref.read`.
+It is similar to `ref.watch` in that it returns the current state of a provider.
+But unlike `ref.watch`, it doesn't listen to the provider.
+-->
+最後一個可用選項是 `ref.read`。
+它類似於 `ref.watch` 返回提供者程式的當前狀態。
+但與 `ref.watch` 不同的是，它不監聽提供者程式。
+
+<!---
+As such, `ref.read` should be only be used in placed where you can't use
+`ref.watch`, such as inside methods of Notifiers.
+-->
+因此，`ref.read` 應該只被用在你不能使用 `ref.watch` 的地方，
+比如通告程式的內部方法。
+
+<AutoSnippet {...readExample} />
+
+:::caution
+<!---
+Be careful when using `ref.read` on a provider as, since it doesn't listen to the
+provider, said provider may decide to destroy its state if it isn't listened.
+-->
+`ref.read` 在提供者程式上使用時要小心，因為它不監聽提供者程式，
+因此如果不監聽提供者程式，則該提供者程式可能會決定處置其狀態。
+:::

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/do_dont.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/do_dont.mdx
@@ -1,0 +1,260 @@
+---
+title: 最佳實踐
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet, When } from "@site/src/components/CodeSnippet";
+
+<!---
+To ensure good maintainability of your code, here is a list of good practices
+you should follow when using Riverpod.
+-->
+為了確保程式碼具有良好的可維護性，
+這裡列出了您在使用 Riverpod 時應遵循的良好實踐。
+
+<!---
+This list is not exhaustive, and is subject to change.  
+If you have any suggestions, feel free to [open an issue](https://github.com/rrousselGit/riverpod/issues/new?assignees=rrousselGit&labels=documentation%2C+needs+triage&projects=&template=example_request.md&title=).
+-->
+此列表並不詳盡，並且可能會發生變化。  
+如果您有任何建議，請隨時[提出問題](https://github.com/rrousselGit/riverpod/issues/new?assignees=rrousselGit&labels=documentation%2C+needs+triage&projects=&template=example_request.md&title=)。
+
+<!---
+Items in this list are not in any particular order.
+-->
+此列表中的專案沒有任何特定的順序。
+
+<!---
+A good portion of these recommendations can be enforced with [riverpod_lint](https://pub.dev/packages/riverpod_lint).
+See <Link documentID="introduction/getting_started" hash="enabling-riverpod_lintcustom_lint"/>
+for installation instructions.
+-->
+這些建議的很大一部分可以透過 [riverpod_lint](https://pub.dev/packages/riverpod_lint) 來執行。
+請參閱<Link documentID="introduction/getting_started" hash="enabling-riverpod_lintcustom_lint"/>瞭解安裝說明。
+
+<!---
+## AVOID initializing providers in a widget
+-->
+## 避免！在小部件中初始化提供者程式​
+
+<!---
+Providers should initialize themselves.  
+They should not be initialized by an external element such as a widget.
+-->
+提供者程式應自行初始化。  
+它們不應由外部元素（例如小部件）初始化。
+
+<!---
+Failing to do so could cause possible race conditions and unexpected behaviors.
+-->
+如果不這樣做可能會導致可能的競爭條件和意外行為。
+
+<!---
+**DON'T**
+-->
+**不要**
+
+```dart
+class WidgetState extends State<MyWidget> {
+  @override
+  void initState() {
+    super.initState();
+    // 壞的：提供者程式應該自己初始化自己
+    ref.read(provider).init();
+  }
+}
+```
+
+<!---
+**CONSIDER**
+-->
+**考慮**
+
+<!---
+There is no "one-size fits all" solution to this problem.  
+If your initialization logic depends on factors external to the provider,
+often the correct place to put such logic is in the `onPressed` method of a button
+triggering navigation:
+-->
+對於這個問題，沒有“一刀切”的解決方案。  
+如果您的初始化邏輯取決於提供者程式的外部因素，
+則放置此類邏輯的正確位置通常是觸發導航的按鈕的 `onPressed` 方法中：
+
+```dart
+ElevatedButton(
+  onPressed: () {
+    ref.read(provider).init();
+    Navigator.of(context).push(...);
+  },
+  child: Text('Navigate'),
+)
+```
+
+<!---
+## AVOID using providers for local widget state.
+-->
+## 避免！使用本地小部件狀態的提供者程式。
+
+<!---
+Providers are designed to be for shared business state.
+They are not meant to be used for local widget state, such as for:
+-->
+提供者程式被設計為共享業務狀態。
+它們不適合用於本地小部件狀態，例如：
+
+<!---
+- storing form state
+- currently selected item
+- animations
+- generally everything that Flutter deals with a "controller" (e.g. `TextEditingController`)
+-->
+- 儲存表單狀態
+- 當前選擇的專案
+- 動畫
+- Flutter 處理常見的 "controller" 相關的所有內容（例如 `TextEditingController` ）
+
+<!---
+If you are looking for a way to handle local widget state, consider using
+[flutter_hooks](https://pub.dev/packages/flutter_hooks) instead.
+-->
+如果您正在尋找一種處理本地小部件狀態的方法，請考慮使用
+[flutter_hooks](https://pub.dev/packages/flutter_hooks) 代替。
+
+<!---
+One reason why this is discouraged is that such state is often scoped to a route.  
+Failing to do so could break your app's back button, due to a new page overriding
+the state of a previous page.
+-->
+不鼓勵這樣做的一個原因是這種狀態通常僅限於一條路由。  
+如果不這樣做，可能會破壞應用程式的後退按鈕，因為新頁面會覆蓋上一頁的狀態。
+
+<!---
+## DON'T perform side effects during the initialization of a provider
+-->
+## 不要！在提供者程式初始化期間執行副作用​
+
+<!---
+Providers should generally be used to represent a "read" operation.
+You should not use them for "write" operations, such as submitting a form.
+-->
+提供者程式通常應用於表示“讀”操作。
+您不應該將它們用於“寫”操作，例如提交表單。
+
+<!---
+Using providers for such operations could have unexpected behaviors, such as
+skipping a side-effect if a previous one was performed.
+-->
+使用提供者程式進行此類操作可能會產生意外行為，例如
+如果執行了前一個操作，則跳過副作用。
+
+<!---
+If you are looking at a way to handle loading/error states of a side-effect,
+see <Link documentID="essentials/side_effects"/>.
+-->
+如果您正在尋找一種處理副作用的載入/錯誤狀態的方法，
+請參閱<Link documentID="essentials/side_effects"/>。
+
+<!---
+**DON'T**:
+-->
+**不要**：
+
+```dart
+final submitProvider = FutureProvider((ref) async {
+  final formState = ref.watch(formState);
+
+  // 壞的：提供者程式不應用於“寫”操作。
+  return http.post('https://my-api.com', body: formState.toJson());
+});
+```
+
+<!---
+## PREFER ref.watch/read/listen (and similar APIs) with statically known providers
+-->
+## 首選！ref.watch/read/listen（和類似的 API）以及靜態已知的提供者程式​
+
+<!---
+Riverpod strongly recommends enabling lint rules (via `riverpod_lint`).  
+But for lints to be effective, your code should be written in a way that is
+statically analysable.
+-->
+Riverpod 強烈建議啟用 lint 規則（透過 riverpod_lint）。  
+但為了使 lint 發揮作用，您的程式碼應該以可靜態分析的方式編寫。
+
+<!---
+Failing to do so could make it harder to spot bugs or cause
+false positives with lints.
+-->
+如果不這樣做，可能會更難發現錯誤或導致 lints 誤報。
+
+<!---
+**Do**:
+-->
+**應該**：
+
+```dart
+final provider = Provider((ref) => 42);
+
+...
+
+// 好的，因為提供者程式是靜態已知的
+ref.watch(provider);
+```
+
+<!---
+**Don't**:
+-->
+**不要**：
+
+```dart
+class Example extends ConsumerWidget {
+  Example({required this.provider});
+  final Provider<int> provider;
+
+  @override
+  Widget build(context, ref) {
+    // 不好，因為靜態分析無法知道 `provider` 是什麼
+    ref.watch(provider);
+  }
+}
+```
+
+<!---
+## AVOID dynamically creating providers
+-->
+## 避免！動態建立提供者程式​
+
+<!---
+Providers should exclusively be top-level final variables.
+-->
+提供者程式應該專門是頂級 final 變數。
+
+<!---
+**Do**:
+-->
+**應該**：
+
+```dart
+final provider = Provider<String>((ref) => 'Hello world');
+```
+
+<!---
+**Don't**:
+-->
+**不要**：
+
+```dart
+class Example {
+  // 不支援的操作。可能導致記憶體洩漏和意外行為。
+  final provider = Provider<String>((ref) => 'Hello world');
+}
+```
+
+:::info
+<!---
+Creating providers as static final variables is allowed,
+but not supported by the code-generator.
+-->
+允許將提供者程式建立為 static final 變數，
+但程式碼生成器不支援。
+:::

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/eager_initialization.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/eager_initialization.mdx
@@ -1,0 +1,117 @@
+---
+title: 急切的初始化提供者程式
+version: 1
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet } from "@site/src/components/CodeSnippet";
+import consumerExample from "!!raw-loader!/docs/essentials/eager_initialization/consumer_example.dart";
+import asyncConsumerExample from "!!raw-loader!/docs/essentials/eager_initialization/async_consumer_example.dart";
+import requireValue from "/docs/essentials/eager_initialization/require_value";
+
+<!---
+All providers are initialized lazily by default. This means that the provider is only
+initialized when it is first used. This is useful for providers that are only
+used in certain parts of the application.
+-->
+預設情況下，所有提供者程式都以延遲方式初始化。
+這意味著提供者程式僅在首次使用時進行初始化。
+這對於僅在應用程式的某些部分使用的提供者程式很有用。
+
+<!---
+Unfortunately, there is no way to flag a provider as needing to be eagerly initialized due
+to how Dart works (for tree shaking purposes). One solution, however, is to forcibly
+read the providers you want to eagerly initialize at the root of your application.
+-->
+不幸的是，由於 Dart 的工作方式（出於搖樹目的），沒有辦法將提供者程式標記為需要急切初始化。
+但是，一種解決方案是在應用程式的根元件下強制讀取要急切初始化的提供者程式。
+
+<!---
+The recommended approach is to simply "watch" a provider in a Consumer placed right under your `ProviderScope`:
+-->
+推薦的方法是簡單地 "watch" 位於 `ProviderScope` 下方的 Consumer 中的提供者程式：
+
+<AutoSnippet raw={consumerExample} />
+
+:::note
+<!---
+Consider putting the initialization consumer in your "MyApp" or in a public widget.
+This enables your tests to use the same behavior, by removing logic from your main.
+-->
+請考慮將初始化使用者放在 "MyApp" 或公共小部件中。
+這使你的測試能夠使用相同的行為，方法是從你的主資料中刪除邏輯。
+:::
+
+<!---
+### FAQ
+-->
+### 常見疑問
+
+<!---
+#### Won't this rebuild our entire application when the provider changes?
+-->
+#### 當提供者程式更改時，這不會重建我們的整個應用程式嗎？
+
+<!---
+No, this is not the case.
+In the sample given above, the consumer responsible for eagerly initializing
+is a separate widget, which does nothing but return a `child`.
+-->
+不，事實並非如此。
+在上面給出的示例中，負責急切初始化的消費者程式是一個單獨的小部件，它只返回一個 `child` .
+
+<!---
+The key part is that it returns a `child`, rather than instantiating `MaterialApp` itself.
+This means that if `_EagerInitialization` ever rebuilds, the `child` variable
+will not have changed. And when a widget doesn't change, Flutter doesn't rebuild it.
+-->
+關鍵部分是它返回一個 `child` ，而不是例項化 `MaterialApp` 自身。
+這意味著，如果重新生成 `_EagerInitialization`，`child` 變數將不會更改。
+當一個小部件沒有改變時，Flutter 不會重建它。
+
+<!---
+As such, only `_EagerInitialization` will rebuild, unless another widget is also listening to that provider.
+-->
+因此，除非另一個小部件也在監聽該提供者程式，否則只會 `_EagerInitialization` 重新構建。
+
+<!---
+#### Using this approach, how can I handle loading and error states?
+-->
+#### 使用此方法，如何處理載入和錯誤狀態？
+
+<!---
+You can handle loading/error states as you normally would in a `Consumer`.
+Your `_EagerInitialization` could check if a provider is in a "loading" state,
+and if so, return a `CircularProgressIndicator` instead of the `child`:
+-->
+您可以像往常一樣在 `Consumer` 中處理載入/錯誤狀態。
+您可以 `_EagerInitialization` 檢查提供者程式是否處於 "loading" 狀態，
+如果是則返回 `CircularProgressIndicator` 否則返回 `child`：
+
+<AutoSnippet raw={asyncConsumerExample} />
+
+<!---
+#### I've handled loading/error states, but other Consumers still receive an AsyncValue! Is there a way to not have to handle loading/error states in every widget?
+-->
+#### 我已經處理了載入/錯誤狀態，但其他消費者程式仍然收到 AsyncValue！有沒有辦法不必處理每個小部件中的載入/錯誤狀態？
+
+<!---
+Rather than trying to have your provider _not_ expose an `AsyncValue`, you can
+instead have your widgets use `AsyncValue.requireValue`.  
+This will read the data without having to do pattern matching. And in case a bug slips through,
+it will throw an exception with a clear message.
+-->
+與其試圖讓你的提供者程式不公開一個 `AsyncValue` ，不如讓你的小部件使用 `AsyncValue.requireValue`。  
+這將讀取資料，而無需進行模式匹配。如果一個錯誤溜走了，它會丟擲一個異常，並帶有明確的資訊。
+
+<AutoSnippet {...requireValue} />
+
+:::note
+<!---
+Although there are ways to not expose the loading/error states in those cases (relying on scoping),
+it is generally discouraged to do so.  
+The added complexity of making two providers and using overrides is not worth the trouble.
+-->
+儘管有一些方法可以在這些情況下不公開載入/錯誤狀態（依賴於範圍），但通常不建議這樣做。  
+建立兩個提供者程式並使用覆蓋所增加的複雜性不值得麻煩。
+:::

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/faq.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/faq.mdx
@@ -1,0 +1,355 @@
+---
+title: FAQ 常見問題
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet, When } from "@site/src/components/CodeSnippet";
+
+<!---
+Here are some commonly asked questions from the community:
+-->
+以下是社群中的一些常見問題：
+
+<!---
+## What is the difference between `ref.refresh` and `ref.invalidate`?
+-->
+## `ref.refresh` 和 `ref.invalidate` 之間有什麼不同？
+
+<!---
+You may have noticed that `ref` has two methods to force a provider to recompute,
+and wonder how they differ.
+-->
+您可能已經注意到 `ref` 有兩種方法可以強制提供者程式重新計算，並且想知道它們有何不同。
+
+<!---
+It's simpler than you think: `ref.refresh` is nothing but syntax sugar for
+`invalidate` + `read`:
+-->
+它比你想象的要簡單： `ref.refresh` 只是 `invalidate` + `read` 的語法糖：
+
+```dart
+T refresh<T>(provider) {
+  invalidate(provider);
+  return read(provider);
+}
+```
+
+<!---
+If you do not care about the new value of a provider after recomputing it,
+then `invalidate` is the way to go.  
+If you do, use `refresh` instead.
+-->
+如果您在重新計算後不關心提供者程式的新值，
+那麼 `invalidate` 就是正確的選擇。  
+如果這樣做，請改用 `refresh`。
+
+:::info
+<!---
+This logic is automatically enforced through lint rules.  
+If you tried to use `ref.refresh` without using the returned value,
+you would get a warning.
+-->
+該邏輯透過 lint 規則自動執行。
+如果您嘗試使用 `ref.refresh` 而不使用返回值，您將收到警告。
+:::
+
+<!---
+The main difference in behavior is by reading the provider right
+after invalidating it, the provider **immediately** recomputes.  
+Whereas if we call `invalidate` but don't read it right after,
+then the update will trigger _later_.
+-->
+行為上的主要區別在於，透過在使提供者程式失效後，
+提供者程式會**立即**重新計算。  
+然而，如果我們呼叫 `invalidate` 但沒有立即讀取它，
+那麼更新將稍後觸發。
+
+<!---
+That "later" update is generally at the start of the next frame.
+Yet, if a provider that is currently not being listened to is invalidated, 
+it will not be updated until it is listened to again.
+-->
+“稍後”更新通常是在下一幀開始時。
+然而，如果當前被未監聽的提供者程式失效，
+則它在再次被監聽之前都不會被更新。
+
+<!---
+## Why is there no shared interface between Ref and WidgetRef?
+-->
+## 為什麼 Ref 和 WidgetRef 之間沒有共享介面？​
+
+<!---
+Riverpod voluntarily dissociates `Ref` and `WidgetRef`.  
+This is done on purpose to avoid writing code which conditionally
+depends on one or the other.
+-->
+Riverpod 自願分離 `Ref` 和 `WidgetRef`。  
+這樣做的目的是為了避免編寫有條件依賴其中之一的程式碼。
+
+<!---
+One issue is that `Ref` and `WidgetRef`, although similar looking,
+have suble differences.  
+Code relying on both would be unreliable in ways that are difficult to spot.
+-->
+一個問題是 `Ref` 和 `WidgetRef` 雖然看起來相似，但存在細微的差異。  
+依賴於兩者的程式碼將變得不可靠，並且難以發現。
+
+<!---
+At the same time, relying on `WidgetRef` is equivalent to relying on `BuildContext`.
+It is effectively putting your logic in the UI layer, which is not recommended.
+-->
+同時，依賴 `WidgetRef` 就相當於依賴 `BuildContext`。
+它實際上將您的邏輯放在 UI 層中，但不建議這樣做。
+
+---
+
+<!---
+Such code should be refactored to **always** use `Ref`.
+-->
+此類程式碼應重構為**始終**使用 `Ref`。
+
+<!---
+The solution to this problem is typically to move your logic
+into a `Notifier` (see <Link documentID="essentials/side_effects" />), 
+and then have your logic be a method of that `Notifier`.
+-->
+此問題的解決方案通常是將您的邏輯移至 `Notifier` 中
+（請參閱 <Link documentID="essentials/side_effects" />），
+然後讓您的邏輯成為該 `Notifier` 的方法。
+
+<!---
+This way, when your widgets want to invoke this logic, they can
+write something along the lines of:
+-->
+這樣，當您的小部件想要呼叫此邏輯時，它們可以編寫如下內容：
+
+```dart
+ref.read(yourNotifierProvider.notifier).yourMethod();
+```
+
+<!---
+`yourMethod` would use the `Notifier`'s `Ref` to interact with other providers.
+-->
+`yourMethod` 將使用 `Notifier` 的 `Ref` 與其他提供者程式互動。
+
+<!---
+## Why do we need to extend ConsumerWidget instead of using the raw StatelessWidget?
+-->
+## 為什麼我們需要擴充套件 ConsumerWidget 而不是使用原始的 StatelessWidget？
+
+<!---
+This is due to an unfortunate limitation in the API of `InheritedWidget`.
+-->
+這是由於 `InheritedWidget` API 中的一個不幸的限制造成的。
+
+<!---
+There are a few problems:
+-->
+有幾個問題：
+
+<!---
+- It is not possible to implement an "on change" listener with `InheritedWidget`.
+  That means that something such as `ref.listen` cannot be used with `BuildContext`.
+
+  `State.didChangeDependencies` is the closest thing to it, but it is not reliable.
+  One issue is that the life-cycle can be triggered even if no dependency changed,
+  especially if your widget tree uses GlobalKeys (and some Flutter widgets already do so internally).
+-->
+- 無法使用 `InheritedWidget` 實現監聽器的“當更改時”。
+  這意味著諸如 `ref.listen` 之類的內容不能與 `BuildContext` 一起使用。
+
+  `State.didChangeDependencies` 是最接近它的東西，但它並不可靠。
+  一個問題是，即使沒有改變依賴關係，生命週期也可能被觸發，
+  特別是如果你的 widget 樹使用 GlobalKeys（並且一些 Flutter widget 已經在內部這樣做了）。
+  
+
+<!---
+- Widgets listening to an `InheritedWidget` never stop listening to it.
+  This is usually fine for pure metadata, such as "theme" or "media query".
+
+  For business logic, this is a problem.
+  Say you use a provider to represent a paginated API.
+  When the page offset changes, you wouldn't want your widget to keep listening
+  to the previously visible pages.
+-->
+- 監聽 `InheritedWidget` 的小部件永遠不會停止監聽它。
+  這通常適用於純元資料，例如 "theme" 或 "media query"。
+
+  對於業務邏輯來說，這是一個問題。
+  假設您使用提供者程式來表示分頁 API。
+  當頁面偏移量發生變化時，您不希望小部件繼續監聽先前可見的頁面。
+
+<!---
+- `InheritedWidget` has no way to track when widgets stop listening to them.
+  Riverpod sometimes relies on tracking whether or not a provider is being listened to.
+-->
+- `InheritedWidget` 無法跟蹤小部件何時停止監聽它們。
+  Riverpod 有時依賴於跟蹤提供者程式是否被監聽。
+
+<!---
+This functionality is crucial for both the auto dispose mechanism and the ability to
+pass arguments to providers.  
+Those features are what make Riverpod so powerful.
+-->
+此功能對於自動處置機制和將引數傳遞給提供者程式的能力至關重要。  
+這些功能使 Riverpod 如此強大。
+
+<!---
+Maybe in a distant future, those issues will be fixed. In that case,
+Riverpod would migrate to using `BuildContext` instead of `Ref`.
+This would enable using `StatelessWidget` instead of `ConsumerWidget`.  
+But that's for another time!
+-->
+也許在遙遠的將來，這些問題將會得到解決。在這種情況下，
+Riverpod 將遷移到使用 `BuildContext` 而不是 `Ref`。
+這將允許使用 `StatelessWidget` 而不是 `ConsumerWidget` 。  
+但那是以後再說了！
+
+<!---
+## Why doesn't hooks_riverpod exports flutter_hooks?
+-->
+## 為什麼 hooks_riverpod 不匯出 flutter_hooks？
+
+<!---
+This is to respect good versioning practices.
+-->
+這是為了尊重良好的版本控制實踐。
+
+<!---
+While you cannot use `hooks_riverpod` without `flutter_hooks`,
+both packages are versioned independently. A breaking change could happen
+in one but not the other.
+-->
+雖然您不能在沒有 `flutter_hooks` 的情況下使用 `hooks_riverpod`，
+但這兩個包都是獨立版本控制的。
+當其中一個可能會發生重大變化時，不會影響另一個。
+
+<!---
+## Why does Riverpod uses `identical` instead of `==` to filter updates in some cases?
+-->
+## 為什麼 Riverpod 在某些情況下使用 `identical` 而不是 `==` 來過濾更新？​
+
+<!---
+Notifiers use `identical` instead of `==` to filter updates.
+-->
+通知者程式使用 `identical` 而不是 `==` 來過濾更新。
+
+<!---
+This is because it is quite common for Riverpod users to also use a code-generator
+such as Freezed/built_value for the sake of a copyWith implementation. Those packages
+override `==` to deeply compare objects. A deep object comparison is quite costly.
+"Business logic" models tend to have lots of properties. Worse, they also have collections
+such as lists, maps, and so on.
+-->
+這是因為 Riverpod 使用者為了實現 copyWith
+而使用 Freezed/built_value 等程式碼生成器是很常見的。
+這些包重寫 `==` 以深入比較物件。深度物件比較的成本相當高。
+“業務邏輯”模型往往具有很多屬性。更糟糕的是，他們還有列表、地圖等集合。
+
+<!---
+At the same time, when using complex "business" objects, most `state = newState` invocations
+always result in a notification (otherwise there is no point in calling the setter). Generally, the main
+case where we call `state = newState` when the current state and new states are equal is
+for primitive objects (ints, enums, strings, but not lists/classes/...).
+These objects are "canonicalized by default". If such objects are equal,
+they generally are also "identical".
+-->
+同時，當使用複雜的“業務”物件時，大多數 `state = newState` 呼叫
+總是會產生通知（否則呼叫 setter 沒有意義）。一般來說，
+噹噹前狀態和新狀態相等時，我們呼叫 `state = newState` 的主要情況
+是對於原始物件（整數、列舉、字串，但不是列表/類/...）。
+這些物件“預設被規範化”。如果這些物件是相等的，
+那麼它們通常也是“相同的（identical）”。
+
+<!---
+Riverpod using `identical` to filter updates is therefore an attempt at having
+a good default for both worlds. For complex objects where we don't really care
+about filtering objects and where `==` may be expensive due to code-generators
+generating an `==` override by default, using `identical` provides an efficient way of notifying listeners.
+At the same time, for simple objects, `identical` does correctly filter redundant notifications.
+-->
+因此，Riverpod 使用 `identical` 來過濾更新是一個兩全其美的預設值嘗試。
+對於複雜物件，我們並不真正關心過濾物件，
+並且由於程式碼生成器預設生成 `==` 覆蓋，因此 `==` 可能會很昂貴，
+使用 `identical` 提供了一種通知監聽器的有效方式。
+同時，對於簡單物件，`identical` 確實正確過濾了冗餘通知。
+
+<!---
+Last but not least, you can change this behavior by overriding the method
+`updateShouldNotify` on Notifiers.
+-->
+最後且同樣重要的一點是，您可以透過重寫通知者程式上的方法 `updateShouldNotify` 來更改此行為。
+
+<!---
+## Is there a way to reset all providers at once?
+-->
+## 有沒有辦法一次性重置所有提供者程式
+
+<!---
+No, there is no way to reset all providers at once.
+-->
+不，沒有辦法立即重置所有提供者程式。
+
+<!---
+This is on purpose, as it is considered an anti-pattern. Resetting all providers
+at once will often reset providers that you did not intend to reset.
+-->
+這是故意的，因為它被認為是反模式。
+立即重置所有提供者程式通常會重置您不打算重置的提供者程式。
+
+<!---
+This is commonly asked by users who want to reset the state of their application
+when the user logs out.  
+If this is what you are after, you should instead have everything dependent on the
+user's state to `ref.watch` the "user" provider.
+-->
+當用戶登出時想要重置應用程式狀態的使用者通常會詢問此問題。  
+如果這就是您所希望的，那麼您應該將所有內容都
+透過 `ref.watch` 依賴於 "user" 提供者程式的使用者狀態。
+
+<!---
+Then, when the user logs out, all providers depending on it would automatically
+be reset but everything else would remain untouched.
+-->
+然後，當用戶登出時，依賴於它的所有提供者程式將自動重置，但其他所有內容都將保持不變。
+
+<!---
+## I have the error "Cannot use "ref" after the widget was disposed", what's wrong?
+-->
+## 我收到錯誤“在處理小部件後無法使用‘ref’”，這是怎麼回事？​
+
+<!---
+You might also see "Bad state: No ProviderScope found", which is an older
+error message of the same issue.
+-->
+您可能還會看到 "Bad state: No ProviderScope found"，這是同一問題的較舊錯誤訊息。
+
+<!---
+This error happens when you try to use `ref` in a widget that is no longer
+mounted. This generally happens after an `await`:
+-->
+當您嘗試在不再安裝的小部件中使用 `ref` 時，會發生此錯誤。這通常發生在 `await` 之後：
+
+```dart
+ElevatedButton(
+  onPressed: () async {
+    await future;
+    ref.read(...); // 可能丟擲 "Cannot use "ref" after the widget was disposed"
+  }
+)
+```
+
+<!---
+The solution is to, like with `BuildContext`, check `mounted` before using `ref`:
+-->
+解決方案是，與 `BuildContext` 一樣，在使用 `ref` 之前檢查 `mounted`：
+
+```dart
+ElevatedButton(
+  onPressed: () async {
+    await future;
+    if (!context.mounted) return;
+    ref.read(...); // 不再丟擲
+  }
+)
+```

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request.mdx
@@ -1,0 +1,580 @@
+---
+title: 開始你的第一次 provider/network 請求
+pagination_prev: introduction/getting_started
+version: 1
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet, When } from "@site/src/components/CodeSnippet";
+import activity from "./first_request/activity";
+import provider from "./first_request/provider";
+import consumer from "./first_request/consumer";
+import consumerWidget from "./first_request/consumer_widget";
+import consumerStatefulWidget from "./first_request/consumer_stateful_widget";
+import hookConsumerWidget from "./first_request/hook_consumer_widget";
+import Legend from "./first_request/legend/legend";
+
+<!---
+Network requests are the core of any application. But there are a lot of things to consider when
+making a network request:
+-->
+網路請求是任何應用程式的核心。但是，在發出網路請求時，需要考慮很多事項：
+
+<!---
+- The UI should render a loading state while the request is being made
+- Errors should be gracefully handled
+- The request should be cached if possible
+-->
+- UI 應在發出請求時呈現載入狀態
+- 應妥善處理錯誤
+- 如果可能，應快取請求
+
+<!---
+In this section, we will see how Riverpod can help us deal with all of this naturally.
+-->
+在本節中，我們將看到 Riverpod 如何幫助我們自然地處理所有這些問題。
+
+<!---
+## Setting up `ProviderScope`
+-->
+## 配置 `ProviderScope`
+
+<!---
+Before we start making network requests, make sure that `ProviderScope` is added at the
+root of the application.
+-->
+在開始發出網路請求之前，請確保將其 `ProviderScope` 新增到應用程式的根目錄。
+
+```dart
+void main() {
+  runApp(
+    // To install Riverpod, we need to add this widget above everything else.
+    // This should not be inside "MyApp" but as direct parameter to "runApp".
+    // 為了安裝 Riverpod，我們需要將這個小元件新增到所有的小元件之上。
+    // 它不應該在 “MyApp” 內部，而是作為 “runApp” 的直接引數。
+    ProviderScope(
+      child: MyApp(),
+    ),
+  );
+}
+```
+
+<!---
+Doing so will enable Riverpod for the entire application.
+-->
+這樣就可以為整個應用程式啟用 Riverpod。
+
+:::note
+<!---
+For complete installation steps (such as installing [riverpod_lint](https://pub.dev/packages/riverpod_lint)
+and running the code-generator), check out <Link documentID="introduction/getting_started" />.
+-->
+有關完整的安裝步驟（例如安裝 [riverpod_lint](https://pub.dev/packages/riverpod_lint)
+和執行程式碼生成器），請檢視<Link documentID="introduction/getting_started" />。
+:::
+
+<!---
+## Performing your network request in a "provider"
+-->
+## 在 “provider” 中執行網路請求
+
+<!---
+Performing a network request is usually what we call "business logic".
+In Riverpod, business logic is placed inside "providers".  
+A provider is a super-powered function.
+They behave like normal functions, with the added benefits of:
+-->
+執行網路請求通常就是我們所說的“業務邏輯”。在 Riverpod 中，業務邏輯位於“providers”中。  
+provider 是一種具有超能力的函式。它們的行為與正常函式類似，並具有以下額外好處：
+
+<!---
+- being cached
+- offering default error/loading handling
+- being listenable
+- automatically re-executing when some data changes
+-->
+- 保持快取
+- 提供預設錯誤/載入處理
+- 可以被監聽
+- 當某些資料發生變化時自動重新執行
+
+<!---
+This make providers a perfect fit for _GET_ network requests (as for _POST/etc_ requests, see <Link documentID="essentials/side_effects" />).
+-->
+這使得 provider 非常適合 _GET_ 網路請求（與 _POST/etc_ 請求一樣，請參閱<Link documentID="essentials/side_effects" />）。
+
+<!---
+As an example, let's make a simple application which suggests a random activity to do when bored.  
+To do so, we will use the [Bored API](https://boredapi.com/). In particular,
+we will perform a _GET_ request on the `/api/activity` endpoint. This returns a JSON object,
+which we will parse into a Dart class instance.  
+The next step would then be to display this activity in the UI. We would also make sure
+to render a loading state while the request is being made, and to gracefully handle errors.
+-->
+舉個例子，讓我們做一個簡單的應用程式，建議在無聊時做一個隨機的活動。  
+為此，我們將使用 [Bored API](https://boredapi.com/)。具體而言，
+我們將在 `/api/activity` 端點上執行 _GET_ 請求。端點返回一個 JSON 物件，我們將把它解析為 Dart 類例項。  
+然後，下一步是在 UI 中顯示此活動。我們還將確保在發出請求時呈現載入狀態，並優雅地處理錯誤。
+
+<!---
+Sounds great? Let's do it!
+-->
+聽起來不錯？讓我們開始吧！
+
+<!---
+### Defining the model
+-->
+### 定義資料模型
+
+<!---
+Before we start, we need to define the model of the data we will receive from the API.
+This model will also need a way to parse the JSON object into a Dart class instance.
+-->
+在開始之前，我們需要定義從 API 接收的資料模型。
+該模型還需要一種方法將 JSON 物件解析為 Dart 類例項。
+
+<!---
+Generally, it is recommended to use a code-generator such as [Freezed](https://pub.dev/packages/freezed)
+or [json_serializable](https://pub.dev/packages/json_serializable) to handle
+JSON decoding. But of course, it's also possible to do it by hand.
+-->
+通常，建議使用 [Freezed](https://pub.dev/packages/freezed)
+或 [json_serializable](https://pub.dev/packages/json_serializable) 等程式碼生成器來處理 JSON 解碼。
+雖然但是，也可以手動完成。
+
+<!---
+Anyway, here's our model:
+-->
+無論如何，這是我們的模型：
+
+<AutoSnippet title="activity.dart" {...activity} />
+
+<!---
+### Creating the provider
+-->
+### 建立 provider
+
+<!---
+Now that we have our model, we can start querying the API.  
+To do so, we will need to create our first provider.
+-->
+現在我們有了模型，可以開始建立查詢 API。  
+為此，我們需要建立我們的第一個 provider。
+
+<!---
+The syntax for defining a provider is as followed:
+-->
+定義 provider 的語法如下：
+
+<When codegen={false}>
+<Legend
+  code={`final name = SomeProvider.someModifier<Result>((ref) {
+  <你的邏輯寫這裡>
+});
+`}
+  annotations={[
+    {
+      offset: 6,
+      length: 4,
+      label: "provider 的變數",
+       description: <>
+
+<!---
+This variable is what will be used to interact with our provider.  
+The variable must be final and "top-level" (global).
+-->
+此變數將用於與我們的提供者程式進行互動。  
+變數必須是 final 和“頂級”（global）。
+
+</>
+    },
+    {
+      offset: 13,
+      length: 12,
+      label: "provider 的型別",
+      description: <>
+
+<!---
+Generally either `Provider`, `FutureProvider` or `StreamProvider`.  
+The type of provider used depends on the return value of your function.
+For example, to create a `Future<Activity>`, you'll want a `FutureProvider<Activity>`.
+-->
+通常為 `Provider`、`FutureProvider` 或 `StreamProvider`。  
+使用提供者程式的型別取決於函式的返回值。
+例如，要建立一個 `Future<Activity>`，您需要一個 `FutureProvider<Activity>`。
+
+<!---
+`FutureProvider` is the one you'll want to use the most.
+-->
+`FutureProvider` 是你最想用的那個。
+
+:::tip
+<!---
+Don't think in terms of "Which provider should I pick".
+Instead, think in terms of "What do I want to return". The provider type
+will follow naturally.
+-->
+不要從“我應該選擇哪個提供者程式”的角度來思考。
+相反，從“我想返回什麼”的角度來思考。
+提供者程式的型別將自然而然地遵循。
+:::
+
+</>
+    },
+    {
+      offset: 25,
+      length: 13,
+      label: "修飾符（可選的）",
+      description: <>
+
+<!---
+Often, after the type of the provider you may see a "modifier".  
+Modifiers are optional, and are used to tweak the behavior of the provider
+in a way that is type-safe.
+-->
+通常，在提供者程式的型別之後，您可能會看到一個“修飾符”。  
+修飾符是可選的，用於以型別安全的方式調整提供者程式的行為。
+
+<!---
+There are currently two modifiers available:
+-->
+目前有兩種修飾符可用：
+
+<!---
+- `autoDispose`, which will automatically clear the cache when the provider
+  stops being used.  
+  See also <Link documentID="essentials/auto_dispose" />
+- `family`, which enables passing arguments to your provider.  
+  See also <Link documentID="essentials/passing_args" />.
+-->
+- `autoDispose`，這將在提供者程式停止使用時自動清除快取。
+  另請參閱<Link documentID="essentials/auto_dispose" />
+- `family`，這可以將引數傳遞給提供者程式。
+  另請參閱<Link documentID="essentials/passing_args" />。
+
+</>
+    },
+    {
+      offset: 48,
+      length: 3,
+      label: "Ref 引用",
+      description: <>
+
+<!---
+An object used to interact with other providers.  
+All providers have one; either as parameter of the provider function,
+or as a property of a Notifier.
+-->
+用於與其他 provider 互動的物件。
+所有提供者程式都有一個 `Ref`；要麼作為 `provider` 函式的引數，要麼作為 `Notifier` 的屬性。
+
+</>
+    },
+    {
+      offset: 57,
+      length: 17,
+      label: "provider 函式",
+      description: <>
+
+<!---
+This is where we place the logic of our providers.
+This function will be called when the provider is first read.  
+Subsequent reads will not call the function again, but instead return the cached value.
+-->
+這就是我們放置提供者程式邏輯的地方。首次讀取提供者程式時將呼叫此函式。  
+後續讀取不會再次呼叫該函式，而是返回快取的值。
+
+</>
+    },
+]}
+/>
+</When>
+
+<When codegen={true}>
+<Legend
+  code={`@riverpod
+Result myFunction(Ref ref) {
+  <你的邏輯寫這裡>
+}
+`}
+  annotations={[
+    {
+      offset: 0,
+      length: 9,
+      label: "註解",
+       description: <>
+
+<!---
+All providers must be annotated with `@riverpod` or `@Riverpod()`.
+This annotation can be placed on global functions or classes.  
+Through this annotation, it is possible to configure the provider.
+-->
+所有提供者程式都必須使用 `@riverpod` 或 `@Riverpod()` 進行註釋。
+此註釋可以放置在全域性函式或類上。  
+透過此註釋，可以配置提供者程式。
+
+<!---
+For example, we can disable "auto-dispose" (which we will see later) by writing `@Riverpod(keepAlive: true)`.
+-->
+例如，我們可以透過編寫 `@Riverpod(keepAlive: true)` 來停用“自動處置”（我們將在後面看到）。
+
+</>
+    },
+    {
+      offset: 17,
+      length: 10,
+      label: "帶註解的函式",
+       description: <>
+
+<!---
+The name of the annotated function determines how the provider
+will be interacted with.  
+For a given function `myFunction`, a generated `myFunctionProvider` variable will be generated.
+-->
+帶批註的函式的名稱決定了如何與提供者程式進行互動。  
+對於給定的函式 `myFunction` ，將生成一個生成的 `myFunctionProvider` 變數。
+
+<!---
+Annotated functions **must** specify a "ref" as first parameter.  
+Besides that, the function can have any number of parameters, including generics.
+The function is also free to return a `Future`/`Stream` if it wishes to.
+-->
+帶註釋的函式**必須**指定“ref”作為第一個引數。  
+除此之外，該函式可以具有任意數量的引數，包括泛型。
+如果願意，該函式也可以自由返回 `Future`/`Stream`。
+
+<!---
+This function will be called when the provider is first read.  
+Subsequent reads will not call the function again, but instead return the cached value.
+-->
+首次讀取提供者程式時將呼叫此函式。  
+後續讀取不會再次呼叫該函式，而是返回快取的值。
+
+</>
+    },
+    {
+      offset: 28,
+      length: 7,
+      label: "Ref",
+      description: <>
+
+<!---
+An object used to interact with other providers.  
+All providers have one; either as parameter of the provider function,
+or as a property of a Notifier.  
+The type of this object is determined by the name of the function/class.
+-->
+用於與其他提供者程式互動的物件。  
+所有提供者程式都有一個 `Ref`；要麼作為 `provider` 函式的引數，要麼作為 `Notifier` 的屬性。 
+此物件的型別由函式/類的名稱確定。
+
+</>
+    },
+]}
+/>
+</When>
+
+<!---
+In our case, we want to _GET_ an activity from the API.  
+Since a _GET_ is an asynchronous operation, that means we will want
+to create a `Future<Activity>`.
+-->
+在我們的例子中，我們希望從 API 中 _GET_ 一個活動。  
+由於 _GET_ 是非同步操作，這意味著我們需要建立一個 `Future<Activity>`。
+
+<!---
+Using the syntax defined previously, we can therefore define our provider as followed:
+-->
+因此，使用前面定義的語法，我們可以按如下方式定義提供者程式：
+
+<AutoSnippet title="provider.dart" {...provider} />
+
+<!---
+In this snippet, we've defined a provider named `activityProvider` which
+our UI will be able to use to obtain a random activity. It is worth noting
+that:
+-->
+在此程式碼片段中，我們定義了一個名為 `activityProvider` 的提供者程式，
+我們的 UI 將能夠使用該提供者程式來獲取隨機活動。值得一提的是：
+
+<!---
+- The network request will not be executed until the UI reads the provider
+  at least once.
+- Subsequent reads will not re-execute the network request,
+  but instead return the previously fetched activity.
+- If the UI stops using this provider, the cache will be destroyed.
+  Then, if the UI ever uses the provider again, that a new network request will be made.
+- We did not catch errors. This is voluntary, as providers
+  natively handle errors.  
+  If the network request or if the JSON parsing throws, the error
+  will be caught by Riverpod. Then, the UI will automatically have the necessary
+  information to render an error page.
+-->
+- 在 UI 讀取提供者程式至少一次之前，不會執行網路請求。
+- 後續讀取不會重新執行網路請求，而是返回之前提取的活動。
+- 如果 UI 停止使用此提供者程式，則快取將被處置。
+  然後，如果 UI 再次使用提供者程式，則會發出新的網路請求。
+- 我們沒有捕獲錯誤。這是自動的，因為提供者程式本身會處理錯誤。  
+  如果網路請求或 JSON 解析丟擲錯誤，則 Riverpod 將捕獲該錯誤。
+  然後，UI 將自動包含呈現錯誤頁面所需的資訊。
+
+:::info
+<!---
+Providers are "lazy". Defining a provider will not execute the network request.
+Instead, the network request will be executed when the provider is first read.
+-->
+提供者程式是“懶惰的”。定義提供者程式不會執行網路請求。
+相反，網路請求將在首次讀取提供者程式時執行。
+:::
+
+<!---
+### Rendering the network request's response in the UI
+-->
+### 在 UI 中呈現網路請求的響應
+
+<!---
+Now that we have defined a provider, we can start using it inside our UI
+to display the activity.
+-->
+現在我們已經定義了一個提供者程式，我們可以開始在 UI 中使用它來顯示活動。
+
+<!---
+To interact with a provider, we need an object called "ref". You may have seen
+it previously in the provider definition, as providers naturally have access
+to a "ref" object.  
+But in our case, we aren't in a provider, but a widget. So how do we get a "ref"?
+-->
+為了與提供者程式互動，我們需要一個名為“ref”的物件。
+您之前可能在提供者程式定義中看到過它，因為提供者程式自然可以訪問“ref”物件。  
+但在我們的例子中，我們不是提供者程式，而是小部件。那麼我們如何獲得“ref”呢？
+
+<!---
+The solution is to use a custom widget called `Consumer`. A `Consumer` is a widget
+similar to `Builder`, but with the added benefit of offering us a "ref". This enables our UI to read providers.
+The following example showcases how to use a `Consumer`:
+-->
+解決方案是使用名為 `Consumer` 的自定義小部件。
+`Consumer` 是一個類似於 `Builder` 的小部件，但還有一個額外的好處，那就是為我們提供了一個“ref”。
+這使我們的 UI 能夠讀取提供者程式。以下示例展示瞭如何使用 `Consumer`：
+
+<AutoSnippet title="consumer.dart" {...consumer} />
+
+<!---
+In that snippet, we've used a `Consumer` to read our `activityProvider` and display the activity.
+We also gracefully handled the loading/error states.  
+Notice how the UI was able to handle loading/error states without having to do anything special
+in the provider.  
+At the same time, if the widget were to rebuild, the network request would correctly
+not be re-executed. Other widgets could also access the same provider without
+re-executing the network request.
+-->
+在該程式碼段中，我們使用了 `Consumer` 來讀取和 `activityProvider` 顯示活動。
+我們還優雅地處理了載入/錯誤狀態。  
+請注意 UI 如何能夠處理載入/錯誤狀態，而無需在提供者程式中執行任何特殊操作。  
+同時，如果小部件要重建，則不會正確地重新執行網路請求。
+其他小部件也可以訪問同一提供者程式，而無需重新執行網路請求。
+
+:::info
+<!---
+Widgets can listen to as many providers as they want. To do so, simply add more `ref.watch` calls.
+-->
+小部件可以根據需要，監聽任意數量的提供者程式。為此，只需新增更多 ref.watch 呼叫即可。
+:::
+
+:::tip
+<!---
+Make sure to install the linter. That will enable your IDE to offer refactoring
+options to automatically add a `Consumer` or convert a `StatelessWidget` into a `ConsumerWidget`.
+-->
+確保安裝 linter。這將使您的 IDE 能夠提供重構選項，
+以自動新增 `Consumer` 或將 `StatelessWidget` 重構為 `ConsumerWidget`。
+
+<!---
+See <Link documentID="introduction/getting_started" hash="enabling-riverpod_lintcustom_lint" /> for installation steps.
+-->
+有關安裝步驟，請參閱<Link documentID="introduction/getting_started" hash="enabling-riverpod_lintcustom_lint" />。
+:::
+
+<!---
+## Going further: Removing code indentation by using `ConsumerWidget` instead of `Consumer`.
+-->
+## 更進一步：使用 `ConsumerWidget` 替代 `Consumer` 刪除程式碼縮排。
+
+<!---
+In the previous example, we used a `Consumer` to read our provider.  
+Although there is nothing wrong with this approach, the added indentation
+can make the code harder to read.
+-->
+在前面的示例中，我們使用 `Consumer` 來讀取提供者程式。  
+儘管這種方法沒有錯，但新增的縮排會使程式碼更難閱讀。
+
+<!---
+Riverpod offers an alternative way of achieving the same result:
+Instead of writing a `StatelessWidget`/`StatefulWidge` return returns a `Consumer`, we can
+define a `ConsumerWidget`/`ConsumerStatefulWidget`.  
+`ConsumerWidget` and `ConsumerStatefulWidget` are effectively the fusion
+of a `StatelessWidget`/`StatefulWidget` and a `Consumer`. They behave the same
+as their original couterpart, but with the added benefit of offering a "ref".
+-->
+Riverpod 提供了另一種實現相同結果的方法：
+我們可以定義 `ConsumerWidget` / `ConsumerStatefulWidget` 來代替在
+`StatelessWidget` / `StatefulWidget` 返回 `Consumer` 小元件。  
+`ConsumerWidget` 和 `ConsumerStatefulWidget` 實際上是 `StatelessWidget` / `StatefulWidget` 和 `Consumer` 的融合。
+它們的行為與原來的 couterpart 相同，但具有提供“ref”的額外好處。
+
+<!---
+We can rewrite the previous examples to use `ConsumerWidget` as followed:
+-->
+我們可以使用 `ConsumerWidget` 重寫前面的例子，如下所示：
+
+<AutoSnippet {...consumerWidget} />
+
+<!---
+As for `ConsumerStatefulWidget`, we would instead write:
+-->
+至於 `ConsumerStatefulWidget`，我們會這樣寫：
+
+<AutoSnippet {...consumerStatefulWidget} />
+
+<!---
+### Flutter_hooks considerations: Combining `HookWidget` and `ConsumerWidget`
+-->
+### Flutter_hooks 注意事項：結合 `HookWidget` 和 `ConsumerWidget`
+
+:::caution
+<!---
+If you have never heard about "hooks" before, feel free to skip this section.  
+[Flutter_hooks](https://pub.dev/packages/flutter_hooks) is a package
+independent from Riverpod but often used alongside it. If you are new to Riverpod,
+using "hooks" is discouraged. See more in <Link documentID="concepts/about_hooks"/>.
+-->
+如果您以前從未聽說過“鉤子（hooks）”，請隨時跳過本節。  
+[Flutter_hooks](https://pub.dev/packages/flutter_hooks) 是一個獨立於 Riverpod 的軟體包，
+但經常與 Riverpod 一起使用。如果您不熟悉 Riverpod，不建議使用“鉤子”。
+有關詳細資訊，請參閱<Link documentID="concepts/about_hooks"/>。
+:::
+
+<!---
+If you are using `flutter_hooks`, you may be wondering how to combine `HookWidget`
+and `ConsumerWidget`. After all, both involve changing the extended widget class.
+-->
+如果您正在使用 `flutter_hooks`，您可能想知道如何將 `ConsumerWidget`
+和 `HookWidget` 組合在一起。畢竟，兩者都涉及更改擴充套件的小部件類。
+
+<!---
+Riverpod offers a solution to this problem: `HookConsumerWidget` and `StatefulHookConsumerWidget`.  
+Similarly to how `ConsumerWidget` and `ConsumerStatefulWidget` are the fusion of `Consumer` and `StatelessWidget`/`StatefulWidget`,
+`HookConsumerWidget` and `StatefulHookConsumerWidget` are the fusion of `Consumer` and `HookWidget`/`HookStatefulWidget`.
+As such, they enable using both hooks and providers in the same widget.
+-->
+Riverpod 為此問題提供瞭解決方案：`HookConsumerWidget` 和 `StatefulHookConsumerWidget`。  
+類似於 `ConsumerWidget` 和 `ConsumerStatefulWidget` 是 `StatelessWidget` / `StatefulWidget` 和 `Consumer` 融合，
+`HookConsumerWidget` 和 `StatefulHookConsumerWidget` 是 `HookWidget` / `HookStatefulWidget` 和 `Consumer` 的融合。
+因此，它們允許在同一個小部件中同時使用鉤子和提供者程式。
+
+<!---
+To showcase this, we could one more time rewrite the previous example:
+-->
+為了展示這一點，我們可以再次重寫前面的例子：
+
+<AutoSnippet {...hookConsumerWidget} />

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/activity.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/activity.ts
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw/activity.dart";
+import codegen from "!!raw-loader!./codegen/activity.dart";
+
+export default {
+  raw: raw,
+  hooks: raw,
+  codegen: codegen,
+  hooksCodegen: codegen,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/codegen/activity.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/codegen/activity.dart
@@ -1,0 +1,23 @@
+/* SNIPPET START */ import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'activity.freezed.dart';
+part 'activity.g.dart';
+
+/// `GET /api/activity` 請求的響應。
+///
+/// 這個定義使用了 `freezed` 和 `json_serializable`。
+@freezed
+sealed class Activity with _$Activity {
+  factory Activity({
+    required String key,
+    required String activity,
+    required String type,
+    required int participants,
+    required double price,
+  }) = _Activity;
+
+  /// 將 JSON 物件轉換為 [Activity] 例項。
+  /// 這可以實現 API 響應的型別安全讀取。
+  factory Activity.fromJson(Map<String, dynamic> json) =>
+      _$ActivityFromJson(json);
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/codegen/provider.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/codegen/provider.dart
@@ -1,0 +1,19 @@
+/* SNIPPET START */ import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'activity.dart';
+
+// 程式碼生成正常工作的必要條件
+part 'provider.g.dart';
+
+/// 這將建立一個名為 `activityProvider` 的提供者程式
+/// 它可以快取函式執行的結果
+@riverpod
+Future<Activity> activity(Ref ref) async {
+  // 使用 package:http, 我們可以從 Bored API 獲取一個隨機的活動。
+  final response = await http.get(Uri.https('boredapi.com', '/api/activity'));
+  // 使用 dart:convert, 然後我們將 JSON 有效負載解碼為 Map 資料結構。
+  final json = jsonDecode(response.body) as Map<String, dynamic>;
+  // 最後，我們將 Map 轉換為 Activity 例項。
+  return Activity.fromJson(json);
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/consumer.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/consumer.ts
@@ -1,0 +1,8 @@
+import raw from "!!raw-loader!./raw/consumer.dart";
+
+export default {
+  raw: raw,
+  hooks: raw,
+  codegen: raw,
+  hooksCodegen: raw,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/consumer_stateful_widget.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/consumer_stateful_widget.ts
@@ -1,0 +1,8 @@
+import raw from "!!raw-loader!./raw/consumer_stateful_widget.dart";
+
+export default {
+  raw: raw,
+  hooks: raw,
+  codegen: raw,
+  hooksCodegen: raw,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/consumer_widget.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/consumer_widget.ts
@@ -1,0 +1,8 @@
+import raw from "!!raw-loader!./raw/consumer_widget.dart";
+
+export default {
+  raw: raw,
+  hooks: raw,
+  codegen: raw,
+  hooksCodegen: raw,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/hook_consumer_widget.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/hook_consumer_widget.ts
@@ -1,0 +1,8 @@
+import raw from "!!raw-loader!./raw/hook_consumer_widget.dart";
+
+export default {
+  raw: raw,
+  hooks: raw,
+  codegen: raw,
+  hooksCodegen: raw,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/legend/DocuCode.scss
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/legend/DocuCode.scss
@@ -1,0 +1,18 @@
+.legend {
+  table,
+  td,
+  tr {
+    background: none !important;
+    border: none;
+
+    vertical-align: top;
+  }
+
+  td:first-child {
+    text-align: end;
+  }
+
+  tr + tr {
+    border-top: solid 0.5px;
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/legend/legend.tsx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/legend/legend.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import PropTypes from "prop-types";
+import CodeBlock from "@theme/CodeBlock";
+import "./DocuCode.scss";
+
+type AnnotatedCode = {
+  color?: string;
+  code: string;
+};
+
+export const colors = [
+  "#2196f3",
+  "#4caf50",
+  "#f44336",
+  "#ff9800",
+  "#009688",
+  "#e91e63",
+  "#00bcd4",
+  "#8bc34a",
+];
+
+const Legend = ({ annotations, code }) => {
+  const fullAnnotations = new Array<AnnotatedCode>();
+
+  let annotationOffset = 0;
+  for (var codeOffset = 0; codeOffset < code.length; ) {
+    if (annotationOffset >= annotations.length) {
+      // Out of annotations, just add the rest of the code
+      fullAnnotations.push({ code: code.substring(codeOffset) });
+      break;
+    }
+
+    const annotation = annotations[annotationOffset];
+    if (codeOffset < annotation.offset) {
+      /// There is an unannotated gap between the last annotation and this one.
+      const codeLength = annotation.offset - codeOffset;
+      fullAnnotations.push({
+        code: code.substring(codeOffset, codeOffset + codeLength),
+      });
+      codeOffset += codeLength;
+    }
+
+    if (annotation.offset >= code.length) {
+      throw new Error("Annotation offset out of bounds");
+    }
+
+    annotationOffset++;
+    codeOffset = annotation.offset + annotation.length;
+    fullAnnotations.push({
+      color: colors[annotationOffset - 1],
+      code: code.substring(
+        annotation.offset,
+        annotation.offset + annotation.length
+      ),
+    });
+  }
+
+  return (
+    <div className="legend">
+      <pre className="code">
+        {fullAnnotations.map(({ code, color }) => {
+          let underlineClass = color ? `underline` : "";
+          let style = color ? { color: color } : undefined;
+
+          return (
+            <span key={code} className={underlineClass} style={style}>
+              {code}
+            </span>
+          );
+        })}
+      </pre>
+      <table className="annotations">
+        <tbody>
+          {annotations.map((annotation, index) => (
+            <tr key={annotation.label} className="annotation">
+              <td className="underline" style={{ color: colors[index] }}>
+                {annotation.label}
+              </td>
+              <td>{annotation.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default Legend;

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/provider.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/provider.ts
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw/provider.dart";
+import codegen from "!!raw-loader!./codegen/provider.dart";
+
+export default {
+  raw: raw,
+  hooks: raw,
+  codegen: codegen,
+  hooksCodegen: codegen,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/activity.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/activity.dart
@@ -1,0 +1,28 @@
+/* SNIPPET START */ /// `GET /api/activity` 請求的響應。
+class Activity {
+  Activity({
+    required this.key,
+    required this.activity,
+    required this.type,
+    required this.participants,
+    required this.price,
+  });
+
+  /// 將 JSON 物件轉換為 [Activity] 例項。
+  /// 這可以實現 API 響應的型別安全讀取。
+  factory Activity.fromJson(Map<String, dynamic> json) {
+    return Activity(
+      key: json['key'] as String,
+      activity: json['activity'] as String,
+      type: json['type'] as String,
+      participants: json['participants'] as int,
+      price: json['price'] as double,
+    );
+  }
+
+  final String key;
+  final String activity;
+  final String type;
+  final int participants;
+  final double price;
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/consumer.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/consumer.dart
@@ -1,0 +1,39 @@
+// ignore_for_file: omit_local_variable_types
+
+/* SNIPPET START */ import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'activity.dart';
+import 'provider.dart';
+
+/// 我們應用程式主頁
+class Home extends StatelessWidget {
+  const Home({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer(
+      builder: (context, ref, child) {
+        // 讀取 activityProvider。如果沒有準備開始，這將會開始一個網路請求。
+        // 透過使用 ref.watch，小元件將會在 activityProvider 更新時重建。
+        // 當下面的事情發生時，會更新小元件：
+        // - 響應從“正在載入”變為“資料/錯誤”
+        // - 請求重重新整理
+        // - 結果被本地修改（例如執行副作用時）
+        // ...
+        final AsyncValue<Activity> activity = ref.watch(activityProvider);
+
+        return Center(
+          /// 由於網路請求是非同步的並且可能會失敗，我們需要處理錯誤和載入的狀態。
+          /// 我們可以為此使用模式匹配。
+          /// 我們也可以使用 `if (activity.isLoading) { ... } else if (...)`
+          child: switch (activity) {
+            AsyncData(:final value) => Text('Activity: ${value.activity}'),
+            AsyncError() => const Text('Oops, something unexpected happened'),
+            _ => const CircularProgressIndicator(),
+          },
+        );
+      },
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/consumer_stateful_widget.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/consumer_stateful_widget.dart
@@ -1,0 +1,42 @@
+// ignore_for_file: omit_local_variable_types, prefer_const_constructors, unused_local_variable, todo
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'activity.dart';
+import 'provider.dart';
+
+/* SNIPPET START */ // 我們擴充套件了 ConsumerStatefulWidget。
+// 這等效於 "Consumer" + "StatefulWidget".
+class Home extends ConsumerStatefulWidget {
+  const Home({super.key});
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _HomeState();
+}
+
+// 請注意，我們如何擴充套件“ConsumerState”而不是“State”。
+// 這和 "ConsumerWidget" 與 "StatelessWidget" 是相同的原理。
+class _HomeState extends ConsumerState<Home> {
+  @override
+  void initState() {
+    super.initState();
+
+    // 狀態生命週期也可以訪問“ref”。
+    // 這使得在特定提供者程式上新增監聽器，以便實現顯示對話方塊/資訊欄等功能。
+    ref.listenManual(activityProvider, (previous, next) {
+      // TODO 顯示一個 snackbar/dialog
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // "ref" is not passed as parameter anymore, but is instead a property of "ConsumerState".
+    // We can therefore keep using "ref.watch" inside "build".
+    // “ref”不再作為引數傳遞，而是作為“ConsumerState”的屬性。
+    // 因此，我們可以繼續在“build”中使用“ref.watch”。
+    final AsyncValue<Activity> activity = ref.watch(activityProvider);
+
+    return Center(/* ... */);
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/consumer_widget.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/consumer_widget.dart
@@ -1,0 +1,23 @@
+// ignore_for_file: omit_local_variable_types, prefer_const_constructors, unused_local_variable
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'activity.dart';
+import 'provider.dart';
+
+/* SNIPPET START */ /// 我們將“ConsumerWidget”替代“StatelessWidget”進行子類化。
+/// 這相當於使用“StatelessWidget”並返回“Consumer”小元件。
+class Home extends ConsumerWidget {
+  const Home({super.key});
+
+  @override
+  // 請注意“build”現在如何接收一個額外的引數：“ref”
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 我們可以像使用“Consumer”一樣，在小部件中使用“ref.watch”
+    final AsyncValue<Activity> activity = ref.watch(activityProvider);
+
+    // 渲染邏輯保持不變
+    return Center(/* ... */);
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/hook_consumer_widget.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/hook_consumer_widget.dart
@@ -1,0 +1,26 @@
+// ignore_for_file: omit_local_variable_types, unused_local_variable, prefer_const_constructors
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'activity.dart';
+import 'provider.dart';
+
+/* SNIPPET START */ /// 我們子類化了 "HookConsumerWidget"。
+/// 這同時組合了 "StatelessWidget"、"Consumer"、"HookWidget"。
+class Home extends HookConsumerWidget {
+  const Home({super.key});
+
+  @override
+  // 請注意“build”現在如何接收一個額外的引數：“ref”
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 可以在我們的小部件中使用諸如“useState”之類的鉤子
+    final counter = useState(0);
+
+    // 我們還可以使用讀取提供者程式
+    final AsyncValue<Activity> activity = ref.watch(activityProvider);
+
+    return Center(/* ... */);
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/provider.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/first_request/raw/provider.dart
@@ -1,0 +1,13 @@
+/* SNIPPET START */ import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'activity.dart';
+
+final activityProvider = FutureProvider.autoDispose((ref) async {
+  // 使用 package:http, 我們可以從 Bored API 獲取一個隨機的活動。
+  final response = await http.get(Uri.https('boredapi.com', '/api/activity'));
+  // 使用 dart:convert, 然後我們將 JSON 有效負載解碼為 Map 資料結構。
+  final json = jsonDecode(response.body) as Map<String, dynamic>;
+  // 最後，我們將 Map 轉換為 Activity 例項。
+  return Activity.fromJson(json);
+});

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args.mdx
@@ -1,0 +1,265 @@
+---
+title: 將引數傳遞給您的請求
+version: 1
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet, When } from "@site/src/components/CodeSnippet";
+import noArgProvider from "/docs/essentials/passing_args/no_arg_provider";
+import family from "!!raw-loader!./passing_args/raw/family.dart";
+import codegenFamily from "!!raw-loader!./passing_args/codegen/family.dart";
+import consumerProvider from "!!raw-loader!/docs/essentials/passing_args/raw/consumer_provider.dart";
+import consumerFamily from "!!raw-loader!/docs/essentials/passing_args/raw/consumer_family.dart";
+import consumerListFamily from "!!raw-loader!/docs/essentials/passing_args/raw/consumer_list_family.dart";
+import multipleConsumerFamily from "!!raw-loader!/docs/essentials/passing_args/raw/multiple_consumer_family.dart";
+import tupleFamily from "!!raw-loader!/docs/essentials/passing_args/raw/tuple_family.dart";
+import consumerTupleFamily from "!!raw-loader!/docs/essentials/passing_args/raw/consumer_tuple_family.dart";
+
+<!---
+In a previous article, we saw how we could define a "provider" to make
+a simple _GET_ HTTP request.  
+But often, HTTP requests depend on external parameters.
+-->
+在上一篇文章中，我們看到了如何定義一個“provider”來發出一個簡單的 _GET_ HTTP 請求。  
+但通常，HTTP 請求依賴於外部引數。
+
+<!---
+For example, previously we used the [Bored API](https://boredapi.com/)
+to suggest a random activity to users.
+But maybe users would want to filter the type of activity they want to do,
+or have price requirements, etc...  
+These parameters are not known in advance. So we need a way to pass
+these parameters from our UI to our providers.
+-->
+例如，以前我們使用 [Bored API](https://boredapi.com/) 向用戶推薦隨機活動。
+但也許使用者想要過濾他們想做的活動型別，或者有價格要求，等等……  
+這些引數事先是未知的。因此，我們需要一種方法將這些引數
+從我們的 UI 傳遞到我們的提供者程式。
+
+<!---
+## Updating our providers to accept arguments
+-->
+## 更新我們的提供者程式以接受引數
+
+<!---
+As a reminder, previously we defined our provider like this:
+-->
+提醒一下，以前我們是這樣定義我們的提供者程式的：
+
+<AutoSnippet {...noArgProvider} />
+
+<When codegen={false}>
+
+<!---
+When not relying on code-generation, we need to tweak the syntax for defining
+our providers a bit to support passing arguments. This is done by relying on
+the "modifier" called "family".
+-->
+當不依賴於程式碼生成時，我們需要稍微調整定義提供者程式的語法，以支援傳遞引數。
+這是透過依靠稱為“family”的“修飾符”來完成的。
+
+<!---
+In short, we need to add `.family` after the type of our provider, and
+an extra type parameter corresponding to the argument type.
+For example, we could update our provider to accept a `String` argument
+corresponding to the type of activity desired:
+-->
+簡而言之，我們需要在提供者程式的型別之後新增 `.family` 一個額外的型別引數，
+以及與引數型別相對應的型別引數。
+例如，我們可以更新提供者程式以接受與所需活動型別相對應的 String 引數：
+
+<AutoSnippet raw={family} />
+
+</When>
+
+<When codegen={true}>
+
+<!---
+To pass parameters to our providers, we can simply add our parameters
+on the annotated function itself.  
+For example, we could update our provider to accept a `String` argument
+corresponding to the type of activity desired:
+-->
+要將引數傳遞給我們的提供者程式，我們只需在帶註解的函式本身上新增引數即可。  
+例如，我們可以更新提供者程式以接受與所需活動型別相對應的 `String` 引數：
+
+<AutoSnippet raw={codegenFamily} />
+
+</When>
+
+:::caution
+<!---
+When passing arguments to providers, it is highly encouraged to
+enable "autoDispose" on the provider.  
+Failing to do so may result in memory leaks.  
+See <Link documentID="essentials/auto_dispose" /> for more details.
+-->
+將引數傳遞給提供者程式時，強烈建議在提供者程式上啟用“autoDispose”。  
+否則可能會導致記憶體洩漏。  
+有關詳細資訊，請參閱<Link documentID="essentials/auto_dispose" />。
+:::
+
+<!---
+## Updating our UI to pass arguments
+-->
+## 更新我們的 UI 以傳遞引數
+
+<!---
+Previously, widgets consumed our provider like this:
+-->
+以前，小部件是這樣消費我們的提供者程式的：
+
+<AutoSnippet raw={consumerProvider} />
+
+<!---
+But now that our provider receives arguments, the syntax to consume it is slightly
+different. The provider is now a function, which needs to be invoked with the parameters
+requested.  
+We could update our UI to pass a hard-coded type of activity like this:
+-->
+但是現在我們的提供者程式收到引數，使用它的語法略有不同。
+提供者程式現在是一個函式，需要使用請求的引數來呼叫它。  
+我們可以更新我們的 UI 以傳遞硬編碼型別的活動，如下所示：
+
+<AutoSnippet raw={consumerFamily} />
+
+<When codegen={true}>
+
+<!---
+The parameters passed to the provider corresponds to the parameters
+of the annotated function, minus the "ref" parameter.
+-->
+傳遞給提供者程式的引數對應於帶註解的函式的引數，減去“ref”引數。
+
+</When>
+
+:::info
+<!---
+It is entirely possible to listen to the same provider with different arguments
+simultaneously.  
+For example, our UI could render both "recreational" _and_ "cooking" activities:
+-->
+完全可以同時監聽具有不同引數的同一提供者程式。  
+例如，我們的 UI 可以同時呈現“娛樂（recreational）”_和_“烹飪（cooking）”活動：
+
+<AutoSnippet raw={multipleConsumerFamily} />
+
+<When codegen={false}>
+
+<!---
+This is the reason why the modifier is called "family": Because passing
+parameters to a provider effectively transforms the provider in a group of
+states with the same logic under the hood.
+-->
+這就是修飾符被稱為“family”的原因：
+因為把引數傳遞給提供者程式（譯者注：作為不同狀態的區分的 key 值），
+可以有效地將提供者程式轉換為一組具有相同邏輯的狀態。
+
+</When>
+:::
+
+<!---
+## Caching considerations and parameter restrictions
+-->
+## 快取注意事項和引數限制
+
+<!---
+When passing parameters to providers, the computation is still cached.
+The difference is that the computation is now cached per-argument.
+-->
+將引數傳遞給提供者程式時，仍會快取計算。
+不同之處在於，計算現在是按引數快取的。
+
+<!---
+This means that if two widgets consumes the same provider with the same
+parameters, only a single network request will be made.  
+But if two widgets consumes the same provider with different parameters,
+two network requests will be made.
+-->
+這意味著，如果兩個小部件使用具有相同引數的同一提供者程式，則只會發出單個網路請求。  
+但是，如果兩個小部件使用具有不同引數的同一提供者程式，則將發出兩個網路請求。
+
+<!---
+For this to work, Riverpod relies on the `==` operator of the parameters.  
+As such, it is important that the parameters passed to the provider
+have consistent equality.
+-->
+為此，Riverpod 依賴於引數的 `==` 運算子。  
+因此，傳遞給提供者程式的引數必須具有一致的相等性，這一點很重要。
+
+:::caution
+<!---
+A common mistake is to directly instantiate a new object as the parameter
+of a provider, when that object does not override `==`.  
+For example, you may be tempted to pass a `List` like so:
+-->
+一個常見的錯誤是直接例項化一個新物件作為提供者程式的引數，但該物件沒有重寫 `==`。  
+例如，您可能很想去這樣使用 `List`：
+
+<AutoSnippet raw={consumerListFamily} />
+
+<!---
+The problem with this code is that `['recreational', 'cooking'] == ['recreational', 'cooking']` is `false`.
+As such, Riverpod will consider that the two parameters are different,
+and attempt to make a new network request.  
+This would result in an infinite loop of network requests, permanently
+showing a progress indicator to the user.
+-->
+此程式碼的問題在於 `['recreational', 'cooking'] == ['recreational', 'cooking']` 的結果是 `false`。
+因此，Riverpod 將認為這兩個引數不同，並嘗試發出新的網路請求。  
+這將導致網路請求的無限迴圈，一直向用戶顯示進度指示器。
+
+<!---
+To fix this, you could either use a `const` list (`const ['recreational', 'cooking']`)
+or use a custom list implementation that overrides `==`.
+-->
+要解決此問題，您可以使用 `const` 列表 (`const ['recreational', 'cooking']`)
+或使用重寫了 `==` 的自定義列表實現。
+
+<!---
+To help spot this mistake, it is recommended to use the [riverpod_lint](https://pub.dev/packages/riverpod_lint)
+and enable the [provider_parameters](https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod_lint#provider_parameters)
+lint rule. Then, the previous snippet would show a warning.
+See <Link documentID="introduction/getting_started" hash="enabling-riverpod_lintcustom_lint" /> for installation steps.
+-->
+為了幫助發現此錯誤，建議使用 [riverpod_lint](https://pub.dev/packages/riverpod_lint)
+並啟用 [provider_parameters](https://github.com/rrousselGit/riverpod/tree/master/packages/riverpod_lint#provider_parameters)
+的 lint 規則。這樣做之後，上面的程式碼片段將顯示警告。
+有關安裝步驟，請參閱<Link documentID="introduction/getting_started" hash="enabling-riverpod_lintcustom_lint" />。
+:::
+
+<When codegen={false}>
+
+<!---
+With that in mind, you may wonder how to pass multiple parameters to a provider.  
+The recommended solution is either to:
+-->
+考慮到這一點，您可能想知道如何將多個引數傳遞給提供者程式。  
+建議的解決方案是：
+
+<!---
+- Switch to code-generation, which enables passing any number of parameters
+- Use Dart 3's records
+-->
+- 切換到程式碼生成，這樣可以傳遞任意數量的引數
+- 使用 Dart 3 的記錄 (record) 語法
+
+<!---
+The reason why Dart 3's records come in handy is because they
+naturally override `==` and have a convenient syntax.  
+As an example, we could update our provider to accept both a type of activity
+and a maximum price:
+-->
+Dart 3 的記錄之所以派上用場，是因為它們自然覆蓋 `==` 並具有方便的語法。  
+例如，我們可以更新我們的提供者程式，以同時接受一種活動型別和最高價格：
+
+<AutoSnippet raw={tupleFamily} />
+
+<!---
+We can then consume this provider like so:
+-->
+然後，我們可以像這樣消費這個提供者程式：
+
+<AutoSnippet raw={consumerTupleFamily} />
+
+</When>

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args/codegen/family.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args/codegen/family.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../../first_request/codegen/activity.dart';
+
+part 'family.g.dart';
+
+/* SNIPPET START */
+@riverpod
+Future<Activity> activity(
+  Ref ref,
+  // 我們可以向提供者程式新增引數。
+  // 引數的型別可以是您想要的任何型別。
+  String activityType,
+) async {
+  // 我們可以使用“activityType”引數來構建 URL。
+  // 這將指向 "https://boredapi.com/api/activity?type=<activityType>"
+  final response = await http.get(
+    Uri(
+      scheme: 'https',
+      host: 'boredapi.com',
+      path: '/api/activity',
+      // 無需手動編碼查詢引數，“Uri”類為我們完成了這一工作。
+      queryParameters: {'type': activityType},
+    ),
+  );
+  final json = jsonDecode(response.body) as Map<String, dynamic>;
+  return Activity.fromJson(json);
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args/codegen/provider.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args/codegen/provider.dart
@@ -1,0 +1,32 @@
+// ignore_for_file: avoid_print
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../../first_request/codegen/activity.dart';
+
+// Necessary for code-generation to work
+part 'provider.g.dart';
+
+FutureOr<Activity> fetchActivity() => throw UnimplementedError();
+
+/* SNIPPET START */
+// “函式型”提供者程式
+@riverpod
+Future<Activity> activity(Ref ref) async {
+  // TODO: 執行網路請求以獲取活動
+  return fetchActivity();
+}
+
+// 或者替代方案，“通知者程式”
+@riverpod
+class ActivityNotifier2 extends _$ActivityNotifier2 {
+  /// 通知者程式引數在構建方法上指定。
+  /// 可以有任意數量的通知者程式引數，可以是任意的變數名稱，甚至可以是可選/命名的引數。
+  @override
+  Future<Activity> build(String activityType) async {
+    // 引數也可透過 "this.<argumentName>" 使用
+    print(this.activityType);
+
+    // TODO: 執行網路請求以獲取活動
+    return fetchActivity();
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args/no_arg_provider.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args/no_arg_provider.ts
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw/provider.dart";
+import codegen from "!!raw-loader!./codegen/provider.dart";
+
+export default {
+  raw: raw,
+  hooks: raw,
+  codegen: codegen,
+  hooksCodegen: codegen,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args/raw/family.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args/raw/family.dart
@@ -1,0 +1,42 @@
+// ignore_for_file: unnecessary_this, avoid_print
+
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../first_request/raw/activity.dart';
+
+FutureOr<Activity> fetchActivity(String activityType) =>
+    throw UnimplementedError();
+
+/* SNIPPET START */
+// “函式型”提供者
+final activityProvider = FutureProvider.autoDispose
+    // 我們使用 ".family" 修飾符。
+    // 泛型型別 "String" 對應於引數的型別。
+    // 我們的提供者程式現在在 "ref" 上收到一個額外的引數：activity 的型別。
+    .family<Activity, String>((ref, activityType) async {
+  // TODO: 使用 "activityType" 執行網路請求以獲取活動
+  return fetchActivity(activityType);
+});
+
+// “通知者程式”的提供者
+final activityProvider2 = AsyncNotifierProvider.autoDispose
+    // 再次，我們使用 ".family" 修飾符，並將引數指定為 "String" 型別。
+    .family<ActivityNotifier, Activity, String>(
+  ActivityNotifier.new,
+);
+
+// 當將 ".family" 與通知者程式一起使用時，我們需要更改通知者程式子類：
+// AsyncNotifier -> FamilyAsyncNotifier
+// AutoDisposeAsyncNotifier -> AutoDisposeFamilyAsyncNotifier
+class ActivityNotifier
+    extends AutoDisposeFamilyAsyncNotifier<Activity, String> {
+  /// Family 引數傳遞給構建方法並可透過 this.arg 訪問
+  @override
+  Future<Activity> build(String activityType) async {
+    // 引數也可透過 "this.arg" 使用
+    print(this.arg);
+
+    // TODO: 執行網路請求以獲取活動
+    return fetchActivity(activityType);
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args/raw/provider.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/passing_args/raw/provider.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../first_request/raw/activity.dart';
+
+/* SNIPPET START */
+
+FutureOr<Activity> fetchActivity() => throw UnimplementedError();
+
+// “函式型”提供者程式
+final activityProvider = FutureProvider.autoDispose((ref) async {
+  // TODO: 執行網路請求以獲取活動
+  return fetchActivity();
+});
+
+// 或者替代方案，“通知者程式”
+final activityProvider2 = AsyncNotifierProvider<ActivityNotifier, Activity>(
+  ActivityNotifier.new,
+);
+
+class ActivityNotifier extends AsyncNotifier<Activity> {
+  @override
+  Future<Activity> build() async {
+    // TODO: 執行網路請求以獲取活動
+    return fetchActivity();
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/provider_observer.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/provider_observer.mdx
@@ -1,0 +1,79 @@
+---
+title: 日誌和錯誤報告
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet, When } from "@site/src/components/CodeSnippet";
+import providerObserver from "!!raw-loader!/docs/essentials/provider_observer/provider_observer.dart";
+
+<!---
+Riverpod natively offers a way to listen to all events happening
+in the provider tree.  
+This can be used to log all the events, or to report errors to a
+remote service.
+-->
+Riverpod 本身提供了一種監聽提供者程式樹中發生的所有事件的方法。  
+這可用於記錄所有事件，或向遠端服務報告錯誤。
+
+<!---
+This is achieved by using the `ProviderObserver` class,
+and passing it to `ProviderScope`/`ProviderContainer`.
+-->
+這是透過使用 `ProviderObserver` 類並將其傳遞給
+`ProviderScope`/`ProviderContainer` 來實現的。
+
+<!---
+## Defining a ProviderObserver
+-->
+## 定義 ProviderObserver ​
+
+<!---
+A `ProviderObserver` is a class that should be extended.  
+It offers various methods which can be overridden to listen to events:
+-->
+ProviderObserver 是一個應該被擴充套件的類。  
+它提供了各種可以重寫的方法來監聽事件：
+
+<!---
+- `didAddProvider`, called when a provider is added to the tree
+- `didUpdateProvider`, called when a provider is updated
+- `didDisposeProvider`, called when a provider is disposed
+- `providerDidFail`, when a synchronous provider throws an error
+-->
+- `didAddProvider`，當提供者程式被新增到元件樹時呼叫
+- `didUpdateProvider`，當提供者程式更新時呼叫
+- `didDisposeProvider`，當提供者程式被處置時呼叫
+- `providerDidFail`，當同步的提供者程式丟擲錯誤時
+
+<AutoSnippet raw={providerObserver} />
+
+<!---
+## Using a ProviderObserver
+-->
+## 使用 ProviderObserver​
+
+<!---
+Now that we've defined an observer, we need to use it.  
+To do so, we should pass it to either `ProviderScope` or `ProviderContainer`:
+-->
+現在我們已經定義了觀察者，我們需要使用它。  
+為此，我們應該將其傳遞給 `ProviderScope` 或 `ProviderContainer` ：
+
+```dart
+runApp(
+  ProviderScope(
+    observers: [
+      MyObserver(),
+    ],
+    child: MyApp(),
+  )
+);
+```
+
+```dart
+final container = ProviderContainer(
+  observers: [
+    MyObserver(),
+  ],
+);
+```

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects.mdx
@@ -1,0 +1,668 @@
+---
+title: 執行副作用
+version: 1
+---
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet, When } from "@site/src/components/CodeSnippet";
+import Legend, { colors } from "./first_request/legend/legend";
+import todoListProvider from "./side_effects/todo_list_provider";
+import todoListNotifier from "./side_effects/todo_list_notifier";
+import todoListNotifierAddTodo from "./side_effects/todo_list_notifier_add_todo";
+import consumerAddTodoCall from "!!raw-loader!/docs/essentials/side_effects/raw/consumer_add_todo_call.dart";
+import restAddTodo from "!!raw-loader!/docs/essentials/side_effects/raw/rest_add_todo.dart";
+import invalidateSelfAddTodo from "!!raw-loader!/docs/essentials/side_effects/raw/invalidate_self_add_todo.dart";
+import manualAddTodo from "!!raw-loader!/docs/essentials/side_effects/raw/manual_add_todo.dart";
+import mutableManualAddTodo from "!!raw-loader!/docs/essentials/side_effects/raw/mutable_manual_add_todo.dart";
+import renderAddTodo from "./side_effects/render_add_todo";
+
+<!---
+So far, we've only seen how to fetch data (aka perform a _GET_ HTTP request).  
+But what about side-effects, such as a _POST_ request?
+-->
+到目前為止，我們只看到瞭如何獲取資料（也就是執行 _GET_ HTTP 請求）。  
+但是副作用（例如 _POST_ 請求）呢？
+
+<!---
+Applications often implement a CRUD (Create, Read, Update, Delete) API.  
+When doing so, it is common that an update request (typically a _POST_) should
+also update the local cache to have the UI reflect the new state.
+-->
+應用程式通常實現 CRUD（建立、讀取、更新、刪除）API。  
+執行此操作時，更新請求（通常是 _POST_）通常還應更新本地快取，以使 UI 反映新狀態。
+
+<!---
+The problem is, how do we update the state of a provider from within a consumer?  
+Naturally, providers do not expose a way to modify their state.
+This is by design, to ensure that the state is only modified in a controlled way
+and promote separation of concerns.  
+Instead, providers have to explicitly expose a way to modify their state.
+-->
+問題是，我們如何從消費者程式內部更新提供者程式的狀態？  
+理所當然的，提供者程式不會公開修改其狀態的方法。
+這是設計使然，以確保僅以受控方式修改狀態並促進關注點分離。  
+相反，提供者程式必須顯式公開修改其狀態的方法。
+
+<!---
+To do that, we will use a new concept: Notifiers.  
+To showcase this new concept, let's use a more advanced example: A to-do list.
+-->
+為此，我們將使用一個新概念：通知者程式（Notifiers）。  
+為了展示這個新概念，讓我們使用一個更高階的例子：待辦事項列表。
+
+<!---
+## Defining a Notifier
+-->
+## 定義通知者程式
+
+<!---
+Let's start with what we already know by this point: A plain simple _GET_ request.
+As saw previously in <Link documentID="essentials/first_request" />, we could
+fetch a list of todos by writing:
+-->
+讓我們從此時我們已經知道的內容開始：一個簡單的 GET 請求。
+正如之前在<Link documentID="essentials/first_request" />中看到的那樣，
+我們可以透過編寫以下內容來獲取待辦事項列表：
+
+<AutoSnippet {...todoListProvider} />
+
+<!---
+Now that we've fetch a list of todos, let's see how we can add a new todos.  
+For this, we will need to modify our provider such that they expose a public API
+for modifying their state. This is done by converting our provider into what
+we call a "notifier".
+-->
+現在我們已經獲取了待辦事項列表，讓我們看看如何新增新的待辦事項。  
+為此，我們需要修改我們的提供者程式，以便它們公開一個公共 API 來修改其狀態。
+這是透過將我們的提供者程式轉換為我們所說的“通知者程式”來完成的。
+
+<!---
+Notifiers are the "stateful widget" of providers. They require a slight tweak to
+the syntax for defining a provider.  
+This new syntax is as follows:
+-->
+通知者程式是提供者程式的“有狀態小部件”。它們需要對定義提供者程式的語法稍作調整。  
+此新語法如下：
+
+<When codegen={false}>
+<Legend
+  code={`final name = SomeNotifierProvider.someModifier<MyNotifier, Result>(MyNotifier.new);
+ 
+class MyNotifier extends SomeNotifier<Result> {
+  @override
+  Result build() {
+    <你的業務邏輯在這裡>
+  }
+ 
+  <你的方法在這裡>
+}`}
+  annotations={[
+    {
+      offset: 6,
+      length: 4,
+      label: "提供者程式變數",
+       description: <>
+
+<!---
+This variable is what will be used to interact with our provider.  
+The variable must be final and "top-level" (global).
+-->
+此變數將用於與我們的提供者程式進行互動。  
+變數必須是 final 和“頂級”（全域性）。
+
+</>
+    },
+    {
+      offset: 13,
+      length: 20,
+      label: "提供者程式型別",
+       description: <>
+
+<!---
+Generally either `NotifierProvider`, `AsyncNotifierProvider` or `StreamNotifierProvider`.  
+The type of provider used depends on the return value of your function.
+For example, to create a `Future<Activity>`, you'll want a `AsyncNotifierProvider<Activity>`.
+-->
+通常為 `NotifierProvider`、`AsyncNotifierProvider` 和 `StreamNotifierProvider`。  
+使用的提供者程式型別取決於函式的返回值。
+例如，要建立一個 `Future<Activity>` ，您需要一個 `AsyncNotifierProvider<Activity>`。
+
+<!---
+`AsyncNotifierProvider` is the one you'll want to use the most.
+-->
+`AsyncNotifierProvider` 是你最想用的那個。
+
+:::tip
+<!---
+Don't think in terms of "Which provider should I pick".
+Instead, think in terms of "What do I want to return". The provider type
+will follow naturally.
+-->
+不要從“我應該選擇哪個提供者程式”的角度來思考。
+相反，從“我想返回什麼”的角度來思考。提供者程式型別將自然而然地遵循。
+:::
+
+</>
+    },
+    {
+      offset: 33,
+      length: 13,
+      label: "修飾符（可選的）",
+      description: <>
+
+<!---
+Often, after the type of the provider you may see a "modifier".  
+Modifiers are optional, and are used to tweak the behavior of the provider
+in a way that is type-safe.
+-->
+通常，在提供者程式的型別之後，您可能會看到一個“修飾符”。  
+修飾符是可選的，用於以型別安全的方式調整提供者程式的行為。
+
+<!---
+There are currently two modifiers available:
+-->
+目前有兩種修飾符可用：
+
+<!---
+- `autoDispose`, which will automatically clear the cache when the provider
+  stops being used.  
+  See also <Link documentID="essentials/auto_dispose" />
+- `family`, which enables passing arguments to your provider.  
+  See also <Link documentID="essentials/passing_args" />.
+-->
+- `autoDispose`，這將在提供者程式停止使用時自動清除快取。  
+  另請參閱<Link documentID="essentials/auto_dispose" />
+- `family`，這樣就可以將引數傳遞給提供者程式。  
+  另請參閱<Link documentID="essentials/passing_args" />
+
+</>
+    },
+    {
+      offset: 67,
+      length: 14,
+      label: "通知者程式的建構函式",
+      description: <>
+
+<!---
+The parameter of "notifier providers" is a function which is expected
+to instantiate the "notifier".  
+It generally should be a "constructor tear-off".
+-->
+“notifier providers”的引數是一個函式，它應該例項化“notifier”。  
+它通常應該是“建構函式撕裂”。
+
+</>
+    },
+    {
+      offset: 86,
+      length: 16,
+      label: "通知者程式",
+      description: <>
+
+<!---
+If `NotifierProvider` is the "StatefulWidget" class, then this part is
+the `State` class.
+-->
+如果 `NotifierProvider` 是 “StatefulWidget” 類，則此部分就是該 `State` 類。
+
+<!---
+This class is responsible for exposing ways to modify the state of the provider.  
+Public methods on this class are accessible to consumers using `ref.read(yourProvider.notifier).yourMethod()`.
+-->
+此類負責公開修改提供者程式狀態的方法。  
+使用者可以使用 `ref.read(yourProvider.notifier).yourMethod()` 此類上的公共方法。
+
+:::note
+<!---
+Notifiers should not have public properties besides the built-in `state`, as the UI
+would have no means to know that state has changed.
+-->
+除了內建的 `state` 之外，通知者程式不應具有公共屬性，因為 UI 無法知道狀態已更改。
+:::
+
+</>
+    },
+    {
+      offset: 111,
+      length: 12,
+      label: "通知者程式型別",
+      description: <>
+
+<!---
+The base class extended by your notifier should match that of the provider + modifiers.
+Some examples would be:
+-->
+通知者程式擴充套件的基類應與提供者程式 + 修飾符的基類匹配。一些例子是：
+
+- <span style={{ color: colors[0] }}>Notifier</span>Provider -> <span style={{ color: colors[0] }}>Notifier</span>
+- <span style={{ color: colors[0] }}>AsyncNotifier</span>Provider -> <span style={{ color: colors[0] }}>AsyncNotifier</span>
+- <span style={{ color: colors[0] }}>AsyncNotifier</span>Provider.
+  <span style={{ color: colors[1] }}>autoDispose</span> -> <span
+    style={{ color: colors[1] }}
+  >
+    AutoDispose
+  </span>
+  <span style={{ color: colors[0] }}>AsyncNotifier</span>
+- <span style={{ color: colors[0] }}>AsyncNotifier</span>Provider.
+  <span style={{ color: colors[1] }}>autoDispose</span>.<span
+    style={{ color: colors[2] }}
+  >
+    family
+  </span> -> <span style={{ color: colors[1] }}>AutoDispose</span>
+  <span style={{ color: colors[2] }}>Family</span>
+  <span style={{ color: colors[0] }}>AsyncNotifier</span>
+
+<!---
+To make this simpler, it is recommended to use the code generator, as it
+automatically infers the correct type.
+-->
+為了簡化此操作，建議使用程式碼生成器，因為它會自動推斷正確的型別。
+
+</>
+    },
+    {
+      offset: 136,
+      length: 54,
+      label: "build 方法",
+      description: <>
+
+<!---
+All notifiers must override the `build` method.  
+This method is equivalent to the place where you would normally put your
+logic in a non-notifier provider.
+-->
+所有通知者程式都必須重寫該 `build` 方法。  
+此方法等效於通常將邏輯放在非通知者程式提供者程式中的位置。
+
+<!---
+This method should not be called directly.
+-->
+不應直接呼叫此方法。
+
+</>
+    },
+]}
+/>
+</When>
+
+<!-- Some separation for good mesure -->
+
+<When codegen={true}>
+<Legend
+  code={`@riverpod
+class MyNotifier extends _$MyNotifier {
+  @override
+  Result build() {
+    <你的業務邏輯在這裡>
+  }
+ 
+  <你的方法在這裡>
+}`}
+  annotations={[
+    {
+      offset: 0,
+      length: 9,
+      label: "註解",
+      description: <>
+
+<!---
+All providers must be annotated with `@riverpod` or `@Riverpod()`.
+This annotation can be placed on global functions or classes.  
+Through this annotation, it is possible to configure the provider.
+-->
+所有提供者程式都必須使用 `@riverpod` 或 `@Riverpod()` 進行註解。
+此註解可以放置在全域性函式或類上。
+透過此註解，可以配置提供者程式。
+
+<!---
+For example, we can disable "auto-dispose" (which we will see later) by writing `@Riverpod(keepAlive: true)`.
+-->
+例如，我們可以透過編寫 `@Riverpod(keepAlive: true)` 來停用“自動處置”（我們將在後面看到）。
+
+</>
+    },
+    {
+      offset: 10,
+      length: 16,
+      label: "通知者程式",
+       description: <>
+
+<!---
+When a `@riverpod` annotation is placed on a class, that class is called
+a "Notifier".  
+The class must extend `_$NotifierName`, where `NotifierName` is the class name.
+-->
+當 `@riverpod` 註解被放置在一個類上時，該類被稱為“通知者程式”。  
+類必須擴充套件 `_$NotifierName` ，其中 `NotifierName` 是類名。
+
+<!---
+Notifiers are responsible for exposing ways to modify the state of the provider.  
+Public methods on this class are accessible to consumers using `ref.read(yourProvider.notifier).yourMethod()`.
+-->
+通知者程式負責公開修改提供者程式狀態的方法。  
+使用者可以使用 `ref.read(yourProvider.notifier).yourMethod()` 此類上的公共方法。
+
+:::note
+<!---
+Notifiers should not have public properties besides the built-in `state`, as the UI
+would have no means to know that state has changed.
+-->
+除了內建的 `state` 之外，通知者程式不應具有公共屬性，因為 UI 無法知道狀態已更改。
+:::
+
+</>
+    },
+    {
+      offset: 52,
+      length: 54,
+      label: "build 方法",
+      description: <>
+
+<!---
+All notifiers must override the `build` method.  
+This method is equivalent to the place where you would normally put your
+logic in a non-notifier provider.
+-->
+所有通知者程式都必須重寫該 `build` 方法。  
+此方法等效於通常將邏輯放在非通知者程式提供者程式中的位置。
+
+<!---
+This method should not be called directly.
+-->
+不應直接呼叫此方法。
+
+</>
+    },
+]}
+/>
+</When>
+
+<!---
+For reference, you might want to check <Link documentID="essentials/first_request" />
+to compare this new syntax with the previously seen syntax.
+-->
+作為參考，您可能需要檢視<Link documentID="essentials/first_request" />，將這裡的新語法與之前看到的語法進行比較。
+
+:::info
+<!---
+A Notifier with no method outside of `build` is identical to using the
+previously seen syntax.  
+The syntax shown in <Link documentID="essentials/first_request" /> can be considered
+as a shorthand for notifiers with no way to be modified from the UI.
+-->
+除了 `build` 以外，沒有其他方法的通知者程式與使用前面看到的語法相同。  
+<Link documentID="essentials/first_request" />中顯示的語法可以被視為通知者程式的簡寫，無法從 UI 進行修改。
+:::
+
+<!---
+Now that we've seen the syntax, let's see how to convert our previously
+defined provider to a notifier:
+-->
+現在我們已經瞭解了語法，讓我們看看如何將之前定義的提供者程式轉換為通知者程式：
+
+<AutoSnippet {...todoListNotifier} />
+
+<!---
+Note that the way of reading the provider inside widgets is unchanged.  
+You can still use `ref.watch(todoListProvider)` as with the previous syntax.
+-->
+請注意，在小部件中讀取提供者程式的方式保持不變。  
+您仍然可以像以前的語法一樣使用 `ref.watch(todoListProvider)`。
+
+:::caution
+<!---
+Do not put logic in the constructor of your notifier.  
+Notifiers should not have a constructor, as `ref` and other properties aren't
+yet available at that point. Instead, put your logic in the `build` method.
+-->
+不要將邏輯放在通知者程式的建構函式中。  
+通知者程式不應具有建構函式，因為 `ref` 此時其他屬性尚不可用。
+相反，將您的邏輯放在方法中 `build`。
+
+```dart
+class MyNotifier extends ... {
+  MyNotifier() {
+    // ❌ 別這樣做
+    // 這將會丟擲一個異常
+    state = AsyncValue.data(42);
+  }
+
+  @override
+  Result build() {
+    // ✅ 應該這樣做
+    state = AsyncValue.data(42);
+  }
+}
+```
+
+:::
+
+<!---
+## Exposing a method to perform a _POST_ request
+-->
+## 公開用於執行 _POST_ 請求的方法
+
+<!---
+Now that we have a Notifier, we can start adding methods to enable
+performing side-effects.
+One such side-effect would be to have the client _POST_ a new todo.
+We could do so by adding an `addTodo` method on our notifier:
+-->
+現在我們有了通知者程式，我們可以開始新增方法來執行副作用。
+其中一個副作用是讓客戶端 _POST_ 一個新的待辦事項。
+我們可以透過在通知者程式上新增一個 `addTodo` 方法來做到這一點：
+
+<AutoSnippet {...todoListNotifierAddTodo} />
+
+<!---
+Then, we can invoke this method in our UI using the same `Consumer`/`ConsumerWidget`
+we saw in <Link documentID="essentials/first_request" />:
+-->
+然後，我們可以在 UI 中使用我們在<Link documentID="essentials/first_request" />中看到的相同 `Consumer`/`ConsumerWidget` 呼叫此方法：
+
+<AutoSnippet raw={consumerAddTodoCall} />
+
+:::info
+<!---
+Notice how we are using `ref.read` instead of `ref.watch` to invoke our method.  
+Although `ref.watch` could technically work, it is recommended to use `ref.read`
+when logic is performed in event handlers such as "onPressed".
+-->
+請注意我們如何使用 `ref.read` 而不是呼叫 `ref.watch` 的方法。
+雖然在技術上可以工作，但 `ref.watch` 建議在事件處理（如“onPressed”）中執行邏輯時使用 `ref.read`。
+:::
+
+<!---
+We now have a button which makes a _POST_ request when pressed.  
+However, at the moment, our UI does not update to reflect the new todo list.
+We will want our local cache to match the server's state.
+-->
+我們現在有一個按鈕，按下時會發出 _POST_ 請求。  
+但是，目前，我們的 UI 不會更新以返回新的待辦事項列表。
+我們希望本地快取與伺服器的狀態相匹配。
+
+<!---
+There are a few ways to do so with their pros and cons.
+-->
+有幾種方法可以做到這一點，下面說說優點和缺點。
+
+<!---
+### Updating our local cache to match the API response
+-->
+### 更新本地快取以匹配 API 響應
+
+<!---
+A common backend practice is to have the _POST_ request return the new
+state of the resource.  
+In particular, our API would return the new list of todos after adding
+a new todo. One way of doing this is by writing `state = AsyncData(response)`:
+-->
+一種常見的後端做法是讓 _POST_ 請求返回資源的新狀態。  
+特別是，我們的 API 將在新增新的待辦事項後返回新的待辦事項列表。
+一種方法是編寫 `state = AsyncData(response)`：
+
+<AutoSnippet raw={restAddTodo} />
+
+:::tip 優點
+
+<!---
+- The UI will have the most up-to-date state possible.
+  If another user added a todo, we will see it too.
+- The server is the source of truth.
+  With this approach, the client doesn't need to know where the new todo
+  needs to be inserted in the list of todos.
+- Only a single network-request is needed.
+-->
+- UI 將盡可能具有最新狀態。如果其他使用者添加了待辦事項，我們也會看到它。
+- 伺服器是事實的來源。使用這種方法，客戶端不需要知道需要在列表的哪個位置插入新的待辦事項。
+- 只需要一個網路請求。
+
+:::
+
+:::danger 缺點
+
+<!---
+- This approach will only work if the server is implemented in a specific way.
+  If the server does not return the new state, this approach will not work.
+- May still not be doable if the associated _GET_ request is more complex,
+  such as if it has filters/sorting.
+-->
+- 僅當伺服器以特定方式實現時，此方法才有效。如果伺服器不返回新狀態，則此方法將不起作用。
+- 如果關聯的 _GET_ 請求更復雜，例如如果它具有過濾/排序的功能，則可能仍然不可行。
+
+:::
+
+<!---
+### Using `ref.invalidateSelf()` to refresh the provider.
+-->
+### 使用 `ref.invalidateSelf()` 重新整理提供者程式。
+
+<!---
+One option is to have our provider re-execute the _GET_ request.  
+This can be done by calling `ref.invalidateSelf()` after the _POST_ request:
+-->
+一種選擇是讓我們的提供者程式重新執行 _GET_ 請求。  
+這可以透過在 _POST_ 請求之後呼叫 `ref.invalidateSelf()` 來完成：
+
+<AutoSnippet raw={invalidateSelfAddTodo} />
+
+:::tip 優點
+
+<!---
+- The UI will have the most up-to-date state possible.
+  If another user added a todo, we will see it too.
+- The server is the source of truth.
+  With this approach, the client doesn't need to know where the new todo
+  needs to be inserted in the list of todos.
+- This approach should work regarless of the server implementation.
+  It can be especially useful if your _GET_ request is more complex,
+  such as if it has filters/sorting.
+-->
+- UI 將盡可能具有最新狀態。如果其他使用者添加了待辦事項，我們也會看到它。
+- 伺服器是事實的來源。使用這種方法，客戶端不需要知道需要在列表的哪個位置插入新的待辦事項。
+- 無論伺服器實現如何，此方法都應該有效。如果您的 _GET_ 請求更復雜，例如它具有過濾器/排序，則它可能特別有用。
+
+:::
+
+:::danger 缺點
+
+<!---
+- This approach will perform an extra _GET_ request, which may be
+  inefficient.
+-->
+- 此方法將執行額外的 _GET_ 請求，這可能效率低下。
+
+:::
+
+<!---
+### Updating the local cache manually
+-->
+### 手動更新本地快取
+
+<!---
+Another option is to update the local cache manually.  
+This would involve trying to mimick the backend's behavior.
+For instance, we would need to know whether the backend inserts new items
+at the start or at the end.
+-->
+另一種選擇是手動更新本地快取。  
+這將涉及嘗試模仿後端的行為。例如，我們需要知道後端是在開頭還是結尾插入新專案。
+
+<AutoSnippet raw={manualAddTodo} />
+
+:::info
+<!---
+This example uses immutable state. This is not required, but recommended.
+See <Link documentID="concepts/why_immutability" /> for more details.  
+If you want to use mutable state instead, you can alternatively do:
+-->
+此示例使用不可變狀態。這不是必需的，但建議這樣做。
+有關更多詳細資訊，請參閱<Link documentID="concepts/why_immutability" />。  
+如果要改用可變狀態，也可以執行以下操作：
+
+<AutoSnippet raw={mutableManualAddTodo} />
+
+:::
+
+:::tip 優點
+
+<!---
+- This approach should work regarless of the server implementation.
+- Only a single network-request is needed.
+-->
+- 無論伺服器實現如何，此方法都應該有效。
+- 只需要一個網路請求。
+
+:::
+
+:::danger 缺點
+
+<!---
+- The local cache may not match the server's state.
+  If another user added a todo, we will not see it.
+- This approach may be more complex to implement and effectively
+  duplicate the backend's logic.
+-->
+- 本地快取可能與伺服器的狀態不匹配。如果其他使用者添加了待辦事項，我們將看不到它。
+- 這種方法的實現和有效地複製後端的邏輯可能更復雜。
+
+:::
+
+<!---
+## Going further: Showing a spinner & error handling
+-->
+## 更進一步：顯示下拉載入器和錯誤處理
+
+<!---
+With all we've seen so far, we have a button which makes a _POST_ request
+when pressed; and when the request is done, the UI updates to reflect
+changes.  
+But at the moment, there is no indication that the request is being
+performed, nor any information if failed.
+-->
+到目前為止我們所看到的一切，我們有一個按鈕，當按下時會發出 _POST_ 請求;
+請求完成後，UI 會更新以反映更改。  
+但目前，沒有跡象表明請求正在執行，如果失敗，也沒有任何資訊。
+
+<!---
+One way to do so is to store the Future returned by `addTodo`
+in the local widget state, and then listen to that future to show
+a snipper or error message.  
+This is one scenario where [flutter_hooks](https://pub.dev/packages/flutter_hooks)
+comes in handy. But of course, you can also use a `StatefulWidget` instead.
+-->
+一種方法是將返回 `addTodo` 的非同步結果儲存在本地小部件狀態中，
+然後監聽該非同步狀態以顯示下拉載入器或錯誤訊息。  
+這時[flutter_hooks](https://pub.dev/packages/flutter_hooks)派上用場的一種情況。
+但是，當然，您也可以使用 `StatefulWidget` 代替。
+
+<!---
+The following snippet shows a progress indicator while
+and operation is pending. And if it failed, renders the button as red:
+-->
+以下程式碼片段顯示了當處於載入狀態時，進度指示器和操作處於掛起狀態。
+如果失敗，則將按鈕呈現為紅色：
+
+![A button which turns red when the operation failed](/img/essentials/side_effects/spinner.gif)
+
+<AutoSnippet {...renderAddTodo} />

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/codegen/todo_list_notifier.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/codegen/todo_list_notifier.dart
@@ -1,0 +1,28 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'todo_list_notifier.freezed.dart';
+part 'todo_list_notifier.g.dart';
+
+@freezed
+class Todo with _$Todo {
+  factory Todo({
+    required String description,
+    @Default(false) bool completed,
+  }) = _Todo;
+
+  factory Todo.fromJson(Map<String, dynamic> json) => _$TodoFromJson(json);
+}
+
+/* SNIPPET START */
+@riverpod
+class TodoList extends _$TodoList {
+  @override
+  Future<List<Todo>> build() async {
+    // 我們之前在 FutureProvider 中的業務邏輯現在位於 build 方法中。
+    return [
+      Todo(description: 'Learn Flutter', completed: true),
+      Todo(description: 'Learn Riverpod'),
+    ];
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/codegen/todo_list_notifier_add_todo.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/codegen/todo_list_notifier_add_todo.dart
@@ -1,0 +1,26 @@
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'todo_list_notifier.dart';
+
+part 'todo_list_notifier_add_todo.g.dart';
+
+/* SNIPPET START */
+@riverpod
+class TodoList extends _$TodoList {
+  @override
+  Future<List<Todo>> build() async => [/* ... */];
+
+  Future<void> addTodo(Todo todo) async {
+    await http.post(
+      Uri.https('your_api.com', '/todos'),
+      // 我們序列化 Todo 物件並將其 POST 到伺服器。
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(todo.toJson()),
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/codegen/todo_list_provider.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/codegen/todo_list_provider.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'todo_list_provider.freezed.dart';
+part 'todo_list_provider.g.dart';
+
+/* SNIPPET START */
+@freezed
+class Todo with _$Todo {
+  factory Todo({
+    required String description,
+    @Default(false) bool completed,
+  }) = _Todo;
+}
+
+@riverpod
+Future<List<Todo>> todoList(Ref ref) async {
+  // 模擬一個網路請求。這通常來自真實的 API
+  return [
+    Todo(description: 'Learn Flutter', completed: true),
+    Todo(description: 'Learn Riverpod'),
+  ];
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/raw/render_add_todo.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/raw/render_add_todo.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'rest_add_todo.dart';
+import 'todo_list_notifier.dart' show Todo;
+
+void main() {
+  runApp(
+    const ProviderScope(child: MyApp()),
+  );
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(home: Example());
+  }
+}
+
+/* SNIPPET START */
+class Example extends ConsumerStatefulWidget {
+  const Example({super.key});
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _ExampleState();
+}
+
+class _ExampleState extends ConsumerState<Example> {
+  // 待處理的 addTodo 操作。如果沒有待處理的，則為 null。
+  Future<void>? _pendingAddTodo;
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder(
+      // 我們監聽待處理的操作，以相應地更新 UI。
+      future: _pendingAddTodo,
+      builder: (context, snapshot) {
+        // 計算是否存在錯誤狀態。
+        // 檢查 connectionState 用於在重試操作時進行處理。
+        final isErrored = snapshot.hasError &&
+            snapshot.connectionState != ConnectionState.waiting;
+
+        return Row(
+          children: [
+            ElevatedButton(
+              style: ButtonStyle(
+                // 如果出現錯誤，我們會將該按鈕顯示為紅色
+                backgroundColor: WidgetStatePropertyAll(
+                  isErrored ? Colors.red : null,
+                ),
+              ),
+              onPressed: () {
+                // 我們將 addTodo 返回的 future 儲存在變數中
+                final future = ref
+                    .read(todoListProvider.notifier)
+                    .addTodo(Todo(description: 'This is a new todo'));
+
+                // 我們將這個 future 儲存在本地的狀態中
+                setState(() {
+                  _pendingAddTodo = future;
+                });
+              },
+              child: const Text('Add todo'),
+            ),
+            // 操作正在等待，讓我們顯示一個進度指示器
+            if (snapshot.connectionState == ConnectionState.waiting) ...[
+              const SizedBox(width: 8),
+              const CircularProgressIndicator(),
+            ]
+          ],
+        );
+      },
+    );
+  }
+} /* SNIPPET END */

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/raw/render_add_todo_hooks.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/raw/render_add_todo_hooks.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'rest_add_todo.dart';
+import 'todo_list_notifier.dart' show Todo;
+
+void main() {
+  runApp(
+    const ProviderScope(child: MyApp()),
+  );
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(home: Example());
+  }
+}
+
+/* SNIPPET START */
+class Example extends HookConsumerWidget {
+  const Example({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 待處理的 addTodo 操作。如果沒有待處理的，則為 null。
+    final pendingAddTodo = useState<Future<void>?>(null);
+    // 我們監聽待處理的操作，以相應地更新 UI。
+    final snapshot = useFuture(pendingAddTodo.value);
+
+    // 計算是否存在錯誤狀態。
+    // 檢查 connectionState 用於在重試操作時進行處理。
+    final isErrored = snapshot.hasError &&
+        snapshot.connectionState != ConnectionState.waiting;
+
+    return Row(
+      children: [
+        ElevatedButton(
+          style: ButtonStyle(
+            // 如果出現錯誤，我們會將該按鈕顯示為紅色
+            backgroundColor: WidgetStatePropertyAll(
+              isErrored ? Colors.red : null,
+            ),
+          ),
+          onPressed: () async {
+            // 我們將 addTodo 返回的 future 儲存在變數中
+            final future = ref
+                .read(todoListProvider.notifier)
+                .addTodo(Todo(description: 'This is a new todo'));
+
+            // 我們將這個 future 儲存在本地的狀態中
+            pendingAddTodo.value = future;
+          },
+          child: const Text('Add todo'),
+        ),
+        // 操作正在等待，讓我們顯示一個進度指示器
+        if (snapshot.connectionState == ConnectionState.waiting) ...[
+          const SizedBox(width: 8),
+          const CircularProgressIndicator(),
+        ]
+      ],
+    );
+  }
+}
+/* SNIPPET END */

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/raw/todo_list_notifier.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/raw/todo_list_notifier.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class Todo {
+  Todo({
+    required this.description,
+    this.completed = false,
+  });
+
+  factory Todo.fromJson(Map<String, Object?> json) {
+    return Todo(
+      description: json['description']! as String,
+      completed: json['completed']! as bool,
+    );
+  }
+
+  final String description;
+  final bool completed;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'description': description,
+        'completed': completed,
+      };
+}
+
+/* SNIPPET START */
+// 我們現在使用 AsyncNotifierProvider 替代 FutureProvider
+final todoListProvider =
+    AsyncNotifierProvider.autoDispose<TodoList, List<Todo>>(
+  TodoList.new,
+);
+
+// 因為我們的邏輯是非同步的，所以我們需要使用 AsyncNotifier。
+// 特別的，由於使用“autoDispose”修飾符，
+// 我們需要 AutoDisposeAsyncNotifier。
+class TodoList extends AutoDisposeAsyncNotifier<List<Todo>> {
+  @override
+  Future<List<Todo>> build() async {
+    // 我們之前在 FutureProvider 中的業務邏輯現在位於 build 方法中。
+    return [
+      Todo(description: 'Learn Flutter', completed: true),
+      Todo(description: 'Learn Riverpod'),
+    ];
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/raw/todo_list_notifier_add_todo.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/raw/todo_list_notifier_add_todo.dart
@@ -1,0 +1,28 @@
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import 'todo_list_notifier.dart';
+
+final todoListProvider =
+    AsyncNotifierProvider.autoDispose<TodoList, List<Todo>>(
+  TodoList.new,
+);
+
+/* SNIPPET START */
+class TodoList extends AutoDisposeAsyncNotifier<List<Todo>> {
+  @override
+  Future<List<Todo>> build() async => [/* ... */];
+
+  Future<void> addTodo(Todo todo) async {
+    await http.post(
+      Uri.https('your_api.com', '/todos'),
+      // 我們序列化 Todo 物件並將其 POST 到伺服器。
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(todo.toJson()),
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/raw/todo_list_provider.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/raw/todo_list_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+class Todo {
+  Todo({
+    required this.description,
+    this.completed = false,
+  });
+
+  factory Todo.fromJson(Map<String, dynamic> json) {
+    return Todo(
+      description: json['description'] as String,
+      completed: json['completed'] as bool,
+    );
+  }
+
+  final String description;
+  final bool completed;
+}
+
+final todoListProvider = FutureProvider.autoDispose<List<Todo>>((ref) async {
+  // 模擬一個網路請求。這通常來自真實的 API
+  return [
+    Todo(description: 'Learn Flutter', completed: true),
+    Todo(description: 'Learn Riverpod'),
+  ];
+});

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/render_add_todo.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/render_add_todo.ts
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw/render_add_todo.dart";
+import hooks from "!!raw-loader!./raw/render_add_todo_hooks.dart";
+
+export default {
+  raw: raw,
+  hooks: hooks,
+  codegen: raw,
+  hooksCodegen: hooks,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/todo_list_notifier.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/todo_list_notifier.ts
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw/todo_list_notifier.dart";
+import codegen from "!!raw-loader!./codegen/todo_list_notifier.dart";
+
+export default {
+  raw: raw,
+  hooks: raw,
+  codegen: codegen,
+  hooksCodegen: codegen,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/todo_list_notifier_add_todo.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/todo_list_notifier_add_todo.ts
@@ -1,0 +1,9 @@
+import raw from "!!raw-loader!./raw/todo_list_notifier_add_todo.dart";
+import codegen from "!!raw-loader!./codegen/todo_list_notifier_add_todo.dart";
+
+export default {
+  raw: raw,
+  hooks: raw,
+  codegen: codegen,
+  hooksCodegen: codegen,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/todo_list_provider.ts
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/side_effects/todo_list_provider.ts
@@ -1,0 +1,7 @@
+import raw from "!!raw-loader!./raw/todo_list_provider.dart";
+import codegen from "!!raw-loader!./codegen/todo_list_provider.dart";
+
+export default {
+  raw: raw,
+  codegen: codegen,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/testing.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/testing.mdx
@@ -1,0 +1,303 @@
+---
+title: 測試你的提供者程式
+---
+
+import { AutoSnippet, When } from "@site/src/components/CodeSnippet";
+import createContainer from "!!raw-loader!/docs/essentials/testing/create_container.dart";
+import unitTest from "!!raw-loader!/docs/essentials/testing/unit_test.dart";
+import widgetTest from "!!raw-loader!/docs/essentials/testing/widget_test.dart";
+import fullWidgetTest from "!!raw-loader!/docs/essentials/testing/full_widget_test.dart";
+import widgetContainerOf from "!!raw-loader!/docs/essentials/testing/widget_container_of.dart";
+import providerToMock from "/docs/essentials/testing/provider_to_mock";
+import mockProvider from "!!raw-loader!/docs/essentials/testing/mock_provider.dart";
+import autoDisposeListen from "!!raw-loader!/docs/essentials/testing/auto_dispose_listen.dart";
+import listenProvider from "!!raw-loader!/docs/essentials/testing/listen_provider.dart";
+import awaitFuture from "!!raw-loader!/docs/essentials/testing/await_future.dart";
+import notifierMock from "/docs/essentials/testing/notifier_mock";
+
+<!---
+A core part of the Riverpod API is the ability to test your providers in isolation.
+-->
+Riverpod API 的核心部分是能夠單獨測試提供者程式。
+
+<!---
+For a proper test suite, there are a few challenges to overcome:
+-->
+對於一個合適的測試套件，有幾個挑戰需要克服：
+
+<!---
+- Tests should not share state. This means that new tests should
+  not be affected by the previous tests.
+- Tests should give us the ability to mock certain functionalities
+  to achieve the desired state.
+- The test environment should be as close as possible to the real
+  environment.
+-->
+- 測試不應共享狀態。這意味著新測試不應受到先前測試的影響。
+- 測試應該使我們能夠模擬某些功能以達到所需的狀態。
+- 測試環境應儘可能接近真實環境。
+
+<!---
+Fortunately, Riverpod makes it easy to achieve all of these goals.
+-->
+幸運的是，Riverpod 可以輕鬆實現所有這些目標。
+
+<!---
+## Setting up a test
+-->
+## 設定測試
+
+<!---
+When defining a test with Riverpod, there are two main scenarios:
+-->
+使用 Riverpod 定義測試時，主要有兩種情況：
+
+<!---
+- Unit tests, usually with no Flutter dependency.
+  This can be useful for testing the behavior of a provider in isolation.
+- Widget tests, usually with a Flutter dependency.
+  This can be useful for testing the behavior of a widget that uses a provider.
+-->
+- 單元測試，通常沒有 Flutter 依賴。
+  這對於單獨測試提供者程式的行為非常有用。
+- Widget 測試，通常帶有 Flutter 依賴項。
+  這對於測試使用提供者程式的小部件的行為非常有用。
+
+<!---
+### Unit tests
+-->
+### 單元測試
+
+<!---
+Unit tests are defined using the `test` function from [package:test](https://pub.dev/packages/test).
+-->
+單元測試是使用 [package:test](https://pub.dev/packages/test) 中的 `test` 函式定義的。
+
+<!---
+The main difference with any other test is that we will want to create
+a `ProviderContainer` object. This object will enable our test to interact
+with providers.
+-->
+與任何其他測試的主要區別在於，我們想要建立一個 `ProviderContainer` 物件。
+此物件將使我們的測試能夠與提供者程式進行互動。
+
+<!---
+It encouraged to make a testing utility for both creating and disposing
+of a `ProviderContainer` object:
+-->
+建議建立一個測試實用程式來建立和處置物件 `ProviderContainer`：
+
+<AutoSnippet raw={createContainer} />
+
+<!---
+Then, we can define a `test` using this utility:
+-->
+然後，我們可以使用此實用程式定義一個 `test`：
+
+<AutoSnippet raw={unitTest} />
+
+<!---
+Now that we have a ProviderContainer, we can use it to read providers using:
+-->
+現在我們有了 ProviderContainer，我們可以使用它來讀取提供者程式，使用：
+
+<!---
+- `container.read`, to read the current value of a provider.
+- `container.listen`, to listen to a provider and be notified of changes.
+-->
+- `container.read`，以讀取提供者程式的當前值。
+- `container.listen`，以監聽提供者程式並接收更改的通知。
+
+:::caution
+<!---
+Be careful when using `container.read` when providers are automatically disposed.  
+If your provider is not listened to, chances are that its state will get destroyed
+in the middle of your test.
+-->
+在自動處置提供者程式時使用 `container.read` 時要小心。  
+如果您的提供者程式沒有被監聽，其狀態可能會在測試過程中被破壞。
+
+<!---
+In that case, consider using `container.listen`.  
+Its return value enables reading the current value of provider anyway,
+but will also ensure that the provider is not disposed in the middle of your test:
+-->
+在這種情況下，請考慮使用 `container.listen`。  
+無論如何，它的返回值都能讀取提供者程式的當前值，
+同時還能確保提供者程式不會在測試過程中被棄置：
+
+<AutoSnippet raw={autoDisposeListen} />
+:::
+
+<!---
+### Widget tests
+-->
+### 小部件測試
+
+<!---
+Widget tests are defined using the `testWidgets` function from [package:flutter_test](https://pub.dev/packages/flutter_test).
+-->
+小部件測試是使用 [package:flutter_test](https://pub.dev/packages/flutter_test) 中的 `testWidgets` 函式定義的。
+
+<!---
+In this case, the main difference with usual Widget tests is that we must add
+a `ProviderScope` widget at the root of `tester.pumpWidget`:
+-->
+在這種情況下，與通常的 Widget 測試的主要區別在於，
+我們必須新增一個 `ProviderScope` 在 `tester.pumpWidget` 的根元件上：
+
+<AutoSnippet raw={widgetTest} />
+
+<!---
+This is similar to what we do when we enable Riverpod in our Flutter app.
+-->
+這類似於我們在 Flutter 應用程式中啟用 Riverpod 時所做的。
+
+<!---
+Then, we can use `tester` to interact with our widget.
+Alternatively if you want to interact with providers, you can obtain
+a `ProviderContainer`.
+One can be obtained using `ProviderScope.containerOf(buildContext)`.  
+By using `tester`, we can therefore write the following:
+-->
+然後，我們可以用 `tester` 來與我們的小部件進行互動。
+或者，如果要與提供者程式互動，可以獲取 `ProviderContainer`。
+也可以使用 `ProviderScope.containerOf(buildContext)` 獲得一個。  
+因此，透過使用 `tester` ，我們可以編寫以下內容：
+
+<AutoSnippet raw={widgetContainerOf} />
+
+<!---
+We can then use it to read providers. Here's a full example:
+-->
+然後，我們可以使用它來讀取提供者程式。下面是一個完整的示例：
+
+<AutoSnippet raw={fullWidgetTest} />
+
+<!---
+## Mocking providers
+-->
+## 模擬提供者程式
+
+<!---
+So far, we've seen how to set up a test and basic interactions with providers.
+However, in some cases, we may want to mock a provider.
+-->
+到目前為止，我們已經瞭解瞭如何設定測試以及與提供者程式的基本互動。
+但是，在某些情況下，我們可能想要模擬一個提供者程式。
+
+<!---
+The cool part: All providers can be mocked by default, without any additional setup.  
+This is possible by specifying the `overrides` parameter on either
+`ProviderScope` or `ProviderContainer`.
+-->
+很酷的部分：預設情況下可以模擬所有提供者程式，無需任何額外設定。  
+這可以透過在 `ProviderScope` 或 `ProviderContainer` 上指定 `overrides` 引數來實現。
+
+<!---
+Consider the following provider:
+-->
+請考慮以下提供者程式：
+
+<AutoSnippet {...providerToMock} />
+
+<!---
+We can mock it using:
+-->
+我們可以模擬它透過以下方式：
+
+<AutoSnippet raw={mockProvider} />
+
+<!---
+## Spying on changes in a provider
+-->
+## 監視提供者程式中的更改
+
+<!---
+Since we obtained a `ProviderContainer` in our tests, it is possible to
+use it to "listen" to a provider:
+-->
+由於我們在測試中獲得了一個 `ProviderContainer`，因此可以使用它來“監聽”提供者程式：
+
+<AutoSnippet raw={listenProvider} />
+
+<!---
+You can then combine this with packages such as [mockito](https://pub.dev/packages/mockito)
+or [mocktail](https://pub.dev/packages/mocktail) to use their `verify` API.  
+Or more simply, you can add all changes in a list and assert on it.
+-->
+然後，您可以將其與 [mockito](https://pub.dev/packages/mockito)
+或 [mocktail](https://pub.dev/packages/mocktail) 等包結合使用，以使用它們的 `verify` API。  
+或者更簡單地說，您可以在列表中新增所有更改並對其進行斷言。
+
+<!---
+## Awaiting asynchronous providers
+-->
+## 等待非同步提供者程式
+
+<!---
+In Riverpod, it is very common for providers to return a Future/Stream.  
+In that case, chances are that our tests need to await for that asynchronous operation
+to be completed.
+-->
+在 Riverpod 中，提供者程式返回 Future/Stream 是很常見的。  
+在這種情況下，我們的測試可能需要等待非同步操作完成。
+
+<!---
+One way to do so is to read the `.future` of a provider:
+-->
+一種方法是讀取提供者程式的 `.future`： 
+
+<AutoSnippet raw={awaitFuture} />
+
+<!---
+## Mocking Notifiers
+-->
+## 模擬通知者程式
+
+<!---
+It is generally discouraged to mock Notifiers.  
+Instead, you should likely introduce a level of abstraction in the logic of your
+Notifier, such that you can mock that abstraction.
+For instance, rather than mocking a Notifier, you could mock a "repository"
+that the Notifier uses to fetch data from.
+-->
+通常不鼓勵嘲笑通知者程式。  
+相反，您可能應該在通告程式的邏輯中引入一個抽象級別，以便您可以模擬該抽象。
+例如，與其模擬通告程式，不如模擬通告程式用來從中獲取資料的“儲存庫”。
+
+<!---
+If you insist on mocking a Notifier, there is a special consideration
+to create such a mock: Your mock must subclass the original Notifier
+base class: You cannot "implement" Notifier, as this would break the interface.
+-->
+如果您堅持要模擬通告程式，那麼建立這樣的通告程式需要特別注意：
+您的模擬必須對原始通告程式基類進行子類化：
+您不能“實現”通告程式，因為這會破壞介面。
+
+<!---
+As such, when mocking a Notifier, instead of writing the following mockito code:
+-->
+因此，在模擬通告程式時，不要編寫以下模擬程式碼：
+
+```dart
+class MyNotifierMock with Mock implements MyNotifier {}
+```
+
+<!---
+You should instead write:
+-->
+你應該改寫：
+
+<AutoSnippet {...notifierMock} />
+
+<When codegen={true}>
+
+<!---
+For this to work, your mock will have to be placed in the same file as the
+Notifier you are mocking. Otherwise you would not have access to the `_$MyNotifier` class.
+-->
+為此，您的模擬必須與您模擬的通知者程式放在同一個檔案中。
+否則，您將無法訪問該 `_$MyNotifier` 類。
+
+</When>

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/websockets_sync.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/essentials/websockets_sync.mdx
@@ -1,0 +1,197 @@
+---
+title: Websocket 和同步執行
+---
+
+import {
+  trimSnippet,
+  AutoSnippet,
+  When,
+} from "@site/src/components/CodeSnippet";
+import syncDefinition from "/docs/essentials/websockets_sync/sync_definition";
+import streamProvider from "/docs/essentials/websockets_sync/stream_provider";
+import syncConsumer from "!!raw-loader!/docs/essentials/websockets_sync/sync_consumer.dart";
+import rawUsage from "!!raw-loader!/docs/essentials/websockets_sync/raw_usage.dart";
+import pipeChangeNotifier from "!!raw-loader!/docs/essentials/websockets_sync/pipe_change_notifier.dart";
+import sharedPipeChangeNotifier from "!!raw-loader!/docs/essentials/websockets_sync/shared_pipe_change_notifier.dart";
+import changeNotifierProvider from "!!raw-loader!/docs/essentials/websockets_sync/change_notifier_provider.dart";
+
+<!---
+So far, we've only covered on how to create a `Future`.  
+This is on purpose, as `Future`s are the core of how Riverpod applications
+should be built. _But_, Riverpod also supports other formats if necessary.
+-->
+到目前為止，我們只介紹瞭如何建立一個 `Future`。  
+這是有意為之的，因為 `Future` 是 Riverpod 應用程式構建方式的核心。
+_但是_，如有必要，Riverpod 還支援其他格式。
+
+<!---
+In particular, instead of a `Future`, providers are free to:
+-->
+特別是，除了 `Future` 型別的提供者程式，還存在靈活的型別：
+
+<!---
+- Synchronously return an object, such as to create a "Repository".
+- Return a `Stream`, such as to listen to websockets.
+-->
+- 同步返回一個物件，例如建立“儲存庫”。
+- 返回一個 `Stream`，例如監聽 websockets。
+
+<!---
+Returning a `Future` and returning a `Stream` or an object
+is quite similar overall. Think of this page as
+an explanation of subtle differences and various tips for those use-cases.
+-->
+返回 `Future` 和返回 `Stream` 或 object 總體上非常相似。
+本頁將解釋這些用例的細微差別和各種提示。
+
+<!---
+## Synchronously returning an object
+-->
+## 同步返回物件
+
+<!---
+To synchronously create an object, make sure that your
+provider does not return a Future:
+-->
+若要同步建立物件，請確保提供者程式不返回 Future：
+
+<AutoSnippet {...syncDefinition} />
+
+<!---
+When a provider synchronously creates an object,
+this impacts how the object is consumed.
+In particular, synchronous values are not wrapped
+in an "AsyncValue":
+-->
+當提供者程式同步建立物件時，這會影響物件的使用方式。
+具體而言，同步值不會被包裝在“AsyncValue”中：
+
+<AutoSnippet raw={syncConsumer} />
+
+<!---
+The consequence of this difference is that if your provider
+throws, trying to read the value will rethrow the error.
+Alternatively, when using `ref.listen`, the "onError" callback
+will be invoked.
+-->
+這種差異的後果是，如果提供者程式丟擲異常，嘗試讀取該值會重新丟擲錯誤。
+或者，當使用 `ref.listen` 時，將呼叫 “onError” 回撥。
+
+<!---
+### Listenable objects considerations
+-->
+### 可監聽物件的注意事項
+
+<When codegen={true}>
+
+<!---
+Listenable objects such as `ChangeNotifier` or `StateNotifier` are not supported.  
+If, for compatibility reasons, you need to interact with one of such objects,
+one workaround is to pipe their notification mechanism to Riverpod.
+-->
+可監聽物件，例如 `ChangeNotifier` 或 `StateNotifier` 是不受支援的。  
+如果出於相容性原因，您需要與其中一個物件進行互動，
+一種解決方法是將其通知機制透過管道傳遞給 Riverpod。
+
+<AutoSnippet raw={pipeChangeNotifier} />
+
+:::info
+<!---
+In case you need such logic many times, it is worth noting that
+the logic shared! The "ref" object is designed to be composable.
+This enables extracting the dispose/listening logic out of the provider:
+-->
+如果你多次需要這樣的邏輯，值得注意的是，
+邏輯是共享的！"ref" 物件被設計為可組合的。
+這樣就可以從提供者程式中提取處置/監聽邏輯：
+
+<AutoSnippet raw={sharedPipeChangeNotifier} />
+:::
+
+</When>
+
+<When codegen={false}>
+
+<!---
+When not using code-generation, Riverpod offers "legacy" providers
+to support `ChangeNotifier` and `StateNotifier` out of the box:
+`ChangeNotifierProvider` and `StateNotifierProvider`. Using them is
+similar to using other kinds of providers. The main difference is
+that they will both listen and dispose of the returned object automatically.
+-->
+當不使用程式碼生成時，Riverpod 提供了“傳統”的提供者程式來支援
+`ChangeNotifier` 和 `StateNotifier` 開箱即用：
+`ChangeNotifierProvider` 和 `StateNotifierProvider`。
+使用它們就像使用其他型別的提供者程式一樣。
+主要區別在於它們將自動監聽和處置返回的物件。
+
+<!---
+These providers are not recommended for new business logic.
+But they can be helpful when interacting with legacy code,
+such as when migrating from `pkg:provider` to Riverpod.
+-->
+不建議將這些提供者程式用於新的業務邏輯。
+但是，在與舊程式碼混合編寫時（例如從 `pkg:provider` 遷移到 Riverpod 時），
+它們可能會有所幫助。
+
+<AutoSnippet raw={changeNotifierProvider} />
+
+</When>
+
+<!---
+## Listening to a Stream
+-->
+## 監聽一個流
+
+<!---
+A common use-case of modern applications is to interact with websockets,
+such as with Firebase or GraphQL subscriptions.  
+Interacting with those APIs is often done by listening to a `Stream`.
+-->
+現代應用程式的一個常見用例是與 Websocket 互動，
+例如與 Firebase 或 GraphQL 訂閱進行互動。  
+與這些 API 的互動通常是透過監聽一個 `Stream`。
+
+<!---
+To help with that, Riverpod naturally supports `Stream` objects.
+Like with `Future`s, the object will be converted to an `AsyncValue`:
+-->
+為了幫助實現這一點，Riverpod 自然地支援 `Stream` 物件。
+與 `Future` 一樣，該物件將轉換為 `AsyncValue`：
+
+<AutoSnippet {...streamProvider} />
+
+:::info
+<!---
+Riverpod is not aware of custom `Stream` implementations, such as
+RX's `BehaviorSubject`.
+As such, returning a `BehaviorSubject` will not expose the `value`
+synchronously to widgets, even if already available on creation.
+-->
+Riverpod 不知道自定義 `Stream` 實現，例如 RX 的 `BehaviorSubject`。
+因此，返回 `BehaviorSubject` 不會同步向小部件公開，`value` 即使在建立時已經可用。
+:::
+
+<!---
+## Disabling conversion of `Stream`s/`Future`s to `AsyncValue`
+-->
+## 停用從 `Stream` / `Future` 轉換到 `AsyncValue`
+
+<!---
+By default, Riverpod will convert `Stream`s and `Future`s to `AsyncValue`.
+Although rarely needed, it is possible to disable this behavior by wrapping
+the return type in a `Raw` typedef.
+-->
+預設情況下，Riverpod 會將 `Stream` 和 `Future` 轉換為 `AsyncValue`。
+儘管很少需要，但可以透過將返回型別包裝在 `Raw` 泛型中來停用此行為。
+
+:::caution
+<!---
+It is generally discouraged to disable the `AsyncValue` conversion.
+Do so only if you know what you are doing.
+-->
+通常不建議停用轉換 `AsyncValue`。
+只有當您知道自己在做什麼時才這樣做。
+:::
+
+<AutoSnippet raw={rawUsage} />

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/from_provider/helpers/item.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/from_provider/helpers/item.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'json.dart';
+
+part 'item.freezed.dart';
+part 'item.g.dart';
+
+@freezed
+sealed class Item with _$Item {
+  const factory Item({required int id}) = _Item;
+  factory Item.fromJson(Json json) => _$ItemFromJson(json);
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/from_provider/helpers/json.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/from_provider/helpers/json.dart
@@ -1,0 +1,1 @@
+typedef Json = Map<String, dynamic>;

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/from_provider/motivation/motivation.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/from_provider/motivation/motivation.mdx
@@ -1,0 +1,434 @@
+---
+title: 動機
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+import sameType from "/docs/from_provider/motivation/same_type";
+import combine from "/docs/from_provider/motivation/combine";
+import asyncValues from "/docs/from_provider/motivation/async_values";
+import autoDispose from "/docs/from_provider/motivation/auto_dispose";
+import override from "/docs/from_provider/motivation/override";
+import sideEffects from "/docs/from_provider/motivation/side_effects";
+import {
+  trimSnippet,
+  AutoSnippet,
+  When,
+} from "@site/src/components/CodeSnippet";
+
+<!---
+This in-depth article is meant to show why Riverpod is even a thing.
+-->
+這篇深入的文章旨在說明為什麼需要 Riverpod 的動機。
+
+<!---
+In particular, this section should answer the following:
+  - Since Provider is widely popular, why would one migrate to Riverpod?
+  - What concrete advantages do I get?
+  - How can I migrate towards Riverpod?
+  - Can I migrate incrementally?
+  - etc.
+-->
+特別是，本節應回答以下問題：
+  - 既然 Provider 廣受歡迎，為什麼要遷移到 Riverpod？
+  - 我能獲得哪些具體優勢？
+  - 如何遷移到 Riverpod？
+  - 我可以增量遷移嗎？
+  - 等等……
+
+<!---
+By the end of this section you should be convinced that Riverpod is to be prefered over Provider. 
+-->
+在本節結束時，您應該確信 Riverpod 優先於 Provider。
+
+<!---
+**Riverpod is indeed a more modern, recommended and reliable approach when compared to Provider**.
+-->
+**與 Provider 相比，Riverpod 確實是一種更現代、更推薦和更可靠的方法。**
+
+<!---
+Riverpod offers better State Management capabilities, better Caching strategies and a simplified Reactivty model.  
+Whereas, Provider is currently lacking in many areas with no way forward.
+-->
+Riverpod 提供更好的狀態管理功能、更好的快取策略和簡化的響應式模型。  
+然而，Provider 目前在許多領域都缺乏，沒有前進的道路。
+
+<!---
+## Provider's Limitations
+-->
+## Provider 的侷限性
+
+<!---
+Provider has fundamental issues due to being restricted by the InheritedWidget API.  
+Inherently, Provider is a "simpler `InheritedWidget`"; 
+Provider is merely an InheritedWidget wrapper, and thus it's limited by it.
+-->
+Provider 存在根本問題是由於受到 InheritedWidget API 的限制。  
+從本質上講，Provider 是一個“更簡單的 `InheritedWidget`”;
+Provider 只是一個 InheritedWidget 包裝器，因此它受到它的限制。
+
+<!---
+Here's a list of known Provider issues.
+-->
+下面是已知的提供者程式問題列表。
+
+<!---
+### Provider can't keep two (or more) providers of the same "type"
+-->
+### 提供者程式不能保留兩個（或多個）相同“型別”的提供者程式
+
+<!---
+Declaring two `Provider<Item>` will result into unreliable behavior: `InheritedWidget`'s API will 
+obtain only *one of the two*: the closest `Provider<Item>` ancestor.  
+While a [workaround] is explained in Provider's 
+documentation, Riverpod simply doesn't have this problem.
+-->
+宣告兩個 `Provider<Item>` 將導致不可靠的行為：
+`InheritedWidget` 的 API 只能獲取*兩者中的一個*：即最接近 `Provider<Item>` 的祖先。  
+雖然 Provider 的文件中解釋了[解決方法]，但 Riverpod 根本沒有這個問題。
+
+<!---
+By removing this limitation, we can freely split logic into tiny pieces, like so:
+-->
+透過消除這個限制，我們可以自由地將邏輯拆分為小塊，如下所示：
+
+<AutoSnippet language="dart" {...sameType}></AutoSnippet>
+
+
+<!---
+### Providers reasonably emit only one value at a time
+-->
+### 提供者程式一次合理地只發出一個值
+
+<!---
+When reading an external RESTful API, it's quite common to show 
+the last read value, while a new call loads the next one.  
+Riverpod allows this behavior via emitting two values at a time (i.e. a previous data value, 
+and an incoming new loading value), via its `AsyncValue`'s APIs:
+-->
+讀取外部 RESTful API 時，通常會顯示上次讀取值，而新呼叫會載入下一個讀取值。  
+Riverpod 透過其 `AsyncValue` 的 API 一次發出兩個值（即一個前一個數據值和一個傳入的新載入值）來允許這種行為：
+
+<AutoSnippet language="dart" {...asyncValues}></AutoSnippet>
+
+<!---
+In the previous snippet, watching `evenItemsProvider` will produce the following effects:
+1. Initially, the request is being made. We obtain an empty list;
+2. Then, say an error occurs. We obtain `[Item(id: -1)]`;
+3. Then, we retry the request with a pull-to-refresh logic (e.g. via `ref.invalidate`);
+4. While we reload the first provider, the second one still exposes `[Item(id: -1)]`;
+5. This time, some parsed data is received correctly: our even items are correctly returned.
+-->
+在前面的程式碼片段中，觀察 `evenItemsProvider` 將產生以下效果：
+1. 最初，正在發出請求。我們得到一個空列表；
+1. 然後，假設發生錯誤。我們獲得 `[Item(id: -1)]`；
+1. 然後，我們使用拉取重新整理邏輯重試請求（例如，透過 `ref.invalidate`）；
+1. 當我們重新載入第一個提供者程式時，第二個提供者程式仍然公開 `[Item(id: -1)]`；
+1. 這一次，一些解析後的資料被正確接收：我們的偶數項被正確返回。
+
+<!---
+With Provider, the above features aren't remotely achievable, and even less easy to workaround.
+-->
+使用 Provider，上述功能無法遠端實現，甚至更難解決。
+
+<!---
+### Combining providers is hard and error prone
+-->
+### 合併提供者程式很困難且容易出錯
+
+<!---
+With Provider we may be tempted to use `context.watch` inside provider's `create`.  
+This would be unreliable, as `didChangeDependencies` may be triggered even if no dependency 
+has changed (e.g. such as when there's a GlobalKey involved in the widget tree).
+-->
+對於 Provider，我們可能很想在 provider 的 `create` 中使用 `context.watch`。  
+這將是不可靠的，因為即使沒有依賴項發生更改（例如，當小部件樹中涉及 GlobalKey 時），
+`didChangeDependencies` 也可能被觸發。
+
+<!---
+Nonetheless, Provider has an ad-hoc solution named `ProxyProvider`, but it's considered tedious and error-prone.
+-->
+儘管如此，Provider 有一個名為 `ProxyProvider` 的臨時解決方案，但它被認為是乏味且容易出錯的。
+
+<!---
+Combining state is a core Riverpod mechanism, as we can combine and cache values reactively with zero overhead 
+with simple yet powerful utilites such as [ref.watch] and [ref.listen]:
+-->
+合併狀態是 Riverpod 的核心機制，因為我們可以使用簡單而強大的方法（如 [ref.watch] 和 [ref.listen]）以零開銷組合和快取值：
+
+<AutoSnippet language="dart" {...combine}></AutoSnippet>
+
+<!---
+Combining values feels natural with Riverpod: dependencies are readable and the APIs remain the same.
+-->
+使用 Riverpod 組合值感覺很自然：依賴項是可讀的，並且 API 保持不變。
+
+
+<!---
+### Lack of safety
+-->
+### 缺乏安全性
+
+<!---
+With Provider, it's common to end-up with a `ProviderNotFoundException` during refactors and / or during large changes.  
+Indeed, this runtime exception *was* one of the main reasons Riverpod was created in the first place.
+-->
+使用 Provider，在重構和/或大型更改期間以 `ProviderNotFoundException` 結束是很常見的。  
+事實上，這個執行時異常*是*最初建立 Riverpod 的主要原因之一。
+
+<!---
+Although it brings much more utility than this, Riverpod simply can't throw this exception.
+-->
+儘管它帶來了比這更多的實用性，但 Riverpod 根本無法丟擲此異常。
+
+<!---
+### Disposing of state is difficult
+-->
+### 處置狀態很困難
+
+<!---
+`InheritedWidget` [can't react when a consumer stops listening to them].  
+This prevents the ability for Provider 
+to automatically destroy its providers' state when they're no-longer used.  
+With Provider, [we have to] rely on scoping providers to dispose the state when it stops being used.  
+But this isn't easy, as it gets tricky when state is shared between pages.
+-->
+`InheritedWidget` [無法對消費者程式停止監聽他們的情況做出反應]。  
+這可以防止提供者程式在不再使用時自動處置其提供者程式的狀態。  
+在使用 Provider 的情況下，[我們必須]依靠作用域提供者程式在停止使用狀態時對其進行處置。  
+但這並不容易，因為當在頁面之間共享狀態時，它會變得棘手。
+
+<!---
+Riverpod solves this with easy-to-understand APIs such as [autodispose] and [keepAlive].  
+These two APIs enable flexible and creative caching strategies (e.g. time-based caching):
+-->
+Riverpod 透過易於理解的 API（如 [autodispose] 和 [keepAlive]）解決了這個問題。  
+這兩個 API 支援靈活且創造性的快取策略（例如基於時間的快取）：
+
+<AutoSnippet language="dart" {...autoDispose}></AutoSnippet>
+
+
+<!---
+Unluckily, there's no way to implement this with a raw `InheritedWidget`, and thus with Provider.
+-->
+不幸的是，沒有辦法用原始 `InheritedWidget` 的來實現這一點，因此沒有辦法用 Provider 來實現。
+
+<!---
+### Lack of a reliable parametrization mechanism
+-->
+### 缺乏可靠的引數化機制
+
+<!---
+Riverpod allows its user to declare "parametrized" Providers with the [.family modifier].  
+Indeed, `.family` is one of Riverpod's most powerful feature and it is core to its innovations, 
+e.g. it enables enormous [simplification of logic]. 
+-->
+Riverpod 允許其使用者使用 [`.family` 修飾符]宣告“引數化”提供者程式。  
+事實上，這是 Riverpod 最強大的功能之一，也是其創新的核心，
+例如，`.family` 它能夠極大地[簡化邏輯]。
+
+<!---
+If we wanted to implement something similar using Provider, we would have to give 
+up easiness of use *and* type-safeness on such parameters. 
+-->
+如果我們想使用 Provider 實現類似的東西，
+我們將不得不放棄這些引數的易用性*和*型別安全性。
+
+<!---
+Furthermore, not being able to implement a similar `.autoDispose` mechanism with Provider 
+inherently prevents any equivalent implementation of `.family`, [as these two features go hand-in-hand].
+-->
+此外，無法使用 Provider 實現類似的 `.autoDispose` 機制
+本身就阻止了 `.family` 的任何等效實現，[因為這兩個功能是齊頭並進的]。
+
+<!---
+Finally, as shown before, [it turns out] that widgets *never* stop to listen to an `InheritedWidget`.  
+This implies significant memory leaks if some provider state is "dynamically mounted", i.e. when using parameters 
+to a build a Provider, which is exactly what `.family` does.  
+Thus, obtaining a `.family` equivalent for Provider is fundamentally impossible at the moment in time.
+-->
+最後，如前所述，[事實證明]，小部件*永遠*不會停止收聽 `InheritedWidget`。  
+這意味著如果某些提供者程式狀態是“動態掛載”的，
+即當使用引數構建提供者程式時，則會出現嚴重的記憶體洩漏，而這正是 `.family` 這樣做的。  
+因此，目前從根本上不可能獲得 Provider 的 `.family` 等價物。
+
+<!---
+### Testing is tedious
+-->
+### 測試很乏味
+
+<!---
+To be able to write a test, you *have to* re-define providers inside each test.
+-->
+為了能夠編寫測試，您*必須*在每個測試中重新定義提供者程式。
+
+<!---
+With Riverpod, providers are ready to use inside tests, by default. Furthermore, Riverpod exposes a 
+handy collection of "overriding" utilites that are crucial when mocking Providers.
+-->
+預設情況下，藉助 Riverpod，提供者程式已準備好在內部測試中使用。
+此外，Riverpod 還公開了一組方便的“覆蓋”的工具，這些實用程式在模擬提供者程式時至關重要。
+
+<!---
+Testing the combined state snippet above would be as simple as the following:
+-->
+測試上面的組合狀態程式碼段非常簡單，如下所示：
+
+<AutoSnippet language="dart" {...override}></AutoSnippet>
+
+<!---
+For more info about testing, see [Testing].
+-->
+有關測試的詳細資訊，請參閱[測試]。
+
+
+<!---
+### Triggering side effects isn't straightforward
+-->
+### 引發副作用並不簡單
+
+<!---
+Since `InheritedWidget` has no `onChange` callback, Provider can't have one.  
+This is problematic for navigation, such as for snackbars, modals, etc. 
+-->
+由於 `InheritedWidget` 沒有 `onChange` 回撥，因此 Provider 也沒有回撥。  
+這對於導航來說是有問題的，例如小吃欄、模態等。
+
+<!---
+Instead, Riverpod simply offers `ref.listen`, which [integrates well with Flutter].
+-->
+相反，Riverpod 只是提供 `ref.listen`，它[與 Flutter 很好地整合在一起]。
+
+<AutoSnippet language="dart" {...sideEffects}></AutoSnippet>
+
+<!---
+## Towards Riverpod
+-->
+## 轉向 Riverpod
+
+<!---
+Conceptually, Riverpod and Provider are fairly similar.
+Both packages fill a similar role. Both try to:
+-->
+從概念上講，Riverpod 和 Provider 非常相似。
+這兩個包都扮演著類似的角色。兩者都嘗試：
+
+<!---
+- cache and dispose some stateful objects;
+- offer a way to mock those objects during tests;
+- offer a way for Widgets to listen to those objects in a simple way.
+-->
+- 快取和處置一些有狀態物件；
+- 提供一種在測試期間模擬這些物件的方法；
+- 為 Widget 提供了一種以簡單的方式監聽這些物件的方法。
+
+<!---
+You can think of Riverpod as what Provider could've been if it continued to mature for a few years.
+-->
+你可以把 Riverpod 想象成 Provider 在幾年內繼續成熟時的樣子。
+
+<!---
+### Why a separate package?
+-->
+### 為什麼要單獨建包？
+
+<!---
+Originally, a major version of Provider was planned to ship, as a way to solve 
+the aforementioned problems.  
+But it was then decided against it, as this would have been 
+"too breaking" and even controversial, because of the new `ConsumerWidget` API.  
+Since Provider is still one of the most used Flutter packages, it was instead decided 
+to create a separate package, and thus Riverpod was created.
+-->
+最初，計劃釋出 Provider 的主要版本，以解決上述問題。  
+但隨後決定反對它，因為由於新的 `ConsumerWidget` API，這將“太麻煩”甚至有爭議。  
+由於 Provider 仍然是最常用的 Flutter 包之一，因此決定建立一個單獨的包，因此建立了 Riverpod。
+
+<!---
+Creating a separate package enabled:
+  - Ease of migration for whoever wants to, by also enabling the temporary use of both approaches, *at the same time*;
+  - Allow folks to stick to Provider if they dislike Riverpod in principle, or if they didn't find it reliable yet;
+  - Experimentation, allowing for Riverpod to search for production-ready solutions to the various Provider's technical limitations.
+-->
+啟用建立單獨的包：
+  - 透過*同時*臨時使用這兩種方法，為任何想要遷移的人提供便利；
+  - 如果人們原則上不喜歡 Riverpod，或者他們覺得它還不可靠，請允許他們堅持使用 Provider；
+  - 實驗，允許 Riverpod 搜尋生產就緒的解決方案，以應對各種提供者程式的技術限制。
+
+<!---
+Indeed, Riverpod is designed to be the spiritual successor of Provider. Hence the name "Riverpod" (which is an anagram of "Provider").
+-->
+事實上，Riverpod 旨在成為 Provider 的精神繼承者。因此得名“Riverpod”（它是“Provider”的字謎，異位詞）。
+
+<!---
+### The breaking change
+-->
+### 破壞性變化
+
+<!---
+The only true downside of Riverpod is that it requires changing the widget type to work:
+-->
+Riverpod 唯一真正的缺點是它需要更改小部件型別才能工作：
+
+<!---
+- Instead of extending `StatelessWidget`, with Riverpod you should extend `ConsumerWidget`.
+- Instead of extending `StatefulWidget`, with Riverpod you should extend `ConsumerStatefulWidget`.
+-->
+- 使用 Riverpod，您應該擴充套件 `ConsumerWidget`，而不是擴充套件 `StatelessWidget`。
+- 使用 Riverpod，您應該擴充套件 `ConsumerStatefulWidget`，而不是擴充套件 `StatefulWidget`。
+
+<!---
+But this inconvenience is fairly minor in the grand scheme of things. And this requirement might, one day, disappear.
+-->
+但這種不便在宏偉的計劃中是相當小的。有朝一日，這種要求可能會消失。
+
+<!---
+### Choosing the right library
+-->
+### 選擇正確的庫
+
+<!---
+You're probably asking yourself: 
+*"So, as a Provider user, should I use Provider or Riverpod?"*.
+-->
+您可能會問自己：*“那麼，作為 Provider 使用者，我應該使用 Provider 還是 Riverpod？”*
+
+<!---
+We want to answer to this question very clearly:
+-->
+我們想非常清楚地回答這個問題：
+
+<!---
+    You probably should be using Riverpod
+-->
+    您可能應該使用 Riverpod
+
+<!---
+Riverpod is overall better designed and could lead to drastic simplifications of your logic.
+-->
+Riverpod 總體上設計得更好，可以大大簡化您的邏輯。
+
+[ref.watch]: /docs/concepts/reading#using-refwatch-to-observe-a-provider
+[ref.listen]: /docs/concepts/reading#using-reflisten-to-react-to-a-provider-change
+[autodispose]: /docs/concepts/modifiers/auto_dispose
+[workaround]: https://pub.dev/packages/provider#can-i-obtain-two-different-providers-using-the-same-type
+[.family modifier]: /docs/concepts/modifiers/family
+[keepAlive]: /docs/concepts/modifiers/auto_dispose#refkeepalive
+[as these two features go hand-in-hand]: /docs/concepts/modifiers/family#prefer-using-autodispose-when-the-parameter-is-not-constant
+[simplification of logic]: /docs/concepts/modifiers/family#usage
+[we have to]: https://github.com/flutter/flutter/issues/128432
+[it turns out]: https://github.com/flutter/flutter/issues/106549
+[can't react when a consumer stops listening to them]: https://github.com/flutter/flutter/issues/106546
+[Testing]: /docs/cookbooks/testing
+[integrates well with Flutter]: /docs/concepts/reading#using-reflisten-to-react-to-a-provider-change
+
+[解決方法]: https://pub.dev/packages/provider#can-i-obtain-two-different-providers-using-the-same-type
+[無法對消費者程式停止監聽他們的情況做出反應]: https://github.com/flutter/flutter/issues/106546
+[我們必須]: https://github.com/flutter/flutter/issues/128432
+[簡化邏輯]: /docs/concepts/modifiers/family#usage
+[`.family` 修飾符]: /docs/concepts/modifiers/family
+[因為這兩個功能是齊頭並進的]: /docs/concepts/modifiers/family#prefer-using-autodispose-when-the-parameter-is-not-constant
+[事實證明]: https://github.com/flutter/flutter/issues/106549
+[測試]: /docs/cookbooks/testing
+[與 Flutter 很好地整合在一起]: /docs/concepts/reading#using-reflisten-to-react-to-a-provider-change

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/from_provider/provider_vs_riverpod.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/from_provider/provider_vs_riverpod.mdx
@@ -1,0 +1,653 @@
+---
+title: Provider 對比 Riverpod
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+import family from "/docs/from_provider/family";
+import {
+  trimSnippet,
+  AutoSnippet,
+  When,
+} from "@site/src/components/CodeSnippet";
+
+
+<!---
+This article recaps the defferences and the similarities between Provider and Riverpod.
+-->
+本文將介紹 Provider 和 Riverpod 之間的差異和相似之處。
+
+<!---
+## Defining providers
+-->
+## 定義提供者程式
+
+<!---
+The primary difference between both packages is how "providers" are defined.
+-->
+這兩個包之間的主要區別在於如何定義“提供者程式”。
+
+<!---
+With [Provider], providers are widgets and as such placed inside the widget tree,
+typically inside a `MultiProvider`:
+-->
+對於 [Provider]，提供者程式是小部件，因此放置在小部件樹中，通常位於 `MultiProvider`：
+
+```dart
+class Counter extends ChangeNotifier {
+ ...
+}
+
+void main() {
+  runApp(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider<Counter>(create: (context) => Counter()),
+      ],
+      child: MyApp(),
+    )
+  );
+}
+```
+
+<!---
+With Riverpod, providers are **not** widgets. Instead they are plain Dart objects.  
+Similarly, providers are defined outside of the widget tree, and instead are declared
+as global final variables.
+-->
+使用 Riverpod，提供者程式**不是**小部件。相反，它們是普通的 Dart 物件。  
+同樣，提供者程式在小部件樹之外定義，而且宣告為全域性 final 變數。
+
+<!---
+Also, for Riverpod to work, it is necessary to add a `ProviderScope` widget above the
+entire application. As such, the equivalent of the Provider example using Riverpod
+would be:
+-->
+此外，要使 Riverpod 正常工作，必須在整個應用程式上方新增一個小 `ProviderScope` 部件。
+因此，使用 Riverpod 和 Provider 示例等效的版本為：
+
+```dart
+// provider 現在是頂級變數
+final counterProvider = ChangeNotifierProvider<Counter>((ref) => Counter());
+
+void main() {
+  runApp(
+    // 該小部件為整個專案啟用了 Riverpod
+    ProviderScope(
+      child: MyApp(),
+    ),
+  );
+}
+```
+
+<!---
+Notice how the provider definition simply moved up a few lines.
+-->
+請注意，這個 ChangeNotifierProvider 的定義只是向上移動了幾行。
+
+:::info
+<!---
+Since with Riverpod providers are plain Dart objects, it is possible to use
+Riverpod without Flutter.  
+For example, Riverpod can be used to write command line applications.
+-->
+由於 Riverpod 的提供者程式是普通的 Dart 物件，因此可以在沒有 Flutter 的情況下使用 Riverpod。  
+例如，Riverpod 可用於編寫命令列應用程式。
+:::
+
+<!---
+## Reading providers: BuildContext
+-->
+## 讀取提供者程式：使用 BuildContext
+
+<!---
+With Provider, one way of reading providers is to use a Widget's `BuildContext`.
+-->
+使用 Provider 庫，讀取提供者程式的一種方法是使用 Widget 的 `BuildContext`。
+
+<!---
+For example, if a provider was defined as:
+-->
+例如，如果 provider 定義為：
+
+```dart
+Provider<Model>(...);
+```
+
+<!---
+then reading it using [Provider] is done with:
+-->
+然後使用 [Provider] 讀取它就可以這樣做：
+
+```dart
+class Example extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    Model model = context.watch<Model>();
+
+  }
+}
+```
+
+<!---
+The equivalent in Riverpod would be:
+-->
+在 Riverpod 中的等效程式碼是：
+
+```dart
+final modelProvider = Provider<Model>(...);
+
+class Example extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    Model model = ref.watch(modelProvider);
+
+  }
+}
+```
+
+<!---
+Notice how:
+-->
+請注意：
+
+<!---
+- Riverpod's snippet extends `ConsumerWidget` instead of `StatelessWidget`.
+  That different widget type adds one extra parameter to our `build` function:
+  `WidgetRef`.
+-->
+- Riverpod 的程式碼片段是擴充套件 `ConsumerWidget` 的，而不是 `StatelessWidget`。
+  不同的小部件型別為我們的 `build` 函式添加了一個額外的引數：`WidgetRef`。
+
+<!---
+- Instead of `BuildContext.watch`, in Riverpod we do `WidgetRef.watch`, using
+  the `WidgetRef` which we obtained from `ConsumerWidget`.
+-->
+- 在 Riverpod 中我們使用 `WidgetRef.watch` 代替 `BuildContext.watch`，
+  `WidgetRef` 是我們從 `ConsumerWidget` 拿到的。
+
+<!---
+- Riverpod does not rely on generic types. Instead it relies on the variable
+  created using provider definition.
+-->
+- Riverpod 不依賴於泛型型別。相反，它依賴於使用提供者程式定義建立的變數。
+
+<!---
+Notice too how similar the wording is. Both Provider and Riverpod use the keyword
+"watch" to describe "this widget should rebuild when the value changes".
+-->
+還要注意措辭的相似程度。Provider 和 Riverpod 都使用關鍵字“watch”來描述“當值更改時，這裡的小部件應重新生成”。
+
+:::info
+<!---
+Riverpod uses the same terminology as Provider for reading providers.
+-->
+Riverpod 使用與 Provider 相同的術語來讀取提供者程式。
+
+- `BuildContext.watch` -> `WidgetRef.watch`
+- `BuildContext.read` -> `WidgetRef.read`
+- `BuildContext.select` -> `WidgetRef.watch(myProvider.select)`
+
+<!---
+The rules for `context.watch` vs `context.read` applies to Riverpod too:  
+Inside the `build` method, use "watch". Inside click handlers and other events,
+use "read". When in need of filtering out values and rebuilds, use "select".
+-->
+`context.watch` 相對於 `context.read` 的規則也適用於 Riverpod：  
+在 `build` 方法中，使用 “watch”。在單擊處理程式和其他事件中，使用 “read”。
+當需要過濾掉值並重新生成時，請使用 “select”。
+:::
+
+<!---
+## Reading providers: Consumer
+-->
+## 讀取提供者程式：使用 Consumer
+
+<!---
+Provider optionally comes with a widget named `Consumer` (and variants such as `Consumer2`)
+for reading providers.
+-->
+Provider 可以選擇附帶一個名為 `Consumer`（以及名為 `Consumer2` 的變體）的小部件，用於讀取提供者程式。
+
+<!---
+`Consumer` is helpful as a performance optimization, by allowing more granular rebuilds
+of the widget tree - updating only the revelant widgets when the state changes:
+-->
+`Consumer` 作為效能最佳化很有幫助，它允許對小部件樹進行更精細的重建 - 在狀態更改時僅更新相關的小部件：
+
+<!---
+As such, if a provider was defined as:
+-->
+因此，如果一個 provider 被定義為：
+
+```dart
+Provider<Model>(...);
+```
+
+<!---
+Provider allows reading that provider using `Consumer` with:
+-->
+Provider 允許使用 `Consumer` 讀取這個 provider：
+
+```dart
+Consumer<Model>(
+  builder: (BuildContext context, Model model, Widget? child) {
+
+  }
+)
+```
+
+<!---
+Riverpod has the same principle. Riverpod, too, has a widget named `Consumer`
+for the exact same purpose.
+-->
+Riverpod 也有同樣的原理。Riverpod 也有一個以完全相同功能的 `Consumer` 小部件。
+
+<!---
+If we defined a provider as:
+-->
+如果我們將一個 provider 定義為：
+
+```dart
+final modelProvider = Provider<Model>(...);
+```
+
+<!---
+Then using `Consumer` we could do:
+-->
+然後我們可以使用 `Consumer` 實現：
+
+```dart
+Consumer(
+  builder: (BuildContext context, WidgetRef ref, Widget? child) {
+    Model model = ref.watch(modelProvider);
+
+  }
+)
+```
+
+<!---
+Notice how `Consumer` gives us a `WidgetRef` object. This is the same object
+as we saw in the previous part related to `ConsumerWidget`.
+-->
+注意 `Consumer` 是如何給我們一個 `WidgetRef` 物件。這與我們在上一部分中看到的 `ConsumerWidget` 與相關的物件相同。
+
+<!---
+### There is no `ConsumerN` equivalent in Riverpod
+-->
+### Riverpod 中沒有 `ConsumerN` 等效的類
+
+<!---
+Notice how pkg:Provider's `Consumer2`, `Consumer3` and such aren't needed nor missed in Riverpod.
+-->
+請注意，在 Riverpod 中不需要 pkg:Provider 的 `Consumer2`、`Consumer3` 等，也不要遺漏重構它們。
+
+<!---
+With Riverpod, if you want to read values from multiple providers, you can simply write multiple `ref.watch` statements,
+like so:
+-->
+使用 Riverpod，如果要從多個提供者程式讀取值，只需編寫多個 ref.watch 語句即可，如下所示：
+
+```dart
+Consumer(
+  builder: (context, ref, child) {
+    Model1 model = ref.watch(model1Provider);
+    Model2 model = ref.watch(model2Provider);
+    Model3 model = ref.watch(model3Provider);
+    // ...
+  }
+)
+```
+
+<!---
+When compared to pkg:Provider's `ConsumerN` APIs, the above solution feels way less heavy and it should be easier to understand.
+-->
+與 pkg:Provider 的 `ConsumerN` API 相比，上述解決方案感覺不那麼沉重，應該更容易理解。
+
+<!---
+## Combining providers: ProxyProvider with stateless objects
+-->
+## 組合提供者程式：ProxyProvider 與無狀態物件
+
+<!---
+When using Provider, the official way of combining providers is using the
+`ProxyProvider` widget (or variants such as `ProxyProvider2`).
+-->
+使用 Provider 時，組合提供者程式的官方方法是使用 `ProxyProvider` widget（或變體，例如 `ProxyProvider2`）。
+
+<!---
+For example we may define:
+-->
+例如，我們可以定義：
+
+```dart
+class UserIdNotifier extends ChangeNotifier {
+  String? userId;
+}
+
+// ...
+
+ChangeNotifierProvider<UserIdNotifier>(create: (context) => UserIdNotifier()),
+```
+
+<!---
+From there we have two options. We may combine `UserIdNotifier` to create a new
+"stateless" provider (typically an immutable value that possibly override ==).
+Such as:
+-->
+在這裡我們有兩個選擇。我們可以組合 `UserIdNotifier` 建立一個新的“無狀態”提供者程式 
+（通常是一個可能覆蓋 == 的不可變值）。如：
+
+```dart
+ProxyProvider<UserIdNotifier, String>(
+  update: (context, userIdNotifier, _) {
+    return 'The user ID of the the user is ${userIdNotifier.userId}';
+  }
+)
+```
+
+<!---
+This provider would automatically return a new `String` whenever
+`UserIdNotifier.userId` changes.
+-->
+每當 `UserIdNotifier.userId` 發生更改時，這個提供者程式都會自動返回新的 `String` 值。
+
+<!---
+We can do something similar in Riverpod, but the syntax is different.  
+First, in Riverpod, the definition of our `UserIdNotifier` would be:
+-->
+我們可以在 Riverpod 中做類似的事情，但語法不同。  
+首先，在 Riverpod 中，我們的 `UserIdNotifier` 定義是：
+
+```dart
+class UserIdNotifier extends ChangeNotifier {
+  String? userId;
+}
+
+// ...
+
+final userIdNotifierProvider = ChangeNotifierProvider<UserIdNotifier>(
+  (ref) => UserIdNotifier(),
+);
+```
+
+<!---
+From there, to generate our `String` based on the `userId`, we could do:
+-->
+那樣的話，要基於 `userId` 生成 `String`，我們可以這樣做：
+
+```dart
+final labelProvider = Provider<String>((ref) {
+  UserIdNotifier userIdNotifier = ref.watch(userIdNotifierProvider);
+  return 'The user ID of the the user is ${userIdNotifier.userId}';
+});
+```
+
+<!---
+Notice the line doing `ref.watch(userIdNotifierProvider)`.
+-->
+請注意這行 ref.watch(userIdNotifierProvider) 做的事。
+
+<!---
+This line of code tells Riverpod to obtain the content of the `userIdNotifierProvider`
+and that whenever that value changes, `labelProvider` will be recomputed too.
+As such, the `String` emitted by our `labelProvider` will automatically update
+whenever the `userId` changes.
+-->
+這行程式碼告訴 Riverpod 獲取 `userIdNotifierProvider` 的內容，
+並且每當該值發生變化時， `labelProvider` 也會重新計算。
+因此，每當 `userId` 更改時，
+我們 `labelProvider` 發出的 `String` 都會自動更新。
+
+<!---
+This `ref.watch` line should feel similar. This pattern was covered previously
+when explaining [how to read providers inside widgets](#reading-providers-buildcontext).
+Indeed, providers are now able to listen to other providers in the same way
+that widgets do.
+-->
+這行 `ref.watch` 應該感覺很熟悉。
+之前在解釋[如何在小部件中讀取提供者程式](#讀取-providersbuildcontext)時已經介紹了這個模式。
+事實上，提供者程式現在能夠與小部件以相同的方式監聽其他提供者程式的改變。
+
+<!---
+## Combining providers: ProxyProvider with stateful objects
+-->
+## 組合提供者程式：ProxyProvider 與有狀態物件
+
+<!---
+When combining providers, another alternative use-case is to expose
+stateful objects, such as a `ChangeNotifier` instance.
+-->
+組合提供者程式時，另一個替代用例是公開有狀態物件，例如 `ChangeNotifier` 例項。
+
+<!---
+For that, we could use `ChangeNotifierProxyProvider` (or variants such as `ChangeNotifierProxyProvider2`).  
+For example we may define:
+-->
+為此，我們可以使用 `ChangeNotifierProxyProvider`（或變體，例如 `ChangeNotifierProxyProvider2`）。  
+例如，我們可以定義：
+
+```dart
+class UserIdNotifier extends ChangeNotifier {
+  String? userId;
+}
+
+// ...
+
+ChangeNotifierProvider<UserIdNotifier>(create: (context) => UserIdNotifier()),
+```
+
+<!---
+Then, we can define a new `ChangeNotifier` that is based on `UserIdNotifier.userId`.
+For example we could do:
+-->
+然後，我們可以定義基於 `UserIdNotifier.userId` 的一個 `ChangeNotifier`。
+例如，我們可以這樣做：
+
+```dart
+class UserNotifier extends ChangeNotifier {
+  String? _userId;
+
+  void setUserId(String? userId) {
+    if (userId != _userId) {
+      print('The user ID changed from $_userId to $userId');
+      _userId = userId;
+    }
+  }
+}
+
+// ...
+
+ChangeNotifierProxyProvider<UserIdNotifier, UserNotifier>(
+  create: (context) => UserNotifier(),
+  update: (context, userIdNotifier, userNotifier) {
+    return userNotifier!
+      ..setUserId(userIdNotifier.userId);
+  },
+);
+```
+
+<!---
+This new provider creates a single instance of `UserNotifier` (which is never re-constructed)
+and prints a string whenever the user ID changes.
+-->
+這個新提供者程式會建立一個 `UserNotifier` 例項（它永遠不會重新構造），
+並在使用者 ID 更改時列印一個字串。
+
+<!---
+Doing the same thing in provider is achieved differently.
+First, in Riverpod, the definition of our `UserIdNotifier` would be:
+-->
+在提供者程式中執行相同的操作是以不同的方式實現的。
+首先，在 Riverpod 中，我們的 `UserIdNotifier` 是這樣定義的：
+
+```dart
+class UserIdNotifier extends ChangeNotifier {
+  String? userId;
+}
+
+// ...
+
+final userIdNotifierProvider = ChangeNotifierProvider<UserIdNotifier>(
+  (ref) => UserIdNotifier(),
+),
+```
+
+<!---
+From there, the equivalent to the previous `ChangeNotifierProxyProvider` would be:
+-->
+相比於上面 `ChangeNotifierProxyProvider` 的等價程式碼將是：
+
+```dart
+class UserNotifier extends ChangeNotifier {
+  String? _userId;
+
+  void setUserId(String? userId) {
+    if (userId != _userId) {
+      print('The user ID changed from $_userId to $userId');
+      _userId = userId;
+    }
+  }
+}
+
+// ...
+
+final userNotifierProvider = ChangeNotifierProvider<UserNotifier>((ref) {
+  final userNotifier = UserNotifier();
+  ref.listen<UserIdNotifier>(
+    userIdNotifierProvider,
+    (previous, next) {
+      if (previous?.userId != next.userId) {
+        userNotifier.setUserId(next.userId);
+      }
+    },
+  );
+
+  return userNotifier;
+});
+```
+
+<!---
+The core of this snippet is the `ref.listen` line.  
+This `ref.listen` function is a utility that allows listening to a provider,
+and whenever the provider changes, executes a function.
+-->
+這個片段的核心是 `ref.listen` 這行程式碼。  
+這裡的 `ref.listen` 函式是一個實用程式，它允許監聽一個提供者程式，
+並在提供者程式更改時執行函式。
+
+<!---
+The `previous` and `next` parameters of that function correspond to the
+last value before the provider changed and the new value after it changed.
+-->
+該函式的 `previous` 和 `next` 引數對應於提供者程式更改前的最後一個值和更改後的新值。
+
+<!---
+## Scoping Providers vs `.family` + `.autoDispose`
+-->
+## 作用域提供者程式與 `.family` + `.autoDispose`
+
+<!---
+In pkg:Provider, scoping was used for two things:
+  - destroying state when leaving a page
+  - having custom state per page
+-->
+在 pkg:Provider 中，作用域用於兩件事：
+  - 離開頁面時處置狀態
+  - 每頁具有自定義狀態
+
+<!---
+Using scoping just to destroy state isn't ideal.  
+The problem is that scoping doesn't work well over large applications.  
+For example, state often is created in one page, but destroyed later in a different page after navigation.  
+This doesn't allow for multiple caches to be active over different pages.
+-->
+僅使用作用域來破壞狀態並不理想。  
+問題在於，作用域在大型應用程式上效果不佳。  
+例如，狀態通常在一個頁面中建立，但在導航後稍後在另一個頁面中處置。  
+這不允許多個快取在不同的頁面上處於活動狀態。
+
+<!---
+Similarly, the "custom state per page" approach quickly becomes difficult to handle if that state 
+needs to be shared with another part of the widget tree, 
+like you'd need with modals or a with a multi-step form.
+-->
+同樣，如果需要與小部件樹的另一部分共享狀態，
+“自定義每個頁面狀態”的方法很快就會變得難以處理，
+就像你需要模態或多步驟表單一樣。
+
+<!---
+Riverpod takes a different approach: first, scoping providers is kind-of discouraged; second, 
+`.family` and `.autoDispose` are a complete replacement solution for this.
+-->
+Riverpod 採取了不同的方法：首先，不鼓勵使用作用域提供者；
+其次， `.family` 和 `.autoDispose` 是完整的替代解決方案。
+
+<!---
+Within Riverpod, Providers marked as `.autoDispose` automatically destroy their state when they aren't used anymore.  
+When the last widget removing a provider is unmounted, Riverpod will detect this and destroy the provider.  
+Try using these two lifecycle methods in a provider to test this behavior:
+-->
+在 Riverpod 中，當一個提供者程式標記為 `.autoDispose` 在不再使用時會自動處置的狀態。  
+當解除安裝最後一個刪除提供者程式的小部件時，Riverpod 將檢測到解除安裝並處置提供者程式。  
+嘗試在提供者程式中使用以下兩種生命週期方法來測試此行為：
+
+```dart
+ref.onCancel((){
+  print("我一個監聽程式都沒有了！");
+});
+ref.onDispose((){
+  print("如果我已經被定義為 `.autoDispose`，我將被處置！");
+});
+```
+
+<!---
+This inherently solves the "destroying state" problem.
+-->
+這從本質上解決了“破壞狀態”問題。
+
+<!---
+Also it is possible to mark a Provider as `.family` (and, at the same time, as `.autoDispose`).  
+This enables passing parameters to providers, which make multiple providers to be spawned and tracked internally.  
+In other words, when passing parameters, *a unique state is created per unique parameter*.
+-->
+此外，還可以將提供者程式標記為 `.family`（同時，也可以標記為 `.autoDispose`）。  
+這樣就可以將引數傳遞給提供者程式，從而在內部生成和跟蹤多個提供者程式。  
+換句話說，在傳遞引數時，*會為每個唯一引數建立一個唯一狀態*。
+
+<AutoSnippet language="dart" {...family}></AutoSnippet>
+
+
+<!---
+This solves the "custom state per page" problem. Actually, there's another advantage: such state is no-longer bound to one specific page.  
+Instead, if a different page tries to access the same state, such page will be able to do so by just reusing the parameters.
+-->
+這解決了“每頁自定義狀態”問題。實際上，還有另一個優點：這種狀態不再繫結到一個特定的頁面。  
+相反，如果不同的頁面嘗試訪問相同的狀態，則該頁面只需重用引數即可實現。
+
+<!---
+In many ways, passing parameters to providers is equivalent to a Map key.  
+If the key is the same, the value obtained is the same. If it's a different key, a different state will be obtained.
+-->
+在許多方面，將引數傳遞給提供者程式等同於 Map 的鍵。  
+如果鍵相同，則獲取的值相同。如果是不同的鍵，則將獲得不同的狀態。
+
+[provider]: https://pub.dev/packages/provider
+[ref.watch]: /docs/concepts/reading#using-refwatch-to-observe-a-provider
+[ref.listen]: /docs/concepts/reading#using-reflisten-to-react-to-a-provider-change
+[autodispose]: /docs/concepts/modifiers/auto_dispose
+[workaround]: https://pub.dev/packages/provider#can-i-obtain-two-different-providers-using-the-same-type
+[.family modifier]: /docs/concepts/modifiers/family
+[keepAlive]: /docs/concepts/modifiers/auto_dispose#refkeepalive
+[as these two features go hand-in-hand]: /docs/concepts/modifiers/family#prefer-using-autodispose-when-the-parameter-is-not-constant
+[simplification of logic]: /docs/concepts/modifiers/family#usage
+[we have to]: https://github.com/flutter/flutter/issues/128432
+[it turns out]: https://github.com/flutter/flutter/issues/106549
+[*can't* react when a consumer stops listening to them]: https://github.com/flutter/flutter/issues/106546
+[integrates well with Flutter]: /docs/concepts/reading#using-reflisten-to-react-to-a-provider-change
+[ChangeNotifierProvider]: /docs/providers/change_notifier_provider
+[Code generation]: /docs/about_code_generation
+[AsyncNotifiers]: /docs/providers/notifier_provider
+[combining Providers]: /docs/concepts/combining_providers
+[global final variable]: /docs/concepts/providers#creating-a-provider

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/from_provider/quickstart.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/from_provider/quickstart.mdx
@@ -1,0 +1,399 @@
+---
+title: 快速開始
+---
+
+:::info
+譯者注：在此章節中，由於 Provider 庫，Provider 類，Provider 及其相關的提供者程式類容易造成混淆，一般的，我們約定：  
+- Provider 庫 -> `pkg:Provider` / `Provider`，和 Riverpod 一樣首字母大寫。
+- Provider 類 -> `provider`，小寫，特指單純的提供者程式類 Provider。
+- Provider 泛指 -> `提供者程式`，表示各種不同的提供者程式類都適用。
+
+其他地方的代指某個 provider，會被具體翻譯，避免不必要的誤解，請放心閱讀。  
+如有翻譯錯誤還請 pr 指正。
+:::
+
+<!---
+This section is designed for people familiar with the [Provider] package who
+wants to learn about Riverpod.
+-->
+本部分專為熟悉 [Provider] 包並希望瞭解 Riverpod 的人員而設計。
+
+<!---
+Before anything, read the short [getting started] article and try out the small
+[sandbox] example to test Riverpod's features out. If you like what you see there, you should then
+definitively consider a migration.
+-->
+首先，請閱讀簡短的[入門指南]文章，並嘗試使用小型[沙盒]示例來測試 Riverpod 的功能。
+如果您喜歡那裡看到的內容，那麼您應該明確考慮遷移。
+
+<!---
+Indeed, migrating from Provider to Riverpod can be very straightforward.  
+-->
+事實上，從 Provider 遷移到 Riverpod 可以非常簡單。
+
+<!---
+Migrating basically consists in a few steps that can be done in an *incremental* way.
+-->
+遷移基本上包括幾個步驟，這些步驟可以以*增量*方式完成。
+
+<!---
+## Start with `ChangeNotifierProvider`
+-->
+## 從 `ChangeNotifierProvider` 開始
+
+<!---
+It's fine to keep using `ChangeNotifier` while transitioning towards Riverpod,
+and not use its latest fancy features ASAP.
+-->
+在過渡到 Riverpod 時是可以的繼續使用，而不是儘快使用 `ChangeNotifier` 其最新的花哨功能。
+
+<!---
+Indeed, the following is perfectly fine to start with:
+-->
+事實上，可以從以下幾點著手開始：
+
+```dart
+// 如果你有這個……
+class MyNotifier extends ChangeNotifier {
+  int state = 0;
+
+  void increment() {
+    state++;
+    notifyListeners();
+  }
+}
+
+// ……只需要加上這個！
+final myNotifierProvider = ChangeNotifierProvider<MyNotifier>((ref) {
+  return MyNotifier();
+});
+```
+
+<!---
+As you can see Riverpod exposes a [ChangeNotifierProvider] class,
+which is there precisely to support migrations from pkg:Provider.
+-->
+正如你所看到的，Riverpod 公開了一個 [ChangeNotifierProvider] 類，
+該類正是為了支援從 pkg:Provider 遷移。
+
+<!---
+Keep in mind that this provider is not recommended when writing new code,
+and it is not the best way to use Riverpod, but it's a gentle and very easy way to start your migration.
+-->
+請記住，在編寫新程式碼時不建議使用 `ChangeNotifierProvider`，因為它不是使用 Riverpod 的最佳方式，
+但它是開始遷移的一種溫和且非常簡單的方法。
+
+:::tip
+<!---
+There is no rush to *immediately* try to change your `ChangeNotifier`s into the more modern [Riverpod's providers].
+Some requite a bit of a paradigm shift, so it may be difficult to do initially.  
+-->
+不要急於*立即*嘗試將您的 `ChangeNotifier` 遷移到更現代的 [Riverpod 的提供者程式]。
+有些地方會進行一些泛型的轉變，因此最初可能很難做到。
+
+<!---
+Take your time, as it is important to get yourself familiar with Riverpod first;
+you'll quickly find out that *almost* all Providers from pkg:provider have a strict equivalent in pkg:riverpod.
+-->
+慢慢來，因為首先熟悉 Riverpod 很重要；
+你很快就會發現，幾乎所有來自 pkg:provider 的提供者程式在 pkg:riverpod 中都有嚴格等價的程式碼。
+:::
+
+<!---
+## Starts with *leaves*
+-->
+## 從*葉子*開始
+
+<!---
+Start with Providers that do not depend on anything else, i.e. start with the *leaves* in your dependency tree.  
+Once you have migrated all of the leaves, you can then move on to the providers that depend on leaves.
+-->
+從不依賴於其他任何內容的提供者程式開始，即從依賴項樹中的*葉子*開始。  
+遷移完所有葉子後，可以轉到依賴於葉子的提供者程式。
+
+<!---
+In other words, avoid migrating `ProxyProvider`s at first; tackle them once all of their dependencies have been migrated.
+-->
+換言之，首先要避免遷移 `ProxyProvider`；當遷移了它們的所有依賴項，就可以開始處理它們了。
+
+<!---
+This should boost and simplify the migration process, while also minimizing / tracking down any errors.
+-->
+這應該促進和簡化遷移過程，同時還可以最大限度地減少/跟蹤任何錯誤。
+
+
+<!---
+## Riverpod and Provider can coexist
+-->
+## Riverpod 和 Provider 可以共存
+
+<!---
+*Keep in mind that it is entirely possible to use both Provider and Riverpod at the same time.*
+-->
+
+*請記住，完全可以同時使用 Provider 和 Riverpod。*
+
+<!---
+Indeed, using import aliases, it is possible to use the two APIs altogheter.  
+This is also great for readibilty and it removes any ambiguous API usage.
+-->
+事實上，使用匯入別名，可以同時使用兩個 API 了。  
+這也非常有助於提高可用性，並消除了任何模稜兩可的 API 用法。
+
+<!---
+If you plan on doing this, consider using import aliases for each Provider import in your codebase.
+-->
+如果計劃執行此操作，請考慮對程式碼庫中的每個提供者程式匯入使用匯入別名。
+
+:::info
+<!---
+A full guide onto how to effectively implement import aliases is incoming soon.
+-->
+關於如何有效實現匯入別名的完整指南即將釋出。
+:::
+
+
+<!---
+## You don't *have to* use `Consumer` right away
+-->
+## 您*不必*立即使用 `Consumer`
+
+<!---
+It's important to keep in mind that there is no need to *immediately* use [Riverpod's `Consumer` APIs].  
+If you've just started the migration, [as mentioned above], you should probably start with `ChangeNotifierProvider`.
+-->
+請務必記住，無需*立即*使用 [Riverpod 的 `Consumer` API]。  
+如果您剛剛開始遷移，[如上所述]，您可能應該從 `ChangeNotifierProvider` 開始。
+
+<!---
+Consider `myNotifierProvider`, defined above.
+-->
+考慮上面定義的 `myNotifierProvider`。
+
+<!---
+Since your inner code is probably depending on pkg:Provider's APIs, use the following to start consuming `ChangeNotifier`s with pkg:Riverpod.
+-->
+由於您的內部程式碼可能依賴於 pkg:Provider 的 API，因此請使用以下程式碼開始使用 pkg:Riverpod 的 `ChangeNotifier`。
+
+```dart
+MultiProvider(
+  providers: [
+    ChangeNotifierProvider.value(value: ref.watch(myNotifierProvider.notifier)),
+  ]
+)
+```
+
+<!---
+This way, only the root Widget has to be initially converted into a `ConsumerWidget`.  
+This should ease the migration towards pkg:Riverpod even more.
+-->
+這樣，最初只需將根 Widget 轉換為 `ConsumerWidget`。  
+這應該會進一步簡化向 pkg:Riverpod 的遷移。
+
+
+<!---
+## Migrate one Provider at a time
+-->
+## 一次遷移一個提供者程式
+
+<!---
+If you have an existing app, don't try to migrate all your providers at once!
+-->
+如果您已有應用，請不要嘗試一次遷移所有的提供者程式！
+
+<!---
+While you should strive toward moving all your application to Riverpod in the long-run, 
+**don't burn yourself out**.  
+Do it one provider at a time.  
+-->
+雖然從長遠來看，您應該努力將所有應用程式遷移到 Riverpod，**但不要讓自己筋疲力盡**。  
+一次只遷移一個提供者程式。
+
+<!---
+Take the above example. **Fully** migrating that `myNotifierProvider` to Riverpod means writing the following:
+-->
+以上面的例子為例。將其 `myNotifierProvider` **完全**遷移到 Riverpod 意味著需要編寫以下內容：
+
+```dart
+class MyNotifier extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void increment() => state++;
+}
+
+final myNotifierProvider = NotifierProvider<MyNotifier, int>(MyNotifier.new);
+```
+
+<!---
+.. and it's _also_ needed to change how that provider is consumed, i.e. writing `ref.watch` in the place of each `context.watch` for this provider.
+-->
+……並且_還_需要更改這個 `myNotifierProvider` 的使用方式，即每個 `context.watch` 的位置替換為 `ref.watch`。
+
+<!---
+This operation might take some time and might lead to some errors, so don't rush doing this all at once.
+-->
+此操作可能需要一些時間，並可能導致一些錯誤，因此不要急於一次完成所有操作。
+
+<!---
+## Migrating `ProxyProvider`s
+-->
+## 遷移 `ProxyProvider`
+
+<!---
+Within pkg:Provider, `ProxyProvider` is used to combine values from other Providers;
+its build depends on the value of other providers, reactively.
+-->
+在 pkg:Provider 中，`ProxyProvider` 用於組合來自其他提供者程式的值；
+它的構建被動地取決於其他提供者程式的價值。
+
+<!---
+With Riverpod, instead, Providers [are composable by default]; therefore, when migrating a `ProxyProvider`
+you'll simply need to write `ref.watch` if you want to declare a direct dependency from a Provider to another.
+-->
+相反，在 Riverpod 中，提供者程式[預設是可組合的]；
+因此，在遷移 `ProxyProvider` 時，如果要宣告從一個提供者程式到另一個提供者程式的直接依賴項，則只需編寫 `ref.watch` 即可。
+
+<!---
+If anything, combining values with Riverpod should feel simpler and straightforward; thus, the migration should greatly
+simplify your code.
+-->
+如果有的話，將值與 Riverpod 相結合應該感覺更簡單明瞭；因此，遷移應該大大簡化程式碼。
+
+<!---
+Furthermore, there are no shanenigans about combining more than two providers together:
+just add another `ref.watch` and you'll be good to go.
+-->
+此外，將兩個以上的提供者程式組合在一起沒有任何障礙：只需新增另一個 `ref.watch`，就可以了。
+
+<!---
+## Eager initialization
+-->
+## 預先初始化
+
+<!---
+Since Riverpod's providers are final global variables, they are [lazy by default].
+-->
+由於 Riverpod 的提供者程式是全域性 final 變數，因此它們[預設是懶載入的]。
+
+<!---
+If you need to initialize some warm-up data or a useful service on startup,
+the best way to do it is to first read your provider in the place where you used to put `MultiProvider`.
+-->
+如果您需要在啟動時初始化一些預熱資料或有用的服務，
+最好的做法是首次讀取提供者程式的時候，您手動去設定 `MultiProvider`。
+
+<!---
+In other words, since Riverpod can't be forced to be eager initialized, they can be read and cached
+in your startup phase, so that they're warm and ready when needed inside the rest of your application.
+-->
+換句話說，由於 Riverpod 不能被強制預先初始化，因此可以在啟動階段讀取和快取它們，
+以便在應用程式的其餘部分需要時它們完成了初始化並準備就緒。
+
+<!---
+A full guide about eager initialization of pkg:Riverpod's providers [is available here].
+-->
+有關 pkg:Riverpod 提供者程式的快速初始化的完整指南 [可在此處獲得]。
+
+<!---
+## Code Generation
+-->
+## 程式碼生成
+
+<!---
+[Code generation] is recommended to use Riverpod the *future-proof* way.  
+As a side note, chances are that when metaprogramming will be a thing, codegen will be default for Riverpod.
+-->
+建議使用[程式碼生成]，以便以*面向未來*的方式使用 Riverpod。  
+順便說一句，當元程式設計成為現實的時候，程式碼生成很可能是 Riverpod 的預設程式碼。
+
+<!---
+Unluckily, `@riverpod` can't generate code for `ChangeNotifierProvider`.  
+To overcome this, you can use the following utility extesion method:
+-->
+不幸的是， `@riverpod` 無法為 `ChangeNotifierProvider` 生成程式碼。  
+要解決此問題，您可以使用以下實用程式擴充套件方法：
+
+```dart
+extension ChangeNotifierWithCodeGenExtension on Ref {
+  T listenAndDisposeChangeNotifier<T extends ChangeNotifier>(T notifier) {
+    notifier.addListener(notifyListeners);
+    onDispose(() => notifier.removeListener(notifyListeners));
+    onDispose(notifier.dispose);
+    return notifier;
+  }
+}
+```
+
+<!---
+And then, you can expose your `ChangeNotifier` with the following codegen syntax:
+-->
+然後，您可以使用以下程式碼生成語法公開您的 `ChangeNotifier`：
+
+```dart
+// ignore_for_file: unsupported_provider_value
+@riverpod
+MyNotifier example(Ref ref) {
+  return ref.listenAndDisposeChangeNotifier(MyNotifier());
+}
+```
+
+<!---
+Once the "base" migration is done, you can change your `ChangeNotifier` to `Notifier`,
+thus eliminating the need for temporary extensions.  
+Taking up the previous examples, a "fully migrated" `Notifier` becomes:
+-->
+完成“基本”遷移後，您可以將 `ChangeNotifier` 更改為 `Notifier`，從而消除了臨時擴充套件的需要。  
+以前面的示例為例，“完全遷移” `Notifier` 變為：
+
+```dart
+@riverpod
+class MyNotifier extends _$MyNotifier {
+  @override
+  int build() => 0;
+
+  void increment() => state++;
+}
+```
+
+<!---
+Once this is done, and you're positive that there are no more `ChangeNotifierProvider`s 
+in your codebase, you can get rid of the temporary extension definitively.
+-->
+一旦完成此操作，並且您確信程式碼庫中不再有 `ChangeNotifierProvider`，您就可以徹底擺脫臨時擴充套件。
+
+<!---
+Keep in mind that, while being recommended, codegen is not *mandatory*.  
+It's good to reason about migrations incrementally:
+if you feel like that implementing this migration *while* transitioning to
+the code generation syntax in one single take might be too much, *that's fine*.
+-->
+請記住，雖然是推薦的，但程式碼生成不是*強制性的*。  
+以增量方式進行遷移是個好的選擇：
+如果您覺得在一次轉換到程式碼生成語法的*同時*實現此遷移可能太麻煩了，*別勉強*。
+
+<!---
+Following this guide, you *can* migrate towards codegen as a further step forward, later on.
+-->
+按照本指南，您*可以*稍後做進一步的遷移到程式碼生成。
+
+[getting started]: /docs/introduction/getting_started
+[sandbox]: https://dartpad.dev/?null_safety=true&id=ef06ab3ce0b822e6cc5db0575248e6e2
+[provider]: https://pub.dev/packages/provider
+[ChangeNotifierProvider]: /docs/providers/change_notifier_provider
+[Code generation]: /docs/concepts/about_code_generation
+[Riverpod's providers]: /docs/providers/notifier_provider
+[are composable by default]: /docs/from_provider/motivation#combining-providers-is-hard-and-error-prone
+[as mentioned above]: /docs/from_provider/quickstart#start-with-changenotifierprovider
+[Riverpod's `Consumer` APIs]: /docs/concepts/reading
+[lazy by default]: /docs/concepts/provider_lifecycles
+
+[入門指南]: /docs/introduction/getting_started
+[沙盒]: https://dartpad.dev/?null_safety=true&id=ef06ab3ce0b822e6cc5db0575248e6e2
+<!--- TODO(yang-lile): 記得修復連結 -->
+[預設是可組合的]: /docs/from_provider/motivation#combining-providers-is-hard-and-error-prone
+[如上所述]: /docs/from_provider/quickstart#從-changenotifierprovider-開始
+[Riverpod 的 `Consumer` API]: /docs/concepts/reading
+[預設是懶載入的]: /docs/concepts/provider_lifecycles
+[程式碼生成]: /docs/concepts/about_code_generation
+[Riverpod 的提供者程式]: /docs/providers/notifier_provider

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/getting_started.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/getting_started.mdx
@@ -1,0 +1,296 @@
+---
+title: 入門指南
+pagination_next: essentials/first_request
+version: 4
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+import pubspec from "./getting_started/pubspec";
+import dartHelloWorld from "/docs/introduction/getting_started/dart_hello_world";
+import pubadd from "./getting_started/pub_add";
+import helloWorld from "/docs/introduction/getting_started/hello_world";
+import dartPubspec from "./getting_started/dart_pubspec";
+import dartPubadd from "./getting_started/dart_pub_add";
+import {
+  AutoSnippet,
+  When,
+} from "@site/src/components/CodeSnippet";
+import { Link } from "@site/src/components/Link";
+
+<!---
+## Try Riverpod online
+-->
+## 線上嘗試 Riverpod
+
+<!---
+To get a feel of Riverpod, try it online on [Dartpad](https://dartpad.dev/?null_safety=true&id=ef06ab3ce0b822e6cc5db0575248e6e2)
+or on [Zapp](https://zapp.run/new):
+-->
+要嘗試 Riverpod，請在 [Dartpad](https://dartpad.dev/?null_safety=true&id=ef06ab3ce0b822e6cc5db0575248e6e2) 
+或 [Zapp](https://zapp.run/new) 上線上試用：
+
+<iframe
+  src="https://zapp.run/edit/zv2060sv306?theme=dark&lazy=false"
+  style={{ width: "100%", border: 0, overflow: "hidden", aspectRatio: "1.5" }}
+></iframe>
+
+<!---
+## Installing the package
+-->
+## 安裝包
+
+<!---
+Once you know what package you want to install, proceed to add the dependency to your app in a single line like this:
+-->
+知道要安裝哪個包後，請繼續在一行中將依賴項新增到應用，如下所示：
+
+<Tabs
+  groupId="riverpod"
+  defaultValue="flutter_riverpod"
+  values={[
+    { label: 'Flutter', value: 'flutter_riverpod', },
+    { label: 'Dart only', value: 'riverpod', },
+  ]}
+>
+<TabItem value="flutter_riverpod">
+
+<AutoSnippet {...pubadd}></AutoSnippet>
+
+</TabItem>
+
+<TabItem value="riverpod">
+
+<AutoSnippet {...dartPubadd}></AutoSnippet>
+
+</TabItem>
+
+</Tabs>
+
+<!---
+Alternatively, you can manually add the dependency to your app from within your `pubspec.yaml`:
+-->
+或者，您可以從以下 pubspec.yaml 位置手動將依賴項新增到您的應用：
+
+<Tabs
+  groupId="riverpod"
+  defaultValue="flutter_riverpod"
+  values={[
+    { label: 'Flutter', value: 'flutter_riverpod', },
+    { label: 'Dart only', value: 'riverpod', },
+  ]}
+>
+<TabItem value="flutter_riverpod">
+
+<AutoSnippet title="pubspec.yaml" language="yaml" {...pubspec}></AutoSnippet>
+
+<!---
+Then, install packages with `flutter pub get`.
+-->
+然後，使用 `flutter pub get` 安裝包。
+
+<!---
+<When codegen={true}>
+  You can now run the code-generator with{" "}
+  <code>dart run build_runner watch</code>.
+</When>
+-->
+<When codegen={true}>
+  現在你可以執行程式碼生成工具 {" "} 
+  <code>dart run build_runner watch</code>.
+</When>
+
+</TabItem>
+<TabItem value="riverpod">
+
+<AutoSnippet
+  title="pubspec.yaml"
+  language="yaml"
+  {...dartPubspec}
+></AutoSnippet>
+
+<!---
+Then, install packages with `dart pub get`.
+-->
+然後，使用 `dart pub get` 安裝包。
+
+<!---
+<When codegen={true}>
+  You can now run the code-generator with{" "}
+  <code>flutter pub run build_runner watch</code>.
+</When>
+-->
+<When codegen={true}>
+  現在你可以執行程式碼生成工具 {" "} 
+  <code>dart run build_runner watch</code>.
+</When>
+
+</TabItem>
+</Tabs>
+
+<!---
+That's it. You've added [Riverpod] to your app!
+-->
+就是這樣。你已將 [Riverpod] 新增到你的應用中！
+
+<!---
+## Enabling riverpod_lint/custom_lint
+-->
+## 啟用 riverpod_lint/custom_lint
+
+<!---
+Riverpod comes with an optional [riverpod_lint]
+package that provides lint rules to help you write better code, and
+provide custom refactoring options.
+-->
+Riverpod 附帶一個可選的 riverpod_lint 包，
+該包提供 lint 規則以幫助您編寫更好的程式碼，
+並提供自定義重構選項。
+
+<!---
+The package should already be installed if you followed the previous steps, but a
+separate step is necessary to enable it.
+-->
+如果按照前面的步驟操作，則應該已經安裝了該包，
+但需要單獨的步驟才能啟用它。
+
+<!---
+To enable [riverpod_lint], you need add an `analysis_options.yaml` placed next to
+your `pubspec.yaml` and include the following:
+-->
+要啟用riverpod_lint，您需要在 `pubspec.yaml` 檔案的旁邊新增一個
+`analysis_options.yaml` 檔案，幷包含以下內容：
+
+<CodeBlock language="yaml" title="analysis_options.yaml">
+  {`analyzer:
+  plugins:
+    - custom_lint`}
+</CodeBlock>
+
+<!---
+You should now see warnings in your IDE if you made mistakes when using Riverpod
+in your codebase.
+-->
+現在，如果在程式碼庫中使用 Riverpod 時出錯，您應該會在 IDE 中看到警告。
+
+<!---
+To see the full list of warnings and refactorings, head to the [riverpod_lint] page.
+-->
+要檢視警告和重構的完整列表，請前往 [riverpod_lint] 頁面。
+
+<!---
+:::note
+Those warnings will not show-up in the `dart analyze` command.  
+If you want to check those warnings in the CI/terminal, you can run the following:
+-->
+:::note
+這些警告不會顯示在 `dart analyze` 命令的結果中。
+如果要在 CI 或終端中檢查這些警告，可以執行以下命令：
+
+```sh
+dart run custom_lint
+```
+
+:::
+
+<!---
+## Usage example: Hello world
+-->
+## 使用示例：Hello world
+
+<!---
+Now that we have installed [Riverpod], we can start using it.
+-->
+現在我們已經安裝了 [Riverpod]，我們可以開始使用它了。
+
+<!---
+The following snippets showcase how to use our new dependency to make a "Hello world":
+-->
+以下程式碼片段展示瞭如何使用我們的新依賴項來建立 “Hello world”：
+
+export const foo = 42;
+
+<Tabs
+  groupId="riverpod"
+  defaultValue="flutter_riverpod"
+  values={[
+    { label: "Flutter", value: "flutter_riverpod" },
+    { label: "Dart only", value: "riverpod" },
+  ]}
+>
+<TabItem value="flutter_riverpod">
+
+<AutoSnippet
+  title="lib/main.dart"
+  language="dart"
+  {...helloWorld}
+></AutoSnippet>
+
+<!---
+Then, start the application with `flutter run`.  
+This will render "Hello world" on your device.
+-->
+然後，使用 `flutter run` 啟動應用程式。  
+這將在您的裝置上呈現 “Hello world”。
+
+</TabItem>
+<TabItem value="riverpod">
+
+<AutoSnippet
+  title="lib/main.dart"
+  language="dart"
+  {...dartHelloWorld}
+></AutoSnippet>
+
+<!---
+Then, start the application with `dart lib/main.dart`.  
+This will print "Hello world" in the console.
+-->
+然後，使用 `dart lib/main.dart` 啟動應用程式。  
+這將在控制檯中列印 “Hello world”。
+
+</TabItem>
+</Tabs>
+
+<!---
+## Going further: Installing code snippets
+-->
+## 更進一步：安裝程式碼片段
+
+<!---
+If you are using `Flutter` and `VS Code` , consider using [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robert-brunhage.flutter-riverpod-snippets)
+-->
+如果你使用的 `Flutter` 是 `VS Code` ，請考慮使用 [Flutter Riverpod Snippets](https://marketplace.visualstudio.com/items?itemName=robert-brunhage.flutter-riverpod-snippets)
+
+<!---
+If you are using `Flutter` and `Android Studio` or `IntelliJ`, consider using [Flutter Riverpod Snippets](https://plugins.jetbrains.com/plugin/14641-flutter-riverpod-snippets)
+-->
+如果您使用的 `Flutter` 是 `Android Studio` 或 `IntelliJ` ，請考慮使用 [Flutter Riverpod Snippets](https://plugins.jetbrains.com/plugin/14641-flutter-riverpod-snippets)
+
+![img](/img/snippets/greetingProvider.gif)
+
+<!---
+## Choose your next step
+-->
+## 選擇你的下一步
+
+<!---
+Learn some basic concepts:
+-->
+瞭解一些基本概念：
+
+- <Link documentID="concepts/providers" />
+
+<!---
+Follow a cookbook:
+-->
+跟著教程走：
+
+- <Link documentID="cookbooks/testing" />
+
+[riverpod]: https://github.com/rrousselgit/riverpod
+[hooks_riverpod]: https://pub.dev/packages/hooks_riverpod
+[flutter_riverpod]: https://pub.dev/packages/flutter_riverpod
+[flutter_hooks]: https://github.com/rrousselGit/flutter_hooks
+[riverpod_lint]: https://pub.dev/packages/riverpod_lint

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/getting_started/dart_pub_add.tsx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/getting_started/dart_pub_add.tsx
@@ -1,0 +1,32 @@
+export function buildDeps({
+  deps = [],
+  devDeps = [],
+}: {
+  deps?: string[];
+  devDeps?: string[];
+}) {
+  var result = "";
+  for (const dep of deps) {
+    result += `dart pub add ${dep}\n`;
+  }
+
+  for (const dep of [...devDeps, "custom_lint", "riverpod_lint"]) {
+    result += `dart pub add dev:${dep}\n`;
+  }
+
+  return result;
+}
+
+const raw = buildDeps({ deps: ["riverpod"] });
+
+const codegen = buildDeps({
+  deps: ["riverpod", "riverpod_annotation"],
+  devDeps: ["riverpod_generator", "build_runner"],
+});
+
+export default {
+  raw,
+  hooks: raw,
+  codegen,
+  hooksCodegen: codegen,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/getting_started/dart_pubspec.tsx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/getting_started/dart_pubspec.tsx
@@ -1,0 +1,40 @@
+import {
+  riverpodVersion,
+  riverpodAnnotationVersion,
+  riverpodGeneratorVersion,
+  riverpodLintVersion,
+} from "@site/src/versions";
+
+const codegen = `name: my_app_name
+environment:
+  sdk: ^3.6.0
+
+dependencies:
+  riverpod: ^${riverpodVersion}
+  riverpod_annotation: ^${riverpodAnnotationVersion}
+
+dev_dependencies:
+  build_runner:
+  custom_lint:
+  riverpod_generator: ^${riverpodGeneratorVersion}
+  riverpod_lint: ^${riverpodLintVersion}
+`;
+
+const raw = `name: my_app_name
+environment:
+  sdk: ^3.6.0
+
+dependencies:
+  riverpod: ^${riverpodVersion}
+
+dev_dependencies:
+  custom_lint:
+  riverpod_lint: ^${riverpodLintVersion}
+`;
+
+export default {
+  raw,
+  hooks: raw,
+  codegen,
+  hooksCodegen: codegen,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/getting_started/pub_add.tsx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/getting_started/pub_add.tsx
@@ -1,0 +1,39 @@
+export function buildDeps({
+  deps = [],
+  devDeps = [],
+}: {
+  deps?: string[];
+  devDeps?: string[];
+}) {
+  var result = '';
+  for (const dep of deps) {
+    result += `flutter pub add ${dep}\n`;
+  }
+
+  for (const dep of [...devDeps, "custom_lint", "riverpod_lint"]) {
+    result += `flutter pub add dev:${dep}\n`;
+  }
+
+  return result;
+}
+
+const raw = buildDeps({ deps: ["flutter_riverpod"] });
+
+const codegen = buildDeps({
+  deps: ["flutter_riverpod", "riverpod_annotation"],
+  devDeps: ["riverpod_generator", "build_runner"],
+});
+
+const hooks = buildDeps({ deps: ["hooks_riverpod", "flutter_hooks"] });
+
+const hooksCodegen = buildDeps({
+  deps: ["hooks_riverpod", "flutter_hooks", "riverpod_annotation"],
+  devDeps: ["riverpod_generator", "build_runner"],
+});
+
+export default {
+  raw: raw,
+  hooks: hooks,
+  codegen: codegen,
+  hooksCodegen: hooksCodegen,
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/getting_started/pubspec.tsx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/getting_started/pubspec.tsx
@@ -1,0 +1,51 @@
+import {
+  flutterRiverpodVersion,
+  hooksRiverpodVersion,
+  riverpodAnnotationVersion,
+  riverpodGeneratorVersion,
+  riverpodLintVersion,
+} from "@site/src/versions";
+
+function plain(riverpod: string) {
+  return `name: my_app_name
+environment:
+  sdk: ^3.6.0
+  flutter: ">=3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  ${riverpod}
+
+dev_dependencies:
+  custom_lint:
+  riverpod_lint: ^${riverpodLintVersion}
+`;
+}
+
+function codegen(riverpod: string) {
+  return `name: my_app_name
+environment:
+  sdk: ^3.6.0
+  flutter: ">=3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  ${riverpod}
+  riverpod_annotation: ^${riverpodAnnotationVersion}
+
+dev_dependencies:
+  build_runner:
+  custom_lint:
+  riverpod_generator: ^${riverpodGeneratorVersion}
+  riverpod_lint: ^${riverpodLintVersion}
+`;
+}
+
+export default {
+  raw: plain(`flutter_riverpod: ^${flutterRiverpodVersion}`),
+  hooks: plain(`hooks_riverpod: ^${hooksRiverpodVersion}\n  flutter_hooks:`),
+  codegen: codegen(`flutter_riverpod: ^${flutterRiverpodVersion}`),
+  hooksCodegen: codegen(`hooks_riverpod: ^${hooksRiverpodVersion}\n  flutter_hooks:`),
+};

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/why_riverpod.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/introduction/why_riverpod.mdx
@@ -1,0 +1,125 @@
+---
+title: 為什麼選擇 Riverpod？
+version: 1
+---
+
+import whyRiverpod from "/docs/introduction/why_riverpod";
+import { AutoSnippet } from "@site/src/components/CodeSnippet";
+
+<!---
+## What is Riverpod?
+-->
+## 什麼是 Riverpod？
+
+<!---
+Riverpod (anagram of [Provider](https://pub.dev/packages/provider)) is a reactive
+caching framework for Flutter/Dart.
+-->
+Riverpod（[Provider](https://pub.dev/packages/provider) 的異序詞）是 Flutter/Dart 的反應式快取框架。
+
+<!---
+Using declarative and reactive programming, Riverpod takes care of
+a large part of your application's logic for you. It can perform network-requests
+with built-in error handling and caching, while automatically re-fetching
+data when necessary.
+-->
+Riverpod 使用宣告式和反應式程式設計，為您處理應用程式的大部分邏輯。
+它可以透過內建的錯誤處理和快取來執行網路請求，同時在必要時自動重新獲取資料。
+
+<!---
+## Motivation
+-->
+## 動機
+
+<!---
+Modern applications rarely come with all the information necessary to render
+their User Interface. Instead, the data is often fetched asynchronously
+from a server.
+-->
+現代應用程式很少提供呈現其使用者介面所需的所有資訊。
+相反，資料通常是從伺服器非同步獲取的。
+
+<!---
+The problem is, working with asynchronous code is hard. Although Flutter comes
+with some way to create state variables and refresh the UI on change, it is still
+fairly limited. A number of challenges remain unsolved:
+-->
+問題是，使用非同步程式碼很困難。
+儘管 Flutter 提供了一些建立狀態變數並在更改時重新整理 UI 的方法，但它仍然相當有限。
+許多挑戰仍未解決：
+
+<!---
+- Asynchronous requests need to be cached locally, as it would be unreasonable
+  to re-execute them whenever the UI updates.
+- Since we have a cache, our cache could get out of date if we're not careful.
+- We also need to handle errors and loading states
+-->
+- 非同步請求需要在本地快取，因為每當 UI 更新時就重新執行非同步請求是不合理的。
+- 由於我們有一個快取，如果我們不關心的話，我們的快取可能會過時。
+- 我們還需要處理錯誤和載入狀態。
+
+<!---
+Nailing those problems at scale can be difficult, and they are impacted by a large
+amount of features, such as:
+-->
+大規模解決這些問題可能很困難，並且它們會受到大量功能的影響，例如：
+
+<!---
+- pull to refresh
+- infinite lists / fetch as we scroll
+- search as we type
+- debouncing asynchronous requests
+- cancelling asynchronous requests when no-longer used
+- optimistic UIs
+- offline mode
+- ...
+-->
+- 下拉重新整理
+- 無限列表/上劃載入
+- 鍵入時搜尋
+- 對非同步請求進行去抖動
+- 不再使用非同步請求時取消非同步請求
+- 樂觀 UI （注：主動積極的更新 UI 以實現良好的使用者體驗）
+- 離線模式
+- ……
+
+<!---
+These features can be tricky to implement, but are crucial for a good user experience.  
+Yet few packages try to tackle those problems directly, and a lot of the work
+has to be done manually.
+-->
+這些功能可能很難實現，但對於良好的使用者體驗至關重要。  
+然而，很少有軟體包嘗試直接解決這些問題，而且很多工作必須手動完成。
+
+<!---
+That's where Riverpod comes in.  
+Riverpod tries to solve those problems, by offering a new unique
+way of writing business logic, inspired by Flutter widgets. In
+many ways Riverpod is comparable to widgets, but for state.
+-->
+這就是 Riverpod 的用武之地。  
+Riverpod 試圖透過提供一種新的、獨特的業務邏輯編寫方式來解決這些問題，
+這種方式的靈感來自 Flutter 小部件。
+在許多方面，Riverpod 可以與小部件相媲美，但僅限於狀態管理。
+
+<!---
+Using this new approach, these complex features are mostly done by default. All
+that's left is to focus on your UI.
+-->
+使用這種新方法，這些複雜的功能大多是預設完成的。
+剩下的就是專注於你的 UI。
+
+<!---
+Skeptical? Here's an example. The following snippet is a simplification of the [Pub.dev](https://github.com/rrousselGit/riverpod/tree/master/examples/pub)
+client application implemented using Riverpod.
+-->
+不信？舉個例子。
+以下程式碼片段是使用 Riverpod 實現的 Pub.dev 客戶端應用程式的簡化版本。
+
+<AutoSnippet language="dart" {...whyRiverpod}></AutoSnippet>
+
+<!---
+This snippet is all the business logic you need for a "search as we type" +
+"pull to refresh" + "infinite list", while handling error/loading states.
+-->
+此程式碼片段是在處理錯誤/載入狀態時，“鍵入時搜尋”+“下拉重新整理”+“無限列表”所需的所有業務邏輯。

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/migration/0.13.0_to_0.14.0.mdx
@@ -1,0 +1,120 @@
+---
+title: ^0.13.0 到 ^0.14.0
+---
+
+隨著 Riverpod 版本 0.14.0 的釋出，使用 [StateNotifierProvider] 的語法發生了變化
+（請參閱 https://github.com/rrousselGit/riverpod/issues/341 瞭解詳細解釋）。
+
+在整篇文章中，請考慮以下的 [StateNotifier]:
+
+```dart
+class MyModel {}
+
+class MyStateNotifier extends StateNotifier<MyModel> {
+  MyStateNotifier(): super(MyModel());
+}
+```
+
+## The changes
+
+- [StateNotifierProvider] 添加了一個額外的泛型引數，該引數應該是您的 [StateNotifier]狀態的型別。
+
+  之前:
+
+  ```dart
+  final provider = StateNotifierProvider<MyStateNotifier>((ref) {
+    return MyStateNotifier();
+  });
+  ```
+
+  之後:
+
+  ```dart
+  final provider = StateNotifierProvider<MyStateNotifier, MyModel>((ref) {
+    return MyStateNotifier();
+  });
+  ```
+
+- 為了獲取 [StateNotifier] ，您現在應該使用 `myProvider.notifier` 而不是僅僅使用 `myProvider`：
+
+  之前:
+
+  ```dart
+  Widget build(BuildContext context, ScopedReader watch) {
+    MyStateNotifier notifier = watch(provider);
+  }
+  ```
+
+  之後:
+
+  ```dart
+  Widget build(BuildContext context, ScopedReader watch) {
+    MyStateNotifier notifier = watch(provider.notifier);
+  }
+  ```
+
+- 為了監聽 [StateNotifier] 的狀態，您現在應該使用 `myProvider` 而不是 `myProvider.state`：
+
+  Before:
+
+  ```dart
+  Widget build(BuildContext context, ScopedReader watch) {
+    MyModel state = watch(provider.state);
+  }
+  ```
+
+  After:
+
+  ```dart
+  Widget build(BuildContext context, ScopedReader watch) {
+    MyModel state = watch(provider);
+  }
+  ```
+
+## 使用遷移工具自動升級專案到新的語法
+
+隨著 0.14.0 版本的釋出，Riverpod 推出了一個命令列工具，可以幫助您遷移專案。
+
+### 安裝命令列工具
+
+要安裝遷移工具，請執行：
+
+```sh
+dart pub global activate riverpod_cli
+```
+
+現在您應該能夠執行：
+
+```sh
+riverpod --help
+```
+
+### 使用說明
+
+既然命令列工具已經安裝，我們可以開始使用它了。
+
+- 首先，在終端中開啟您想要遷移的專案。
+- **不要** 升級 Riverpod.  
+  遷移工具會為您升級 Riverpod 的版本。
+- 確保您的專案不包含錯誤。
+- 執行：
+  ```sh
+  riverpod migrate
+  ```
+
+然後，該工具將分析您的專案並提出更改建議。例如，您可能會看到：
+
+```diff
+Widget build(BuildContext context, ScopedReader watch) {
+-  MyModel state = watch(provider.state);
++  MyModel state = watch(provider);
+}
+
+Accept change (y = yes, n = no [default], A = yes to all, q = quit)? 
+```
+
+要接受更改，只需按 <kbd>y</kbd> 鍵。否則，要拒絕更改，按 <kbd>n</kbd> 鍵。
+
+
+[statenotifierprovider]: ../providers/state_notifier_provider
+[statenotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/migration/0.14.0_to_1.0.0.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/migration/0.14.0_to_1.0.0.mdx
@@ -1,0 +1,226 @@
+---
+title: ^0.14.0 到 ^1.0.0
+---
+
+import { Link } from "@site/src/components/Link";
+
+
+經過漫長的等待，Riverpod 迎來了首個穩定版本的釋出 👏
+
+要檢視完整的變更列表，請參閱 [Changelog](https://pub.dev/packages/flutter_riverpod/changelog#100).  
+在本頁面中，我們將重點介紹如何將現有的 Riverpod 應用程式從版本 0.14.x 遷移到版本 1.0.0。
+
+## 使用遷移工具自動升級專案到新的語法
+
+在解釋各種變更之前，值得注意的是，Riverpod 提供了一個命令列工具，可以自動為您的專案進行遷移。
+
+### 安裝命令列工具
+
+要安裝遷移工具，請執行：
+
+```sh
+dart pub global activate riverpod_cli
+```
+
+現在您應該能夠執行：
+
+```sh
+riverpod --help
+```
+
+### 使用說明
+
+既然命令列工具已經安裝，我們可以開始使用它了。
+
+- 首先，在終端中開啟您想要遷移的專案。
+- **不用** 升級 Riverpod.  
+  遷移工具將會為您升級 Riverpod 的版本。
+
+  :::danger
+  不升級 Riverpod 非常重要。  
+  如果您已經安裝了版本 1.0.0，該工具將無法正常執行。因此，請確保在啟動工具之前正確使用較舊的版本。
+  :::
+
+- 確保您的專案不包含錯誤。
+- 執行
+  ```sh
+  riverpod migrate
+  ```
+
+然後，該工具將分析您的專案並提出更改建議。例如，您可能會看到：
+
+```diff
+-Widget build(BuildContext context, ScopedReader watch) {
++Widget build(BuildContext context, Widget ref) {
+-  MyModel state = watch(provider);
++  MyModel state = ref.watch(provider);
+}
+
+Accept change (y = yes, n = no [default], A = yes to all, q = quit)?
+```
+
+要接受更改，只需按 <kbd>y</kbd> 鍵。否則，要拒絕更改，按 <kbd>n</kbd> 鍵.
+
+## 變更內容
+
+現在我們已經瞭解瞭如何使用命令列工具自動升級專案，讓我們詳細看看所需的更改。
+
+
+### 語法統一
+
+Riverpod 1.0.0 版本主要關注與提供程式互動的語法統一。  
+在此之前，Riverpod 對於讀取提供程式有許多類似但不同的語法，
+例如 `ref.watch(provider)` 與 `useProvider(provider)` 與 `watch(provider)`。  
+在版本 1.0.0 中，只剩下一種語法： `ref.watch(provider)`。其他的語法已經被移除。
+
+例如：
+
+- `useProvider` 已被移除，而推薦使用 `HookConsumerWidget`。
+
+  之前:
+
+  ```dart
+  class Example extends HookWidget {
+    @override
+    Widget build(BuildContext context) {
+      useState(...);
+      int count = useProvider(counterProvider);
+      ...
+    }
+  }
+  ```
+
+  之後:
+
+  ```dart
+  class Example extends HookConsumerWidget {
+    @override
+    Widget build(BuildContext context, WidgetRef ref) {
+      useState(...);
+      int count = ref.watch(counterProvider);
+      ...
+    }
+  }
+  ```
+
+- 在 `ConsumerWidget` 的 `build` 方法和 `Consumer` 的 `builder` 方法原型發生了變化.
+ 
+  之前:
+
+  ```dart
+  class Example extends ConsumerWidget {
+    @override
+    Widget build(BuildContext context, ScopedReader watch) {
+      int count = watch(counterProvider);
+      ...
+    }
+  }
+
+  Consumer(
+    builder: (context, watch, child) {
+      int count = watch(counterProvider);
+      ...
+    }
+  )
+  ```
+
+  之後:
+
+  ```dart
+  class Example extends ConsumerWidget {
+    @override
+    Widget build(BuildContext context, WidgetRef ref) {
+      int count = ref.watch(counterProvider);
+      ...
+    }
+  }
+
+  Consumer(
+    builder: (context, ref, child) {
+      int count = ref.watch(counterProvider);
+      ...
+    }
+  )
+  ```
+
+- `context.read` 被移除，取而代之的是 `ref.read` 。
+
+  之前:
+
+  ```dart
+  class Example extends StatelessWidget {
+    @override
+    Widget build(BuildContext context) {
+      SomeButton(
+        onPressed: () => context.read(provider.notifier).doSomething(),
+      );
+    }
+  }
+  ```
+
+  之後:
+
+  ```dart
+  class Example extends ConsumerWidget {
+    @override
+    Widget build(BuildContext context, WidgetRef ref) {
+      SomeButton(
+        onPressed: () => ref.read(provider.notifier).doSomething(),
+      );
+    }
+  }
+  ```
+
+### StateProvider 更新
+
+[StateProvider] 已更新以匹配 [StateNotifierProvider]。
+
+在更新之前，使用 `ref.watch(StateProvider)` 會返回一個 `StateController` 例項。
+現在它只返回 `StateController` 的狀態。
+
+要進行遷移，有幾種解決方案。  
+如果您的程式碼僅獲取狀態而不修改它，可以從：
+
+```dart
+final provider = StateProvider<int>(...);
+
+Consumer(
+  builder: (context, ref, child) {
+    StateController<int> count = ref.watch(provider);
+
+    return Text('${count.state}');
+  }
+)
+```
+
+變到:
+
+```dart
+final provider = StateProvider<int>(...);
+
+Consumer(
+  builder: (context, ref, child) {
+    int count = ref.watch(provider);
+
+    return Text('${count}');
+  }
+)
+```
+
+或者，您可以使用新的 `StateProvider.state` 來保持舊的行為。
+
+```dart
+final provider = StateProvider<int>(...);
+
+Consumer(
+  builder: (context, ref, child) {
+    StateController<int> count = ref.watch(provider.state);
+
+    return Text('${count.state}');
+  }
+)
+```
+
+[statenotifierprovider]: ../providers/state_notifier_provider
+[stateprovider]: ../providers/state_provider
+[statenotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/migration/from_change_notifier.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/migration/from_change_notifier.mdx
@@ -1,0 +1,259 @@
+---
+title: 從 `ChangeNotifier` 遷移
+---
+
+import old from "!!raw-loader!/docs/migration/from_change_notifier/old.dart";
+import declaration from "/docs/migration/from_change_notifier/declaration";
+import initialization from "/docs/migration/from_change_notifier/initialization";
+import migrated from "/docs/migration/from_change_notifier/migrated";
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet } from "@site/src/components/CodeSnippet";
+
+
+<!---
+Within Riverpod, `ChangeNotifierProvider` is meant to be used to offer a smooth transition from
+pkg:provider.
+-->
+在 Riverpod 中，`ChangeNotifierProvider` 用於提供從 pkg:provider 的平滑過渡。
+
+<!---
+If you've just started a migration to pkg:riverpod, make sure you read the dedicated guide
+(see <Link documentID="from_provider/quickstart" />).
+This article is meant for folks that already transitioned to riverpod, but want to move away from
+`ChangeNotifier` definetively.
+-->
+如果您剛剛開始遷移到 pkg:riverpod，請務必閱讀專用指南
+（請參閱<Link documentID="from_provider/quickstart" />）。
+本文適用於已經過渡到 Riverpod，但想要徹底放棄 `ChangeNotifier` 的人們。
+
+<!---
+All in all, migrating from `ChangeNotifier` to `AsyncNotifer` requires a
+paradigm shift, but it brings great simplification with the resulting migrated
+code. See also <Link documentID="concepts/why_immutability" />.
+-->
+總而言之，從 `ChangeNotifier` 遷移到 `AsyncNotifer` 需要正規化轉換，
+但它極大地簡化了遷移後的程式碼。
+另請參閱<Link documentID="concepts/why_immutability" />。
+
+<!---
+Take this (faulty) example:
+-->
+以這個（錯誤的）例子為例：
+<AutoSnippet raw={old} />
+
+<!---
+This implementation shows several weak design choices such as:
+- The usage of `isLoading` and `hasError` to handle different asynchronous cases
+- The need to carefully handle requests with tedious `try`/`catch`/`finally` expressions
+- The need to inkove `notifyListeners` at the right times to make this implementation work
+- The presence of inconsistent or possibly undesirable states, e.g. initialization with an empty list
+-->
+該實現顯示了幾個薄弱的設計選擇，例如：
+- 使用 `isLoading` 和 `hasError` 處理不同的非同步情況
+- 需要仔細處理帶有繁瑣的 `try`/`catch`/`finally` 表示式的請求
+- 需要在正確的時間呼叫 `notifyListeners` 才能使此實現發揮作用
+- 存在不一致或可能不需要的狀態，例如使用空列表進行初始化
+
+<!---
+Note how this example has been crafted to show how `ChangeNotifier` can lead to faulty design choices
+for newbie developers; also, another takeaway is that mutable state might be way harder than it
+initially promises.
+-->
+請注意這個示例是如何精心設計的，以向新手開發人員展示 `ChangeNotifier`
+如何導致錯誤的設計方案；此外，另一個要點是可變狀態可能比最初承諾的要困難得多。
+
+<!---
+`Notifier`/`AsyncNotifer`, in combination with immutable state, can lead to better design choices
+and less errors.
+-->
+`Notifier`/`AsyncNotifer` 與不可變狀態相結合，
+可以帶來更好的設計方案和更少的錯誤。
+
+<!---
+Let's see how to migrate the above snippet, one step at a time, towards the newest APIs.
+-->
+讓我們看看如何將上述程式碼片段一步一步遷移到最新的 API。
+
+
+<!---
+## Start your migration
+-->
+## 開始遷移​
+<!---
+First, we should declare the new provider / notifier: this requires some thought process which
+depends on your unique business logic.
+-->
+首先，我們應該宣告新的提供者程式/通知者程式：這需要一些思維過程，這取決於您獨特的業務邏輯。
+
+<!---
+Let's summarize the above requirements:
+- State is represented with `List<Todo>`, which obtained via a network call, with no parameters
+- State should *also* expose info about its `loading`, `error` and `data` state
+- State can be mutated via some exposed methods, thus a function isn't enough
+-->
+我們總結一下上面的要求：
+- 狀態用 `List<Todo>` 表示，透過網路呼叫獲得，不帶引數
+- 狀態還應該公開有關其 `loading`、`error` 和 `data` 狀態的資訊
+- 狀態可以透過一些公開的方法進行改變，因此一個函式是不夠的
+
+:::tip
+<!---
+The above thought process boils down to answering the following questions:
+1. Are some side effects required?
+    - `y`: Use riverpod's class-based API
+    - `n`: Use riverpod's function-based API
+2. Does state need to be loaded asynchronously?
+    - `y`: Let `build` return a `Future<T>`
+    - `n`: Let `build` simply return `T`
+3. Are some parameters required?
+    - `y`: Let `build` (or your function) accept them
+    - `n`: Let `build` (or your function) accept no extra parameters
+-->
+上述思考過程歸結為回答以下問題：
+1. 是否需要一些副作用？
+    - `y`：使用 Riverpod 的基於類的 API
+    - `n`：使用 Riverpod 的基於函式的 API
+1. State 需要非同步載入嗎？
+    - `y`：讓 `build` 返回 `Future<T>`
+    - `n`：讓 `build` 簡單地返回 `T`
+1. 是否需要一些引數？
+    - `y`：讓 `build` （或你的函式）接受它們
+    - `n`：讓 `build` （或你的函式）不接受額外的引數
+:::
+
+:::info
+<!---
+If you're using codegen, the above thought process is enough.  
+There's no need to think about the right class names and their *specific* APIs.  
+`@riverpod` only asks you to write a class with its return type, and you're good to go.
+-->
+如果您使用的是 codegen，上述思考過程就足夠了。  
+無需考慮正確的類名及其*特定*的 API。  
+`@riverpod` 僅要求您編寫一個具有返回型別的類，然後就可以開始了。
+:::
+
+<!---
+Technically, the best fit here is to define a `AutoDisposeAsyncNotifier<List<Todo>>`,
+which meets all the above requirements. Let's write some pseudocode first.
+-->
+從技術上講，這裡最合適的是定義一個 `AutoDisposeAsyncNotifier<List<Todo>>`，
+它滿足上述所有要求。讓我們先寫一些虛擬碼。
+
+<AutoSnippet language="dart" {...declaration}></AutoSnippet>
+
+:::tip
+<!---
+Remember: use snippets in your IDE to get some guidance, or just to speed up your code writing.
+See <Link documentID="introduction/getting_started" hash="going-further-installing-code-snippets" />.
+-->
+請記住：在 IDE 中使用程式碼片段可以獲得一些指導，或者只是為了加快程式碼編寫速度。
+請參閱<Link documentID="introduction/getting_started" hash="going-further-installing-code-snippets" />。
+:::
+
+<!---
+With respect with `ChangeNotifier`'s implementation, we don't need to declare `todos` anymore;
+such variable is `state`, which is implicitly loaded with `build`.
+-->
+考慮到 `ChangeNotifier` 的實現，我們不再需要宣告 `todos`；
+這樣的變數是 `state`，它是用 `build` 隱式載入的。
+
+<!---
+Indeed, riverpod's notifiers can expose *one* entity at a time.
+-->
+事實上，Riverpod 的通知者程式一次可以暴露*一個*實體。
+
+:::tip
+<!---
+Riverpod's API is meant to be granular; nonetheless, when migrating, you can still define a custom
+entity to hold multiple values. Consider using [Dart 3's records](https://dart.dev/language/records)
+to smooth out the migration at first.
+-->
+Riverpod 的 API 是細粒度的；儘管如此，在遷移時，
+您仍然可以定義自定義實體來儲存多個值。首先考慮使用 [Dart 3 的記錄](https://dart.dev/language/records)
+來平滑遷移。
+:::
+
+
+<!---
+### Initialization
+-->
+### 初始化​
+<!---
+Initalizing a notifier is easy: just write initialization logic inside `build`.  
+We can now get rid of the old `_init` function.
+-->
+初始化通知者程式很簡單：只需在 `build` 內編寫初始化邏輯即可。  
+我們現在可以擺脫舊的 `_init` 函式。
+
+<AutoSnippet language="dart" {...initialization}></AutoSnippet>
+
+<!---
+With respect of the old `_init`, the new `build` isn't missing anything: there is no need to
+initialize variables such as `isLoading` or `hasError` anymore.
+-->
+相對於舊的 `_init` ，新的 `build` 沒有丟失任何內容：
+不需要初始化 `isLoading` 或 `hasError`
+
+<!---
+Riverpod will automatically translate any asynchronous provider, via exposing an `AsyncValue<List<Todo>>`
+and handles the intricacies of asynchronous state way better than what two simple boolean flags can do.
+-->
+Riverpod 將透過公開 `AsyncValue<List<Todo>>` 自動轉換任何非同步提供者程式，
+並比兩個簡單的布林標誌更好地處理非同步狀態的複雜性。
+
+<!---
+Indeed, any `AsyncNotifier` effectively makes writing additional `try`/`catch`/`finally` an anti-pattern
+for handling asynchronous state.
+-->
+事實上，任何 `AsyncNotifier` 都會有效地使編寫額外的 `try`/`catch`/`finally` 成為處理非同步狀態的反模式。
+
+
+<!---
+### Mutations and Side Effects
+-->
+### 突變和副作用​
+<!---
+Just like initialization, when performing side effects there's no need to manipulate boolean flags
+such as `hasError`, or to write additional `try`/`catch`/`finally` blocks.
+-->
+就像初始化一樣，執行副作用時，無需操作布林標誌，
+例如 `hasError`，或編寫額外的 `try`/`catch`/`finally`
+
+<!---
+Below, we've cut down all the boilerplate and successfully fully migrated the above example:
+-->
+下面，我們刪除了所有樣板檔案併成功完全遷移了上面的示例：
+<AutoSnippet language="dart" {...migrated} />
+
+:::tip
+<!---
+Syntax and design choices may vary, but in the end we just need to write our request and update
+state afterwards. See <Link documentID="essentials/side_effects" />.
+-->
+語法和設計方案可能會有所不同，但最終我們只需要編寫我們的請求並隨後更新狀態。
+請參閱<Link documentID="essentials/side_effects" />。
+:::
+
+<!---
+## Migration Process Summary
+-->
+## 遷移過程總結
+
+<!---
+Let's review the whole migration process applied above, from a operational point of view.
+-->
+讓我們從操作的角度回顧一下上面應用的整個遷移過程。
+
+<!---
+1. We've moved the initialization, away from a custom method invoked in a constructor, to `build`
+2. We've removed `todos`, `isLoading` and `hasError` properties: internal `state` will suffice
+3. We've removed any `try`-`catch`-`finally` blocks: returning the future is enough
+4. We've applied the same simplification on the side effects (`addTodo`)
+5. We've applied the mutations, via simply reassign `state`
+-->
+1. 我們已將初始化從建構函式中呼叫的自定義方法移至 `build`
+1. 我們刪除了 `todos`、`isLoading` 和 `hasError` 屬性：內部 `state` 就足夠了
+1. 我們已經刪除了所有 `try`-`catch`-`finally` 塊：返回 Future 就足夠了
+1. 我們對副作用應用了相同的簡化（`addTodo`）
+1. 我們已經透過簡單地重新分配 `state` 應用了突變

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/migration/from_state_notifier.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/migration/from_state_notifier.mdx
@@ -1,0 +1,547 @@
+---
+title: 從 `StateNotifier` 遷移
+---
+
+import buildInit from "/docs/migration/from_state_notifier/build_init";
+import buildInitOld from "!!raw-loader!/docs/migration/from_state_notifier/build_init_old.dart";
+import consumersDontChange from "!!raw-loader!/docs/migration/from_state_notifier/consumers_dont_change.dart";
+import familyAndDispose from "/docs/migration/from_state_notifier/family_and_dispose";
+import familyAndDisposeOld from "!!raw-loader!/docs/migration/from_state_notifier/family_and_dispose_old.dart";
+import asyncNotifier from "/docs/migration/from_state_notifier/async_notifier";
+import asyncNotifierOld from "!!raw-loader!/docs/migration/from_state_notifier/async_notifier_old.dart";
+import addListener from "/docs/migration/from_state_notifier/add_listener";
+import addListenerOld from "!!raw-loader!/docs/migration/from_state_notifier/add_listener_old.dart";
+import fromStateProvider from "/docs/migration/from_state_notifier/from_state_provider";
+import fromStateProviderOld from "!!raw-loader!/docs/migration/from_state_notifier/from_state_provider_old.dart";
+import oldLifecycles from "/docs/migration/from_state_notifier/old_lifecycles";
+import oldLifecyclesOld from "!!raw-loader!/docs/migration/from_state_notifier/old_lifecycles_old.dart";
+import oldLifecyclesFinal from "/docs/migration/from_state_notifier/old_lifecycles_final";
+import obtainNotifierOnTests from "!!raw-loader!/docs/migration/from_state_notifier/obtain_notifier_on_tests.dart";
+
+import { Link } from "@site/src/components/Link";
+import { AutoSnippet } from "@site/src/components/CodeSnippet";
+
+<!---
+Along with [Riverpod 2.0](https://pub.dev/packages/flutter_riverpod/changelog#200), new classes
+were introduced: `Notifier` / `AsyncNotifer`.  
+`StateNotifier` is now discouraged in favor of those new APIs.
+-->
+與 [Riverpod 2.0](https://pub.dev/packages/flutter_riverpod/changelog#200)
+一起引入了新類： `Notifier`/`AsyncNotifer`。  
+現在不鼓勵使用 `StateNotifier`，轉而使用這些新 API。
+
+<!---
+This page shows how to migrate from the deprecated `StateNotifier` to the new APIs.
+-->
+本頁展示如何從已棄用的 `StateNotifier` 遷移到新的 API。
+
+<!---
+The main benefit introduced by `AsyncNotifier` is a better `async` support; indeed,
+`AsyncNotifier` can be thought as a `FutureProvider` which can expose ways to be modified from the UI..
+-->
+`AsyncNotifier` 帶來的主要好處是更好的 `async` 支援；事實上，
+`AsyncNotifier` 可以被認為是 `FutureProvider` ，並且具備從 UI 修改的公開方法。
+
+<!---
+Furthermore, the new `(Async)Notifier`s:
+-->
+此外，新的 (Async)Notifier：
+
+<!---
+- Expose a `Ref` object inside its class
+- Offer similar syntax between codegen and non-codegen approaches
+- Offer similar syntax between their sync and async versions
+- Move away logic from Providers and centralize it into the Notifiers themselves
+-->
+- 在其類中公開 `Ref` 物件
+- 在程式碼生成和非程式碼生成方法之間提供類似的語法
+- 在同步和非同步版本之間提供類似的語法
+- 將邏輯從提供者程式中移開，並將其集中到通知者程式本身中
+
+<!---
+Let's see how to define a `Notifier`, how it compares with `StateNotifier` and how to migrate
+the new `AsyncNotifier` for asynchronous state.
+-->
+讓我們看看如何定義 `Notifier`、它與 `StateNotifier` 的比較以及如何遷移新的
+`AsyncNotifier` 以獲得非同步狀態。
+
+<!---
+## New syntax comparison
+-->
+## 新語法比較​
+
+<!---
+Be sure to know how to define a `Notifier` before diving into this comparison.
+See <Link documentID="essentials/side_effects" hash="defining-a-notifier" />.
+-->
+在進行比較之前，請務必瞭解如何定義 `Notifier`。
+請參閱<Link documentID="essentials/side_effects" hash="defining-a-notifier" />。
+
+<!---
+Let's write an example, using the old `StateNotifier` syntax:
+-->
+讓我們使用舊的 `StateNotifier` 語法編寫一個示例：
+<AutoSnippet raw={buildInitOld}/>
+
+<!---
+Here's the same example, built with the new `Notifier` APIs, which roughly translates to:
+-->
+這是使用新的 `Notifier` API 構建的相同示例，大致可翻譯為：
+<AutoSnippet language="dart" {...buildInit}></AutoSnippet>
+
+<!---
+Comparing `Notifier` with `StateNotifier`, one can observe these main differences:
+-->
+比較 `Notifier` 與 `StateNotifier`，可以觀察到以下主要區別：
+
+<!---
+- `StateNotifier`'s reactive dependencies are declared in its provider, whereas `Notifier`
+  centralizes this logic in its `build` method
+- `StateNotifier`'s whole initialization process is split between its provider and its constructor,
+  whereas `Notifier` reserves a single place to place such logic
+- Notice how, as opposed to `StateNotifier`, no logic is ever written into a `Notifier`'s constructor
+-->
+- `StateNotifier` 的反應式依賴項在其提供者程式中宣告，而 `Notifier`
+  將此邏輯集中在其 `build` 方法中
+- `StateNotifier` 的整個初始化過程分為其提供者程式和建構函式，
+  而 `Notifier` 保留一個位置來放置此類邏輯
+- 請注意，與 `StateNotifier` 不同，沒有任何邏輯被寫入 `Notifier` 的建構函式中
+
+<!---
+Similar conclusions can be made with `AsyncNotifer`, `Notifier`'s asynchronous equivalent.  
+-->
+使用 `AsyncNotifer`、`Notifier` 的非同步等效項可以得出類似的結論。
+
+<!---
+## Migrating asynchronous `StateNotifier`s
+-->
+## 遷移非同步 `StateNotifier`
+
+<!---
+The main appeal of the new API syntax is an improved DX on asynchronous data.  
+Take the following example:
+-->
+新 API 語法的主要吸引力在於改進了非同步資料的開發體驗。  
+舉個例子：
+
+<AutoSnippet raw={asyncNotifierOld}/>
+
+<!---
+Here's the above example, rewritten with the new `AsyncNotifier` APIs:
+-->
+下面是用新的 `AsyncNotifier` API 重寫的上面的示例：
+
+<AutoSnippet language="dart" {...asyncNotifier}></AutoSnippet>
+
+<!---
+`AsyncNotifer`, just like `Notifier`, brings a simpler and more uniform API.
+Here, it's easy to see `AsyncNotifer` as a `FutureProvider` with methods.
+-->
+`AsyncNotifer` 與 `Notifier` 一樣，帶來了更簡單、更統一的 API。
+在這裡，很容易將 `AsyncNotifer` 視為帶有方法的 `FutureProvider`。
+
+<!---
+`AsyncNotifer` comes with a set of utilities and getters that `StateNotifier` doesn't have, such as e.g.
+[`future`](https://pub.dev/documentation/riverpod/latest/riverpod/AutoDisposeAsyncNotifier/future.html)
+and [`update`](https://pub.dev/documentation/riverpod/latest/riverpod/AutoDisposeAsyncNotifier/update.html).
+This enables us to write much simpler logic when handling asynchronous mutations and side-effects.
+See also <Link documentID="essentials/side_effects" />.
+-->
+`AsyncNotifer` 附帶了一組 `StateNotifier` 沒有的實用程式和 getter，例如
+[`future`](https://pub.dev/documentation/riverpod/latest/riverpod/AutoDisposeAsyncNotifier/future.html)
+和 [`update`](https://pub.dev/documentation/riverpod/latest/riverpod/AutoDisposeAsyncNotifier/update.html)。
+這使我們能夠在處理非同步突變和副作用時編寫更簡單的邏輯。
+另請參閱<Link documentID="essentials/side_effects" />。
+:::tip
+<!---
+Migrating from `StateNotifier<AsyncValue<T>>` to a `AsyncNotifer<T>` boils down to:
+
+- Putting initialization logic into `build`
+- Removing any `catch`/`try` blocks in initialization or in side effects methods
+- Remove any `AsyncValue.guard` from `build`, as it converts `Future`s into `AsyncValue`s
+-->
+從 `StateNotifier<AsyncValue<T>>` 遷移到 `AsyncNotifer<T>` 歸結為：
+
+- 將初始化邏輯放入 `build`
+- 刪除初始化或副作用方法中的任何 `catch`/`try` 塊
+- 從 `build` 中刪除任何 `AsyncValue.guard` ，因為它將 `Future` 轉換為 `AsyncValue`
+:::
+
+
+<!---
+### Advantages
+-->
+## 優點​
+
+<!---
+After these few examples, let's now highlight the main advantages of `Notifier` and `AsyncNotifer`: 
+- The new syntax should feel way simpler and more readable, especially for asynchronous state
+- New APIs are likely to have less boilerplate code in general
+- Syntax is now unified, no matter the type of provider you're writing, enabling code generation
+(see <Link documentID="concepts/about_code_generation" />)
+-->
+在這幾個示例之後，現在讓我們重點介紹 `Notifier` 和 `AsyncNotifer` 的主要優點：
+- 新語法應該感覺更簡單、更具可讀性，特別是對於非同步狀態
+- 一般來說，新 API 的樣板程式碼可能會更少
+- 無論您正在編寫哪種型別的提供者程式，語法現在都是統一的，從而支援程式碼生成
+  （請參閱<Link documentID="concepts/about_code_generation" />）
+
+<!---
+Let's go further down and highlight more differences and similarities.
+-->
+讓我們進一步深入並強調更多的差異和相似之處。
+
+<!---
+## Explicit `.family` and `.autoDispose` modifications
+-->
+## 顯式 `.family` 和 `.autoDispose` 修改​
+
+<!---
+Another important difference is how families and auto dispose is handled with the new APIs.
+-->
+另一個重要的區別是新 API 處理系列和自動處置的方式。
+
+<!---
+`Notifier`, has its own `.family` and `.autoDispose` counterparts, such as `FamilyNotifier`
+and `AutoDisposeNotifier`.  
+As always, such modifications can be combined (aka `AutoDisposeFamilyNotifier`).  
+`AsyncNotifer` has its asynchronous equivalent, too (e.g. `AutoDisposeFamilyAsyncNotifier`).
+-->
+`Notifier`，有其自己的 `.family` 和 `.autoDispose` 對應項，
+例如 `FamilyNotifier` 和 `AutoDisposeNotifier`。  
+與往常一樣，此類修改可以組合使用（又名 `AutoDisposeFamilyNotifier`）。  
+`AsyncNotifer` 也有其非同步等效項（例如 `AutoDisposeFamilyAsyncNotifier`）。
+
+<!---
+Modifications are explicitly stated inside the class; any parameters are directly injected in the
+`build` method, so that they're available to the initialization logic.  
+This should bring better readability, more conciseness and overall less mistakes.
+-->
+修改在類中明確說明；所有引數都直接注入 `build` 方法中，以便初始化邏輯可以使用它們。  
+這應該會帶來更好的可讀性、更簡潔、總體上更少的錯誤。
+
+<!---
+Take the following example, in which a `StateNotifierProvider.family` is being defined.
+-->
+以下面的示例為例，其中定義了 `StateNotifierProvider.family`。
+<AutoSnippet raw={familyAndDisposeOld}/>
+
+<!---
+`BugsEncounteredNotifier` feels... heavy / hard to read.  
+Let's take a look at its migrated `AsyncNotifier` counterpart:
+-->
+`BugsEncounteredNotifier` 感覺...沉重/難以閱讀。  
+讓我們看一下它的遷移後的 `AsyncNotifier` 對應部分：
+
+<AutoSnippet language="dart" {...familyAndDispose}></AutoSnippet>
+
+<!---
+Its migrated counterpart should feel like a light read.
+-->
+其遷移後的版本應該是一本輕鬆的讀物。
+
+:::info
+<!---
+`(Async)Notifier`'s `.family` parameters are available via `this.arg` (or `this.paramName` when using codegen)
+-->
+`(Async)Notifier` 的 `.family` 引數可透過 `this.arg` 獲取（或使用程式碼生成時的 `this.paramName`）
+:::
+
+<!---
+## Lifecycles have a different behavior
+-->
+## 生命週期有不同的行為​
+
+<!---
+Lifecycles between `Notifier`/`AsyncNotifier` and `StateNotifier` differ substantially.
+-->
+`Notifier`/`AsyncNotifier` 和 `StateNotifier` 之間的生命週期有很大不同。
+
+<!---
+This example showcases - again - how the old API have sparse logic:
+-->
+這個例子再次展示了舊 API 如何具有稀疏邏輯：
+
+<AutoSnippet raw={oldLifecyclesOld}/>
+
+<!---
+Here, if `durationProvider` updates, `MyNotifier` _disposes_: its instance is then re-instantiated
+and its internal state is then re-initialized.  
+Furthermore, unlike every other provider, the `dispose` callback is to be defined
+in the class, separately.  
+Finally, it is still possible to write `ref.onDispose` in its _provider_, showing once again how
+sparse the logic can be with this API; potentially, the developer might have to look into eight (8!)
+different places to understand this Notifier behavior!
+-->
+在這裡，如果 `durationProvider` 更新，`MyNotifier` 會進行處置：
+然後重新例項化其例項，然後重新初始化其內部狀態。  
+此外，與其他提供者程式不同的是，`dispose` 回撥將在類中單獨定義。  
+最後，仍然可以在其 _provider_ 中編寫 `ref.onDispose`，
+再次顯示此 API 的邏輯是多麼稀疏；潛在地，開發人員可能必須研究八 (8!)
+個不同的地方才能理解此通知者程式行為！
+
+<!---
+These ambiguities are solved with `Riverpod 2.0`.
+-->
+這些歧義可以透過 `Riverpod 2.0` 解決。
+
+<!---
+### Old `dispose` vs `ref.onDispose`
+-->
+### 舊 `dispose` 與 `ref.onDispose`
+<!---
+`StateNotifier`'s `dispose` method refers to the dispose event of the notifier itself, aka it's a
+callback that gets called *before disposing of itself*.
+-->
+`StateNotifier` 的 `dispose` 方法指的是通知者程式本身的 dispose 事件，
+也就是*在自行處置之前*呼叫的回撥。
+
+<!---
+`(Async)Notifier`s don't have this property, since *they don't get disposed of on rebuild*; only
+their *internal state* is.  
+In the new notifiers, dispose lifecycles are taken care of in only _one_ place, via `ref.onDispose`
+(and others), just like any other provider.
+This simplifies the API, and hopefully the DX, so that there is only _one_ place to look at to
+understand lifecycle side-effects: its `build` method.
+-->
+`(Async)Notifier` 沒有此屬性，因為*它們在重建時不會被處置*；只有他們的內部狀態是。  
+在新的通知者程式中，處置生命週期僅在_一個_地方處理，透過 `ref.onDispose`
+（和其他），就像任何其他提供者程式一樣。
+這簡化了 API，希望也提高了開發體驗，這樣只需檢視_一個_地方
+即可瞭解生命週期的副作用：它的 `build` 方法。
+
+<!---
+Shortly: to register a callback that fires before its *internal state* rebuilds, we can use
+`ref.onDispose` like every other provider.
+-->
+簡而言之：要註冊在*內部狀態*重建之前觸發的回撥，
+我們可以像其他提供者程式一樣使用 `ref.onDispose`。
+
+<!---
+You can migrate the above snippet like so:
+-->
+您可以像這樣遷移上面的程式碼片段：
+
+<AutoSnippet language="dart" {...oldLifecycles}></AutoSnippet>
+
+<!---
+In this last snippet there sure is some simplification, but there's still an open problem: we
+are now unable to understand whether or not our notifiers are still alive while performing `update`.  
+This might arise an unwanted `StateError`s.
+-->
+在最後一個片段中，肯定有一些簡化，但仍然存在一個未解決的問題：
+我們現在無法瞭解我們的通知者程式在執行 `update` 時是否仍然存在。  
+這可能會出現不需要的 `StateError`。
+
+<!---
+### No more `mounted`
+-->
+### 不再 `mounted`
+<!---
+This happens because `(Async)Notifier`s lacks a `mounted` property, which was available on
+`StateNotifier`.  
+Considering their difference in lifecycle, this makes perfect sense; while possible, a `mounted`
+property would be misleading on the new notifiers: `mounted` would *almost always* be `true`.
+-->
+發生這種情況是因為 `(Async)Notifier` 缺少 `mounted` 屬性，
+而該屬性在 `StateNotifier` 上可用。  
+考慮到它們生命週期的差異，這是完全有道理的；儘管只是可能，`mounted`
+屬性可能會誤導新通知者程式：`mounted` *幾乎總是* `true` 。
+
+<!---
+While it would be possible to craft a [custom workaround](https://github.com/rrousselGit/riverpod/issues/1879#issuecomment-1303189191),
+it's recomended to work around this by canceling the asynchronous operation.
+-->
+雖然可以制定[自定義解決方法](https://github.com/rrousselGit/riverpod/issues/1879#issuecomment-1303189191)，
+但建議透過取消非同步操作來解決此問題。
+
+<!---
+Canceling an operation can be done with a custom [Completer](https://api.flutter.dev/flutter/dart-async/Completer-class.html),
+or any custom derivative.
+-->
+可以使用自定義[完成器](https://api.flutter.dev/flutter/dart-async/Completer-class.html)
+或任何自定義派生程式來取消操作。
+
+<!---
+For example, if you're using `Dio` to perform network requests, consider using a [cancel token](https://pub.dev/documentation/dio/latest/dio/CancelToken-class.html)
+(see also <Link documentID="essentials/auto_dispose" />).
+-->
+例如，如果您使用 `Dio` 執行網路請求，請考慮使用[取消令牌](https://pub.dev/documentation/dio/latest/dio/CancelToken-class.html)
+（另請參閱<Link documentID="essentials/auto_dispose" />）。
+
+<!---
+Therefore, the above example migrates to the following:
+-->
+因此，上面的示例遷移到以下內容：
+<AutoSnippet language="dart" {...oldLifecyclesFinal}></AutoSnippet>
+
+
+<!---
+## Mutations APIs are the same as before
+-->
+## 突變 API 與之前相同​
+
+<!---
+Up until now we've shown the differences between `StateNotifier` and the new APIs.  
+Instead, one thing `Notifier`, `AsyncNotifer` and `StateNotifier` share is how their states
+can be consumed and mutated.
+-->
+到目前為止，我們已經展示了 `StateNotifier` 和新 API 之間的差異。  
+相反， `Notifier`、`AsyncNotifer` 和 `StateNotifier` 共享的一件事是
+如何使用和改變它們的狀態。
+
+<!---
+Consumers can obtain data from these three providers with the same syntax, which is great in case
+you're migrating away from `StateNotifier`; this applies for notifiers methods, too.
+-->
+消費者程式可以使用相同的語法從這三個提供者程式獲取資料，
+這在您從 `StateNotifier` 遷移時非常有用；這也適用於通知者程式方法。
+
+<AutoSnippet raw={consumersDontChange}></AutoSnippet>
+
+<!---
+## Other migrations
+-->
+## 其他遷移​
+
+<!---
+Let's explore the less-impactful differences between `StateNotifier` and `Notifier` (or `AsyncNotifier`)
+-->
+讓我們探討一下 `StateNotifier` 和 `Notifier`（或 `AsyncNotifier`）之間影響較小的差異
+
+<!---
+### From `.addListener` and `.stream`
+-->
+### 從 `.addListener` 和 `.stream` 遷移​
+
+<!---
+`StateNotifier`'s `.addListener` and `.stream` can be used to listen for state changes.
+These two APIs are now to be considered outdated.
+-->
+`StateNotifier` 的 `.addListener` 和 `.stream` 可用於監聽狀態更改。
+這兩個 API 現在被認為已經過時了。
+
+<!---
+This is intentional due to the desire to reach full API uniformity with `Notifier`, `AsyncNotifier` and other providers.  
+Indeed, using a `Notifier` or an `AsyncNotifier` shouldn't be any different from any other provider.
+-->
+這是有意為之，因為我們希望與 `Notifier`、`AsyncNotifier` 和其他提供者程式實現完全的 API 統一。  
+事實上，使用 `Notifier` 或 `AsyncNotifier` 應該與任何其他提供者程式沒有任何不同。
+
+<!---
+Therefore this:
+-->
+因此：
+<AutoSnippet raw={addListenerOld}/>
+
+<!---
+Becomes this:
+-->
+就變成這樣了：
+<AutoSnippet language="dart" {...addListener}></AutoSnippet>
+
+<!---
+In a nutshell: if you want to listen to a `Notifier`/`AsyncNotifer`, just use `ref.listen`.
+See <Link documentID="essentials/combining_requests" hash="the-reflistenlistenself-methods" />.
+-->
+簡而言之：如果你想監聽 `Notifier`/`AsyncNotifer`，只需使用 `ref.listen`。
+請參閱<Link documentID="essentials/combining_requests" hash="the-reflistenlistenself-methods" />。
+
+<!---
+### From `.debugState` in tests
+-->
+### 從測試中的 `.debugState` 遷移​
+
+<!---
+`StateNotifier` exposes `.debugState`: this property is used for pkg:state_notifier users to enable
+state access from outside the class when in development mode, for testing purposes.
+-->
+`StateNotifier` 公開 `.debugState`：此屬性供 pkg:state_notifier
+使用者在開發模式下啟用從類外部進行狀態訪問，以用於測試目的。
+
+<!---
+If you're using `.debugState` to access state in tests, chances are that you need to drop this
+approach.
+-->
+如果您在測試中使用 `.debugState` 訪問狀態，則您很可能需要放棄這種方法。
+
+<!---
+`Notifier` / `AsyncNotifer` don't have a `.debugState`; instead, they directly expose `.state`,
+which is `@visibleForTesting`.
+-->
+`Notifier`/`AsyncNotifer` 沒有 `.debugState`；相反，它們直接公開 `.state`，
+即 `@visibleForTesting` 。
+
+:::danger
+<!---
+AVOID accessing `.state` from tests; if you have to, do it _if and only if_ you had already have
+a `Notifier` / `AsyncNotifer` properly instantied;
+then, you could access `.state` inside tests freely.
+-->
+避免！從測試中訪問 `.state`；如果必須的話，_當且僅當_您已經正確例項化了
+`Notifier`/`AsyncNotifer` 時才執行此操作；
+然後，您可以在測試中自由訪問 `.state`。
+
+<!---
+Indeed, `Notifier` / `AsyncNotifier` _should not_ be instantiated by hand; instead, they should be
+interacted with by using its provider: failing to do so will *break* the notifier,
+due to ref and family args not being initialized.
+-->
+事實上，`Notifier`/`AsyncNotifier` _不應該_手動例項化；相反，
+它們應該透過使用其提供者程式進行互動：如果不這樣做將會*破壞*通知者程式，
+因為 ref 和 family 引數沒有被初始化。
+:::
+
+<!---
+Don't have a `Notifier` instance?  
+No problem, you can obtain one with `ref.read`, just like you would read its exposed state:
+-->
+沒有 `Notifier` 例項？  
+沒問題，您可以使用 `ref.read` 獲取一個，就像您讀取其暴露狀態一樣：
+
+<AutoSnippet raw={obtainNotifierOnTests}/>
+
+<!---
+Learn more about testing in its dedicated guide. See <Link documentID="essentials/testing" />.
+-->
+在其專用指南中瞭解有關測試的更多資訊。請參閱<Link documentID="essentials/testing" />。
+
+<!---
+### From `StateProvider` 
+-->
+### 從 `StateProvider` 遷移​
+
+<!---
+`StateProvider` was exposed by Riverpod since its release, and it was made to save a few LoC for
+simplified versions of `StateNotifierProvider`.  
+Since `StateNotifierProvider` is deprecated, `StateProvider` is to be avoided, too.  
+Furthermore, as of now, there is no `StateProvider` equivalent for the new APIs.
+-->
+`StateProvider` 自發布以來就被 Riverpod 暴露出來，
+它是為了節省一些程式碼行數（LoC）來簡化 `StateNotifierProvider` 的版本。  
+由於 `StateNotifierProvider` 已被棄用，因此 `StateProvider` 也應避免使用。  
+此外，到目前為止，新 API 還沒有等效的 `StateProvider`。
+
+<!---
+Nonetheless, migrating from `StateProvider` to `Notifier` is simple.
+-->
+儘管如此，從 `StateProvider` 遷移到 `Notifier` 很簡單。
+
+<!---
+This:
+-->
+這樣：
+<AutoSnippet raw={fromStateProviderOld}/>
+
+<!---
+Becomes:
+-->
+變成：
+<AutoSnippet language="dart" {...fromStateProvider}></AutoSnippet>
+
+<!---
+Even though it costs us a few more LoC, migrating away from `StateProvider` enables us to
+definetively archive `StateNotifier`.
+-->
+儘管它花費了我們更多的程式碼行數（LoC），但從 `StateProvider`
+遷移使我們能夠明確地歸檔 `StateNotifier` 。

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/migration/utils.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/migration/utils.dart
@@ -1,0 +1,23 @@
+import 'dart:math' as math;
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final randomProvider = Provider<int>((ref) {
+  return math.Random().nextInt(6);
+});
+
+final taskTrackerProvider = Provider<TaskTrackerRepo>((ref) {
+  return TaskTrackerRepo();
+});
+
+class TaskTrackerRepo {
+  Future<int> fix({required String id, required int fixed}) async => 0;
+}
+
+final durationProvider = Provider<Duration>((ref) {
+  return Duration.zero;
+});
+
+final availableWaterProvider = Provider<int>((ref) {
+  return 40;
+});

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/change_notifier_provider.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/change_notifier_provider.mdx
@@ -1,0 +1,59 @@
+---
+title: ChangeNotifierProvider
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import todos from "!!raw-loader!/docs/providers/change_notifier_provider/todos.dart";
+import todosConsumer from "!!raw-loader!/docs/providers/change_notifier_provider/todos_consumer.dart";
+import { trimSnippet } from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+`ChangeNotifierProvider` (flutter_riverpod/hooks_riverpod only) is a provider that
+is used to listen to and expose a [ChangeNotifier] from Flutter itself.
+
+Using `ChangeNotifierProvider` is discouraged by Riverpod and exists primarily for:
+
+- an easy transition from `package:provider` when using its `ChangeNotifierProvider`
+- supporting mutable state, even though immutable state is preferred
+
+:::info
+Prefer using [NotifierProvider] instead.  
+Consider using `ChangeNotifierProvider` only if you are absolutely certain
+that you want mutable state.
+:::
+
+Using mutable state instead of immutable state can sometimes be more efficient.
+The downside is, it can be harder to maintain and may break various features.  
+For example, using `provider.select` to optimize rebuilds of your widgets
+may not work if your state is mutable, as `select` will think that the value
+hasn't changed.  
+As such, using immutable data structures can sometimes be faster. Therefore
+it is important to make benchmarks specific to your use-case, to make sure
+that you are truly gaining performance by using `ChangeNotifierProvider`.
+
+As a usage example, we could use `ChangeNotifierProvider` to implement a todo-list.
+Doing so would allow us to expose methods such as `addTodo` to let the UI
+modify the list of todos on user interactions:
+
+<CodeBlock>{trimSnippet(todos)}</CodeBlock>
+
+Now that we have defined a `ChangeNotifierProvider`, we can use it to interact
+with the list of todos in our UI:
+
+<CodeBlock>{trimSnippet(todosConsumer)}</CodeBlock>
+
+[state_notifier]: https://pub.dev/packages/state_notifier
+[statenotifierprovider]: ./state_notifier_provider
+[notifierprovider]: ./notifier_provider
+[changenotifier]: https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html
+[provider]: ./provider
+[futureprovider]: ./future_provider

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/change_notifier_provider/todos.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/change_notifier_provider/todos.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+class Todo {
+  Todo({
+    required this.id,
+    required this.description,
+    required this.completed,
+  });
+
+  String id;
+  String description;
+  bool completed;
+}
+
+class TodosNotifier extends ChangeNotifier {
+  final todos = <Todo>[];
+
+  // Let's allow the UI to add todos.
+  void addTodo(Todo todo) {
+    todos.add(todo);
+    notifyListeners();
+  }
+
+  // Let's allow removing todos
+  void removeTodo(String todoId) {
+    todos.remove(todos.firstWhere((element) => element.id == todoId));
+    notifyListeners();
+  }
+
+  // Let's mark a todo as completed
+  void toggle(String todoId) {
+    final todo = todos.firstWhere((todo) => todo.id == todoId);
+    todo.completed = !todo.completed;
+    notifyListeners();
+  }
+}
+
+// Finally, we are using ChangeNotifierProvider to allow the UI to interact with
+// our TodosNotifier class.
+final todosProvider = ChangeNotifierProvider<TodosNotifier>((ref) {
+  return TodosNotifier();
+});

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/change_notifier_provider/todos_consumer.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/change_notifier_provider/todos_consumer.dart
@@ -1,0 +1,32 @@
+// ignore_for_file: omit_local_variable_types, prefer_final_locals
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'todos.dart';
+
+/* SNIPPET START */
+
+class TodoListView extends ConsumerWidget {
+  const TodoListView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // rebuild the widget when the todo list changes
+    List<Todo> todos = ref.watch(todosProvider).todos;
+
+    // Let's render the todos in a scrollable list view
+    return ListView(
+      children: [
+        for (final todo in todos)
+          CheckboxListTile(
+            value: todo.completed,
+            // When tapping on the todo, change its completed status
+            onChanged: (value) =>
+                ref.read(todosProvider.notifier).toggle(todo.id),
+            title: Text(todo.description),
+          ),
+      ],
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/future_provider.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/future_provider.mdx
@@ -1,0 +1,66 @@
+---
+title: FutureProvider
+version: 1
+---
+
+import configProvider from "/docs/providers/future_provider/config_provider";
+import configConsumer from "/docs/providers/future_provider/config_consumer";
+import { AutoSnippet} from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+`FutureProvider` is the equivalent of [Provider] but for asynchronous code.
+
+`FutureProvider` is typically used for:
+
+- performing and caching asynchronous operations (such as network requests)
+- nicely handling error/loading states of asynchronous operations
+- combining multiple asynchronous values into another value
+
+`FutureProvider` gains a lot when combined with [ref.watch]. This combination
+allows automatic re-fetching of some data when some variables change,
+ensuring that we always have the most up-to-date value.
+
+:::info
+`FutureProvider` does not offer a way of directly modifying the computation after
+a user interaction. It is designed to solve simple use-cases.  
+For more advanced scenarios, consider using [AsyncNotifierProvider].
+:::
+
+## Usage example: reading a configuration file
+
+`FutureProvider` can be a convenient way to expose a `Configuration` object
+created by reading a JSON file.
+
+Creating the configuration would be done with your typical async/await
+syntax, but inside the provider.
+Using Flutter's asset system, this would be:
+
+<AutoSnippet language="dart" {...configProvider}></AutoSnippet>
+
+
+Then, the UI can listen to configurations like so:
+
+<AutoSnippet language="dart" {...configConsumer}></AutoSnippet>
+
+This will automatically rebuild the UI when the [Future] completes.
+At the same time, if multiple widgets want the configurations,
+the asset will be decoded only once.
+
+As you can see, listening to a `FutureProvider` inside a widget returns
+an [AsyncValue] – which allows handling the error/loading states.
+
+[ref.watch]: ../concepts/reading#using-refwatch-to-observe-a-provider
+[asyncnotifierprovider]: ./notifier_provider
+[provider]: ./provider
+[asyncvalue]: https://pub.dev/documentation/riverpod/latest/riverpod/AsyncValue-class.html
+[future]: https://api.dart.dev/dart-async/Future-class.html
+[family]: ../concepts/modifiers/family

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/notifier_provider.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/notifier_provider.mdx
@@ -1,0 +1,59 @@
+---
+title: (Async)NotifierProvider
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import todos from "/docs/providers/notifier_provider/todos";
+import todosConsumer from "!!raw-loader!/docs/providers/notifier_provider/todos/todos_consumer.dart";
+import remoteTodos from "/docs/providers/notifier_provider/remote_todos";
+import remoteTodosConsumer from "!!raw-loader!/docs/providers/notifier_provider/remote_todos/todos_consumer.dart";
+import { trimSnippet, AutoSnippet } from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+[NotifierProvider] is a provider that is used to listen to and expose a [Notifier].  
+[AsyncNotifierProvider] is a provider that is used to listen to and expose an [AsyncNotifier].
+[AsyncNotifier] is a [Notifier] that can be asynchronously initialized.  
+`(Async)NotifierProvider` along with `(Async)Notifier` is Riverpod's recommended solution
+for managing state which may change in reaction to a user interaction.
+
+It is typically used for:
+
+- exposing a state which can change over time after reacting to custom events.
+- centralizing the logic for modifying some state (aka "business logic") in a
+  single place, improving maintainability over time.
+
+As a usage example, we could use [NotifierProvider] to implement a todo-list.
+Doing so would allow us to expose methods such as `addTodo` to let the UI
+modify the list of todos on user interactions:
+
+<AutoSnippet language="dart" {...todos}></AutoSnippet>
+
+Now that we have defined a [NotifierProvider], we can use it to interact
+with the list of todos in our UI:
+
+<CodeBlock>{trimSnippet(todosConsumer)}</CodeBlock>
+
+As a usage example, we could use [AsyncNotifierProvider] to implement a remote todo-list.
+Doing so would allow us to expose methods such as `addTodo` to let the UI
+modify the list of todos on user interactions:
+
+<AutoSnippet language="dart" {...remoteTodos}></AutoSnippet>
+
+Now that we have defined a [AsyncNotifierProvider], we can use it to interact
+with the list of todos in our UI:
+
+<CodeBlock>{trimSnippet(remoteTodosConsumer)}</CodeBlock>
+
+[notifier]: https://pub.dev/documentation/riverpod/latest/riverpod/Notifier-class.html
+[notifierprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/NotifierProvider.html
+[asyncnotifier]: https://pub.dev/documentation/riverpod/latest/riverpod/AsyncNotifier-class.html
+[asyncnotifierprovider]: https://pub.dev/documentation/riverpod/latest/riverpod/AsyncNotifierProvider.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/provider.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/provider.mdx
@@ -1,0 +1,109 @@
+---
+title: Provider
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import todo from "/docs/providers/provider/todo";
+import completedTodos from "/docs/providers/provider/completed_todos";
+import todosConsumer from "!!raw-loader!/docs/providers/provider/todos_consumer.dart";
+import unoptimizedPreviousButton from "/docs/providers/provider/unoptimized_previous_button";
+import optimizedPreviousButton from "/docs/providers/provider/optimized_previous_button";
+import { trimSnippet, AutoSnippet } from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+`Provider` is the most basic of all providers. It creates a value... And that's about it.
+
+`Provider` is typically used for:
+
+- caching computations
+- exposing a value to other providers (such as a `Repository`/`HttpClient`).
+- offering a way for tests or widgets to override a value.
+- reducing rebuilds of providers/widgets without having to use `select`.
+
+## Using `Provider` to cache computations
+
+`Provider` is a powerful tool for caching synchronous operations when combined
+with [ref.watch].
+
+An example would be filtering a list of todos.
+Since filtering a list could be slightly expensive, we ideally do not want to
+filter our list of todos whenever our application re-renders.
+In this situation, we could use `Provider` to do the filtering for us.
+
+For that, assume that our application has an existing [NotifierProvider]
+which manipulates a list of todos:
+
+<AutoSnippet language="dart" {...todo}></AutoSnippet>
+
+From there, we can use `Provider` to expose the filtered list of todos, showing
+only the completed todos:
+
+<AutoSnippet language="dart" {...completedTodos}></AutoSnippet>
+
+With this code, our UI is now able to show the list of the completed todos
+by listening to `completedTodosProvider`:
+
+<CodeBlock>{trimSnippet(todosConsumer)}</CodeBlock>
+
+The interesting part is, the list filtering is now cached.
+
+Meaning that the list of completed todos will not be recomputed until
+todos are added/removed/updated, even if we are reading the list of completed
+todos multiple times.
+
+Note how we do not need to manually invalidate the cache when the list of todos
+changes. `Provider` is automatically able to know when the result must be recomputed
+thanks to [ref.watch].
+
+## Reducing provider/widget rebuilds by using `Provider`
+
+A unique aspect of `Provider` is that even when `Provider` is recomputed
+(typically when using [ref.watch]), it will not update the widgets/providers
+that listen to it unless the value changed.
+
+A real world example would be for enabling/disabling previous/next buttons
+of a paginated view:
+
+![stepper example](https://user-images.githubusercontent.com/134939/47580830-31263a00-d950-11e8-9b61-0eaddab2709e.png)
+
+In our case, we will focus specifically on the "previous" button.
+A naive implementation of such button would be a widget which obtains the
+current page index, and if that index is equal to 0, we would disable the button.
+
+This code could be:
+
+<AutoSnippet language="dart" {...unoptimizedPreviousButton}></AutoSnippet>
+
+The issue with this code is that whenever we change the current page, the "previous"
+button will rebuild.  
+In the ideal world, we would want the button to rebuild only when changing between
+activated and deactivated.
+
+The root of the issue here is that we are computing whether the user is
+allowed to go to the previous page directly within the "previous" button.
+
+A way to solve this is to extract this logic outside of the widget and into a `Provider`:
+
+<AutoSnippet language="dart" {...optimizedPreviousButton}></AutoSnippet>
+
+By doing this small refactoring, our `PreviousButton` widget will no longer
+rebuild when the page index changes thanks to `Provider`.
+
+From now on when the page index changes, our `canGoToPreviousPageProvider` provider
+will be recomputed. But if the value exposed by the provider does not change,
+then `PreviousButton` will not rebuild.
+
+This change both improved the performance of our button and had the interesting
+benefit of extracting the logic outside of our widget.
+
+[ref.watch]: ../concepts/reading#using-refwatch-to-observe-a-provider
+[notifierprovider]: ./notifier_provider

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/provider/todos_consumer.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/provider/todos_consumer.dart
@@ -1,0 +1,18 @@
+// ignore_for_file: unused_local_variable
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'completed_todos/completed_todos.dart';
+
+Widget build() {
+  return
+/* SNIPPET START */
+Consumer(builder: (context, ref, child) {
+  final completedTodos = ref.watch(completedTodosProvider);
+  // TODO show the todos using a ListView/GridView/.../* SKIP */
+  return Container();
+  /* SKIP END */
+});
+/* SNIPPET END */
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_notifier_provider.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_notifier_provider.mdx
@@ -1,0 +1,49 @@
+---
+title: StateNotifierProvider
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import todos from "!!raw-loader!/docs/providers/state_notifier_provider/todos.dart";
+import todosConsumer from "!!raw-loader!/docs/providers/state_notifier_provider/todos_consumer.dart";
+import { trimSnippet } from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+`StateNotifierProvider` is a provider that is used to listen to and expose a
+[StateNotifier] (from the package [state_notifier], which Riverpod re-exports).
+
+It is typically used for:
+
+- exposing an **immutable** state which can change over time after reacting to
+  custom events.
+- centralizing the logic for modifying some state (aka "business logic") in a
+  single place, improving maintainability over time.
+
+:::info
+Prefer using [NotifierProvider] instead.  
+:::
+
+As a usage example, we could use `StateNotifierProvider` to implement a todo-list.
+Doing so would allow us to expose methods such as `addTodo` to let the UI
+modify the list of todos on user interactions:
+
+<CodeBlock>{trimSnippet(todos)}</CodeBlock>
+
+Now that we have defined a `StateNotifierProvider`, we can use it to interact
+with the list of todos in our UI:
+
+<CodeBlock>{trimSnippet(todosConsumer)}</CodeBlock>
+
+[state_notifier]: https://pub.dev/packages/state_notifier
+[statenotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html
+[provider]: ./provider
+[futureprovider]: ./future_provider
+[notifierprovider]: ./notifier_provider

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_notifier_provider/todos.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_notifier_provider/todos.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+// The state of our StateNotifier should be immutable.
+// We could also use packages like Freezed to help with the implementation.
+@immutable
+class Todo {
+  const Todo({required this.id, required this.description, required this.completed});
+
+  // All properties should be `final` on our class.
+  final String id;
+  final String description;
+  final bool completed;
+
+  // Since Todo is immutable, we implement a method that allows cloning the
+  // Todo with slightly different content.
+  Todo copyWith({String? id, String? description, bool? completed}) {
+    return Todo(
+      id: id ?? this.id,
+      description: description ?? this.description,
+      completed: completed ?? this.completed,
+    );
+  }
+}
+
+// The StateNotifier class that will be passed to our StateNotifierProvider.
+// This class should not expose state outside of its "state" property, which means
+// no public getters/properties!
+// The public methods on this class will be what allow the UI to modify the state.
+class TodosNotifier extends StateNotifier<List<Todo>> {
+  // We initialize the list of todos to an empty list
+  TodosNotifier(): super([]);
+
+  // Let's allow the UI to add todos.
+  void addTodo(Todo todo) {
+    // Since our state is immutable, we are not allowed to do `state.add(todo)`.
+    // Instead, we should create a new list of todos which contains the previous
+    // items and the new one.
+    // Using Dart's spread operator here is helpful!
+    state = [...state, todo];
+    // No need to call "notifyListeners" or anything similar. Calling "state ="
+    // will automatically rebuild the UI when necessary.
+  }
+
+  // Let's allow removing todos
+  void removeTodo(String todoId) {
+    // Again, our state is immutable. So we're making a new list instead of
+    // changing the existing list.
+    state = [
+      for (final todo in state)
+        if (todo.id != todoId) todo,
+    ];
+  }
+
+  // Let's mark a todo as completed
+  void toggle(String todoId) {
+    state = [
+      for (final todo in state)
+        // we're marking only the matching todo as completed
+        if (todo.id == todoId)
+          // Once more, since our state is immutable, we need to make a copy
+          // of the todo. We're using our `copyWith` method implemented before
+          // to help with that.
+          todo.copyWith(completed: !todo.completed)
+        else
+          // other todos are not modified
+          todo,
+    ];
+  }
+}
+
+// Finally, we are using StateNotifierProvider to allow the UI to interact with
+// our TodosNotifier class.
+final todosProvider = StateNotifierProvider<TodosNotifier, List<Todo>>((ref) {
+  return TodosNotifier();
+});

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_notifier_provider/todos_consumer.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_notifier_provider/todos_consumer.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: omit_local_variable_types, prefer_final_locals
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'todos.dart';
+
+/* SNIPPET START */
+
+class TodoListView extends ConsumerWidget {
+  const TodoListView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // rebuild the widget when the todo list changes
+    List<Todo> todos = ref.watch(todosProvider);
+
+    // Let's render the todos in a scrollable list view
+    return ListView(
+      children: [
+        for (final todo in todos)
+          CheckboxListTile(
+            value: todo.completed,
+            // When tapping on the todo, change its completed status
+            onChanged: (value) => ref.read(todosProvider.notifier).toggle(todo.id),
+            title: Text(todo.description),
+          ),
+      ],
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider.mdx
@@ -1,0 +1,137 @@
+---
+title: StateProvider
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import product from "!!raw-loader!/docs/providers/state_provider/product.dart";
+import productListView from "!!raw-loader!/docs/providers/state_provider/product_list_view.dart";
+import dropdown from "!!raw-loader!/docs/providers/state_provider/dropdown.dart";
+import sortProvider from "!!raw-loader!/docs/providers/state_provider/sort_provider.dart";
+import connectedDropdown from "!!raw-loader!/docs/providers/state_provider/connected_dropdown.dart";
+import sortedProductProvider from "!!raw-loader!/docs/providers/state_provider/sorted_product_provider.dart";
+import updateReadTwice from "!!raw-loader!/docs/providers/state_provider/update_read_twice.dart";
+import updateReadOnce from "!!raw-loader!/docs/providers/state_provider/update_read_once.dart";
+import { trimSnippet } from "@site/src/components/CodeSnippet";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+`StateProvider` is a provider that exposes a way to modify its state.
+It is a simplification of [NotifierProvider], designed to avoid
+having to write a [Notifier] class for very simple use-cases.
+
+`StateProvider` exists primarily to allow the modification of
+**simple** variables by the User Interface.  
+The state of a `StateProvider` is typically one of:
+
+- an enum, such as a filter type
+- a String, typically the raw content of a text field
+- a boolean, for checkboxes
+- a number, for pagination or age form fields
+
+You should not use `StateProvider` if:
+
+- your state needs validation logic
+- your state is a complex object (such as a custom class, a list/map, ...)
+- the logic for modifying your state is more advanced than a simple `count++`.
+
+For more advanced cases, consider using [NotifierProvider] instead and
+create a [Notifier] class.  
+While the initial boilerplate will be a bit larger, having a custom
+[Notifier] class is critical for the long-term maintainability of your
+project – as it centralizes the business logic of your state in a single place.
+
+## Usage example: Changing the filter type using a dropdown
+
+A real-world use-case of `StateProvider` would be to manage the state of
+simple form components like dropdowns/text fields/checkboxes.  
+In particular, we will see how to use `StateProvider` to implement a dropdown
+that allows changing how a list of products is sorted.
+
+For the sake of simplicity, the list of products that we will obtain
+will be built directly in the application and will be as follows:
+
+<CodeBlock>{trimSnippet(product)}</CodeBlock>
+
+In a real-world application, this list would typically be obtained using
+[FutureProvider] by making a network request.
+
+The User Interface could then show the list of products by doing:
+
+<CodeBlock>{trimSnippet(productListView)}</CodeBlock>
+
+Now that we're done with the base, we can add a dropdown, which will
+allow filtering our products either by price or by name.  
+For that, we will use [DropDownButton](https://api.flutter.dev/flutter/material/DropdownButton-class.html).
+
+<CodeBlock>{trimSnippet(dropdown)}</CodeBlock>
+
+Now that we have a dropdown, let's create a `StateProvider` and
+synchronize the state of the dropdown with our provider.
+
+First, let's create the `StateProvider`:
+
+<CodeBlock>{trimSnippet(sortProvider)}</CodeBlock>
+
+Then, we can connect this provider with our dropdown by doing:
+
+<CodeBlock>{trimSnippet(connectedDropdown)}</CodeBlock>
+
+With this, we should now be able to change the sort type.  
+It has no impact on the list of products yet though! It's now time for the
+final part: Updating our `productsProvider` to sort the list of products.
+
+A key component of implementing this is to use [ref.watch], to have
+our `productsProvider` obtain the sort type and recompute the list of
+products whenever the sort type changes.
+
+The implementation would be:
+
+<CodeBlock>{trimSnippet(sortedProductProvider)}</CodeBlock>
+
+That's all! This change is enough for the User Interface to automatically
+re-render the list of products when the sort type changes.
+
+Here is the complete example on Dartpad:
+
+<iframe
+  src="https://dartpad.dev/embed-flutter.html?gh_owner=rrousselGit&gh_repo=riverpod&gh_path=website%2Fdocs%2Fproviders%2Fstate_provider"
+  style={{ border: 0, width: "100%", aspectRatio: "2/1.5" }}
+></iframe>
+
+## How to update the state based on the previous value without reading the provider twice
+
+Sometimes, you want to update the state of a `StateProvider` based on the previous value.
+Naturally, you may end-up writing:
+
+<CodeBlock>{trimSnippet(updateReadTwice)}</CodeBlock>
+
+While there's nothing particularly wrong with this snippet, the syntax is a bit inconvenient.
+
+To make the syntax a bit better, we can use the `update` function.
+This function will take a callback that will receive the current state and is expected
+to return the new state.  
+We can use it to refactor our previous code to:
+
+<CodeBlock>{trimSnippet(updateReadOnce)}</CodeBlock>
+
+This change achieves the same effect while making the syntax a bit better.
+
+[ref.watch]: ../concepts/reading#using-refwatch-to-observe-a-provider
+[ref.read]: ../concepts/reading#using-refread-to-obtain-the-state-of-a-provider-once
+[statenotifierprovider]: ./state_notifier_provider
+[notifierprovider]: ./notifier_provider
+[futureprovider]: ./future_provider
+[notifier]: https://pub.dev/documentation/riverpod/latest/riverpod/Notifier-class.html
+[statenotifier]: https://pub.dev/documentation/state_notifier/latest/state_notifier/StateNotifier-class.html
+[provider]: ./provider
+[asyncvalue]: https://pub.dev/documentation/riverpod/latest/riverpod/AsyncValue-class.html
+[future]: https://api.dart.dev/dart-async/Future-class.html
+[family]: ../concepts/modifiers/family

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/connected_dropdown.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/connected_dropdown.dart
@@ -1,0 +1,25 @@
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'dropdown.dart';
+import 'sort_provider.dart';
+
+Widget build(BuildContext context, WidgetRef ref) {
+  return AppBar(actions: [
+/* SNIPPET START */
+DropdownButton<ProductSortType>(
+  // When the sort type changes, this will rebuild the dropdown
+  // to update the icon shown.
+  value: ref.watch(productSortTypeProvider),
+  // When the user interacts with the dropdown, we update the provider state.
+  onChanged: (value) =>
+      ref.read(productSortTypeProvider.notifier).state = value!,
+  items: [
+    // ...
+  ],
+),
+/* SNIPPET END */
+  ]);
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/dartpad_metadata.yaml
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/dartpad_metadata.yaml
@@ -1,0 +1,4 @@
+name: StateProvider example
+mode: flutter
+files:
+  - name: full.dart

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/dropdown.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/dropdown.dart
@@ -1,0 +1,43 @@
+// ignore_for_file: unused_local_variable
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'full.dart';
+
+/* SNIPPET START */
+
+// An enum representing the filter type
+enum ProductSortType {
+  name,
+  price,
+}
+
+Widget build(BuildContext context, WidgetRef ref) {
+  final products = ref.watch(productsProvider);
+  return Scaffold(
+    appBar: AppBar(
+      title: const Text('Products'),
+      actions: [
+        DropdownButton<ProductSortType>(
+          value: ProductSortType.price,
+          onChanged: (value) {},
+          items: const [
+            DropdownMenuItem(
+              value: ProductSortType.name,
+              child: Icon(Icons.sort_by_alpha),
+            ),
+            DropdownMenuItem(
+              value: ProductSortType.price,
+              child: Icon(Icons.sort),
+            ),
+          ],
+        ),
+      ],
+    ),
+    body: ListView.builder(
+      // ... /* SKIP */
+      itemBuilder: (c, i) => Container(), /* SKIP END */
+    ),
+  );
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/full.dart
@@ -1,0 +1,100 @@
+// This code is distributed under the MIT License.
+// Copyright (c) 2022 Remi Rousselet.
+// You can find the original at https://github.com/rrousselGit/riverpod.
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  runApp(const ProviderScope(child: MyApp()));
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: MyHomePage(),
+    );
+  }
+}
+
+class Product {
+  Product({required this.name, required this.price});
+
+  final String name;
+  final double price;
+}
+
+final _products = [
+  Product(name: 'iPhone', price: 999),
+  Product(name: 'cookie', price: 2),
+  Product(name: 'ps5', price: 500),
+];
+
+enum ProductSortType {
+  name,
+  price,
+}
+
+final productSortTypeProvider = StateProvider<ProductSortType>(
+  // We return the default sort type, here name.
+  (ref) => ProductSortType.name,
+);
+
+final productsProvider = Provider<List<Product>>((ref) {
+  final sortType = ref.watch(productSortTypeProvider);
+  switch (sortType) {
+    case ProductSortType.name:
+      return _products.sorted((a, b) => a.name.compareTo(b.name));
+    case ProductSortType.price:
+      return _products.sorted((a, b) => a.price.compareTo(b.price));
+  }
+});
+
+class MyHomePage extends ConsumerWidget {
+  const MyHomePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final products = ref.watch(productsProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Products'),
+        actions: [
+          DropdownButton<ProductSortType>(
+            // When the sort type changes, this will rebuild the dropdown
+            // to update the icon shown.
+            value: ref.watch(productSortTypeProvider),
+            // When the user interacts with the dropdown, we update the provider state.
+            onChanged: (value) =>
+                ref.read(productSortTypeProvider.notifier).state = value!,
+            items: const [
+              DropdownMenuItem(
+                value: ProductSortType.name,
+                child: Icon(Icons.sort_by_alpha),
+              ),
+              DropdownMenuItem(
+                value: ProductSortType.price,
+                child: Icon(Icons.sort),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: products.length,
+        itemBuilder: (context, index) {
+          final product = products[index];
+          return ListTile(
+            title: Text(product.name),
+            subtitle: Text('${product.price} \$'),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/product.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/product.dart
@@ -1,0 +1,20 @@
+import 'package:riverpod/riverpod.dart';
+
+/* SNIPPET START */
+
+class Product {
+  Product({required this.name, required this.price});
+
+  final String name;
+  final double price;
+}
+
+final _products = [
+  Product(name: 'iPhone', price: 999),
+  Product(name: 'cookie', price: 2),
+  Product(name: 'ps5', price: 500),
+];
+
+final productsProvider = Provider<List<Product>>((ref) {
+  return _products;
+});

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/product_list_view.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/product_list_view.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'product.dart';
+
+/* SNIPPET START */
+
+Widget build(BuildContext context, WidgetRef ref) {
+  final products = ref.watch(productsProvider);
+  return Scaffold(
+    body: ListView.builder(
+      itemCount: products.length,
+      itemBuilder: (context, index) {
+        final product = products[index];
+        return ListTile(
+          title: Text(product.name),
+          subtitle: Text('${product.price} \$'),
+        );
+      },
+    ),
+  );
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/sort_provider.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/sort_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'dropdown.dart';
+
+/* SNIPPET START */
+
+final productSortTypeProvider = StateProvider<ProductSortType>(
+  // We return the default sort type, here name.
+  (ref) => ProductSortType.name,
+);

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/sorted_product_provider.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/sorted_product_provider.dart
@@ -1,0 +1,24 @@
+import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'dropdown.dart';
+import 'product.dart';
+import 'sort_provider.dart';
+
+final _products = [
+  Product(name: 'iPhone', price: 999),
+  Product(name: 'cookie', price: 2),
+  Product(name: 'ps5', price: 500),
+];
+
+/* SNIPPET START */
+
+final productsProvider = Provider<List<Product>>((ref) {
+  final sortType = ref.watch(productSortTypeProvider);
+  switch (sortType) {
+    case ProductSortType.name:
+      return _products.sorted((a, b) => a.name.compareTo(b.name));
+    case ProductSortType.price:
+      return _products.sorted((a, b) => a.price.compareTo(b.price));
+  }
+});

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/update_read_once.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/update_read_once.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+final counterProvider = StateProvider<int>((ref) => 0);
+
+class HomeView extends ConsumerWidget {
+  const HomeView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          /* highlight-start */
+          ref.read(counterProvider.notifier).update((state) => state + 1);
+          /* highlight-end */
+        },
+      ),
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/update_read_twice.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/state_provider/update_read_twice.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+
+final counterProvider = StateProvider<int>((ref) => 0);
+
+class HomeView extends ConsumerWidget {
+  const HomeView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // We're updating the state from the previous value, we ended-up reading
+          // the provider twice!
+          ref.read(counterProvider.notifier).state = ref.read(counterProvider.notifier).state + 1;
+        },
+      ),
+    );
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/stream_provider.mdx
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/stream_provider.mdx
@@ -1,0 +1,63 @@
+---
+title: StreamProvider
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import { trimSnippet,AutoSnippet } from "@site/src/components/CodeSnippet";
+import streamProvider from "/docs/providers/stream_provider/live_stream_chat_provider";
+import streamConsumer from "!!raw-loader!/docs/providers/stream_provider/live_stream_chat_consumer.dart";
+
+:::caution
+<!---
+The content of this page may be outdated.  
+It will be updated in the future, but for now you may want to refer to the content
+in the top of the sidebar instead (introduction/essentials/case-studies/...)
+-->
+本頁內容可能已經過時。  
+今後會進行更新，但目前您可能需要參考側邊欄頂部的內容（介紹/要點/應用案例/......）。
+:::
+
+`StreamProvider` is similar to [FutureProvider] but for [Stream]s instead of
+[Future]s.
+
+`StreamProvider` is usually used for:
+
+- listening to Firebase or web-sockets
+- rebuilding another provider every few seconds
+
+Since [Stream]s naturally expose a way for listening to updates, some may think
+that using `StreamProvider` has a low value. In particular, you may believe that
+Flutter's [StreamBuilder] would work just as well for listening to a [Stream], but
+this is a mistake.
+
+Using `StreamProvider` over [StreamBuilder] has numerous benefits:
+
+- it allows other providers to listen to the stream using [ref.watch].
+- it ensures that loading and error cases are properly handled, thanks to [AsyncValue].
+- it removes the need for having to differentiate broadcast streams vs normal streams.
+- it caches the latest value emitted by the stream, ensuring that if a
+  listener is added after an event is emitted, the listener will still have
+  immediate access to the most up-to-date event.
+- it allows easily mocking the stream during tests by overriding the `StreamProvider`.
+
+## Usage example: live chat using sockets
+
+`StreamProvider` is used in when we handle stream of asynchronous data
+such as Video Streaming, Weather broadcasting Apis or Live chat as follows:
+
+<AutoSnippet language="dart" {...streamProvider}></AutoSnippet>
+
+Then, the UI can listen to live streaming chats like so:
+
+<CodeBlock>{trimSnippet(streamConsumer)}</CodeBlock>
+
+[ref.watch]: ../concepts/reading#using-refwatch-to-observe-a-provider
+[statenotifierprovider]: ./state_notifier_provider
+[provider]: ./provider
+[futureprovider]: ./future_provider
+[asyncvalue]: https://pub.dev/documentation/riverpod/latest/riverpod/AsyncValue-class.html
+[future]: https://api.dart.dev/dart-async/Future-class.html
+[stream]: https://api.dart.dev/dart-async/Stream-class.html
+[stream.periodic]: https://api.dart.dev/stable/2.15.1/dart-async/Stream/Stream.periodic.html
+[family]: ../concepts/modifiers/family
+[streambuilder]: https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/stream_provider/live_stream_chat_consumer.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/stream_provider/live_stream_chat_consumer.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'live_stream_chat_provider.dart';
+
+/* SNIPPET START */
+Widget build(BuildContext context, WidgetRef ref) {
+  final liveChats = ref.watch(chatProvider);
+
+  // Like FutureProvider, it is possible to handle loading/error states using AsyncValue.when
+  return switch (liveChats) {
+    // Display all the messages in a scrollable list view.
+    AsyncData(:final value) => ListView.builder(
+        // Show messages from bottom to top
+        reverse: true,
+        itemCount: value.length,
+        itemBuilder: (context, index) {
+          final message = value[index];
+          return Text(message);
+        },
+      ),
+    AsyncError(:final error) => Text(error.toString()),
+    _ => const CircularProgressIndicator(),
+  };
+}

--- a/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/stream_provider/live_stream_chat_provider.dart
+++ b/website/i18n/zh-Hant/docusaurus-plugin-content-docs/current/providers/stream_provider/live_stream_chat_provider.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/* SNIPPET START */
+final chatProvider = StreamProvider<List<String>>((ref) async* {
+  // Connect to an API using sockets, and decode the output
+  final socket = await Socket.connect('my-api', 4242);
+  ref.onDispose(socket.close);
+  
+  var allMessages = const <String>[];
+  await for (final message in socket.map(utf8.decode)) {
+    // A new message has been received. Let's add it to the list of all messages.
+    allMessages = [...allMessages, message];
+    yield allMessages;
+  }
+});

--- a/website/i18n/zh-Hant/docusaurus-theme-classic/footer.json
+++ b/website/i18n/zh-Hant/docusaurus-theme-classic/footer.json
@@ -1,0 +1,54 @@
+{
+  "link.title.Docs": {
+    "message": "文件",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Community": {
+    "message": "社群",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.Sponsors": {
+    "message": "贊助",
+    "description": "The title of the footer links column with title=Sponsors in the footer"
+  },
+  "link.item.label.Why Riverpod?": {
+    "message": "為什麼選擇 Riverpod？",
+    "description": "The label of footer link with label=Why Riverpod? linking to docs/introduction/why_riverpod"
+  },
+  "link.item.label.Getting started": {
+    "message": "開始上手",
+    "description": "The label of footer link with label=Getting started linking to docs/introduction/getting_started"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/GSt793j6eT"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/rrousselgit/riverpod"
+  },
+  "link.item.label.Stack Overflow": {
+    "message": "Stack Overflow",
+    "description": "The label of footer link with label=Stack Overflow linking to https://stackoverflow.com/questions/tagged/flutter"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/remi_rousselet"
+  },
+  "link.item.label.Code of conduct": {
+    "message": "行為準則",
+    "description": "The label of footer link with label=Code of conduct linking to https://github.com/rrousselGit/riverpod/blob/master/CODE_OF_CONDUCT.md"
+  },
+  "link.item.label.Contributing guide": {
+    "message": "貢獻指南",
+    "description": "The label of footer link with label=Contributing guide linking to https://github.com/rrousselGit/riverpod/blob/rework-flow/CONTRIBUTING.md"
+  },
+  "copyright": {
+    "message": "Copyright © 2023 Remi Rousselet.<br /> 使用 Docusaurus 構建。",
+    "description": "The footer copyright"
+  },
+  "logo.alt": {
+    "message": "Riverpod",
+    "description": "The alt text of footer logo"
+  }
+}

--- a/website/i18n/zh-Hant/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/zh-Hant/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,18 @@
+{
+  "title": {
+    "message": "Riverpod",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "Riverpod",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Docs": {
+    "message": "文件",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}


### PR DESCRIPTION
This pull request introduces support for Traditional Chinese (zh-Hant) in the Riverpod documentation. The following updates were made to facilitate this:

* A new `zh-Hant` folder was created in the `website/i18n` directory.
* The `docusaurus.config.js` file was modified to include zh-Hant in the list of supported languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**  
  - Added Traditional Chinese language support, expanding the website’s localization options.

- **Documentation**  
  - Introduced a comprehensive suite of Traditional Chinese guides covering advanced topics such as performance optimization, network request debouncing and cancellation, pull-to-refresh functionality, and code generation.  
  - Enhanced content on provider lifecycle, testing strategies, migration guides, and best practices for Riverpod in Flutter, enabling a richer, more accessible user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->