### PR TITLE
make const

### DIFF
--- a/packages/riverpod/lib/src/experiments/providers.dart
+++ b/packages/riverpod/lib/src/experiments/providers.dart
@@ -108,7 +108,7 @@ class _AsyncProviderElement<T> extends ProviderElementBase<AsyncValue<T>>
 }
 
 class _DelegatedAsyncProvider<StateT> with AsyncProvider<StateT> {
-  _DelegatedAsyncProvider(this._build);
+  const _DelegatedAsyncProvider(this._build);
   final FutureOr<StateT> Function(AsyncRef<StateT> ref) _build;
 
   @override
@@ -130,14 +130,14 @@ ProviderElementProxy<AsyncValue<T>, Future<T>> _future<T>(
 
 abstract mixin class AsyncProvider<StateT>
     implements ProviderBase2<AsyncValue<StateT>> {
-  factory AsyncProvider(
+  const factory AsyncProvider(
     FutureOr<StateT> Function(AsyncRef<StateT> ref) build,
   ) = _DelegatedAsyncProvider;
 
   @override
   Record? get args => null;
 
-  late final ProviderListenable<Future<StateT>> future = _future(this);
+  ProviderListenable<Future<StateT>> get future => _future(this);
 
   FutureOr<StateT> build(AsyncRef<StateT> ref);
 


### PR DESCRIPTION
```dart
class Example with AsyncProvider<int> {
  const Example(this.name);

  final String name;

  Record get args => (name,);

  void function(int b) {}

  @override
  FutureOr<int> build(AsyncRef<int> ref) => throw UnimplementedError();
}

void main() {
  const exampleProvider1 = Example('a');
  const exampleProvide2 = Example('a');
  final exampleProvide3 = Example('a');
  final exampleProvide4 = Example('a');

  print(exampleProvide1.function == exampleProvide2.function); // true
  print(exampleProvide3.function == exampleProvide4.function); // false
}
```
