### PR TITLE
Update listenable

### DIFF
--- a/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
+++ b/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
@@ -294,15 +294,11 @@ class ChangeNotifierProviderElement<NotifierT extends ChangeNotifier?>
   }
 
   @override
-  void visitChildren({
-    required void Function(ProviderElementBase<Object?> element) elementVisitor,
-    required void Function($ElementLense<Object?> element) notifierVisitor,
-  }) {
-    super.visitChildren(
-      elementVisitor: elementVisitor,
-      notifierVisitor: notifierVisitor,
-    );
-    notifierVisitor(_notifierNotifier);
+  void visitListenables(
+    void Function($ElementLense<Object?> element) listenableVisitor,
+  ) {
+    super.visitListenables(listenableVisitor);
+    listenableVisitor(_notifierNotifier);
   }
 }
 

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -331,10 +331,8 @@ abstract class ProviderElementBase<StateT> implements Ref<StateT>, Node {
     // do not want to set the _dependencyMayHaveChanged flag to true.
     // Since the dependency is known to have changed, there is no reason to try
     // and "flush" it, as it will already get rebuilt.
-    visitChildren(
-      elementVisitor: (element) => element._markDependencyMayHaveChanged(),
-      notifierVisitor: (notifier) => notifier.notifyDependencyMayHaveChanged(),
-    );
+    visitChildren((element) => element._markDependencyMayHaveChanged());
+    visitListenables((notifier) => notifier.notifyDependencyMayHaveChanged());
   }
 
   /// A utility for re-initializing a provider when needed.
@@ -634,9 +632,9 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     _dependencyMayHaveChanged = true;
 
     visitChildren(
-      elementVisitor: (element) => element._markDependencyMayHaveChanged(),
-      notifierVisitor: (notifier) => notifier.notifyDependencyMayHaveChanged(),
+      (element) => element._markDependencyMayHaveChanged(),
     );
+    visitListenables((notifier) => notifier.notifyDependencyMayHaveChanged());
   }
 
   bool _debugAssertCanDependOn(Object? listenable) {
@@ -832,10 +830,9 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
   /// This method does not guarantee that a dependency is visited only once.
   /// If a provider both [watch] and [listen] an element, or if a provider
   /// [listen] multiple times to an element, it may be visited multiple times.
-  void visitChildren({
-    required void Function(ProviderElementBase element) elementVisitor,
-    required void Function($ElementLense element) notifierVisitor,
-  }) {
+  void visitChildren(
+    void Function(ProviderElementBase element) elementVisitor,
+  ) {
     for (var i = 0; i < _providerDependents.length; i++) {
       elementVisitor(_providerDependents[i]);
     }
@@ -848,6 +845,10 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
       }
     }
   }
+
+  void visitListenables(
+    void Function($ElementLense element) listenableVisitor,
+  ) {}
 
   /// Visit the [ProviderElementBase]s that this provider is listening to.
   ///

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -753,23 +753,19 @@ class ProviderContainer implements Node {
       // were already visited before.
       // If a child does not have all of its ancestors visited, when those
       // ancestors will be visited, they will retry visiting this child.
-      element.visitChildren(
-        elementVisitor: (dependent) {
-          if (dependent.container == this) {
-            // All the parents of a node must have been visited before a node is visited
-            var areAllAncestorsAlreadyVisited = true;
-            dependent.visitAncestors((e) {
-              if (e._container == this && !visitedNodes.contains(e)) {
-                areAllAncestorsAlreadyVisited = false;
-              }
-            });
+      element.visitChildren((dependent) {
+        if (dependent.container == this) {
+          // All the parents of a node must have been visited before a node is visited
+          var areAllAncestorsAlreadyVisited = true;
+          dependent.visitAncestors((e) {
+            if (e._container == this && !visitedNodes.contains(e)) {
+              areAllAncestorsAlreadyVisited = false;
+            }
+          });
 
-            if (areAllAncestorsAlreadyVisited) queue.add(dependent);
-          }
-        },
-        // We only care about Elements here, so let's ignore notifiers
-        notifierVisitor: (_) {},
-      );
+          if (areAllAncestorsAlreadyVisited) queue.add(dependent);
+        }
+      });
     }
   }
 }

--- a/packages/riverpod/lib/src/experiments/mutations.dart
+++ b/packages/riverpod/lib/src/experiments/mutations.dart
@@ -70,14 +70,10 @@ mixin _MutationElement<T> on ProviderElementBase<T> {
   final mutations = <Mutation<Object?>, _MutationState<Object?>>{};
 
   @override
-  void visitChildren({
-    required void Function(ProviderElementBase element) elementVisitor,
-    required void Function($ElementLense element) notifierVisitor,
-  }) {
-    super.visitChildren(
-      elementVisitor: elementVisitor,
-      notifierVisitor: notifierVisitor,
-    );
+  void visitListenables(
+    void Function($ElementLense element) notifierVisitor,
+  ) {
+    super.visitListenables(notifierVisitor);
     for (final mutation in mutations.values) {
       notifierVisitor(mutation.listenable);
     }

--- a/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
@@ -473,7 +473,8 @@ mixin FutureHandlerProviderElementMixin<T>
 
   @override
   void visitListenables(
-      void Function($ElementLense element) listenableVisitor) {
+    void Function($ElementLense element) listenableVisitor,
+  ) {
     super.visitListenables(listenableVisitor);
     listenableVisitor(futureNotifier);
   }
@@ -493,7 +494,8 @@ abstract class AsyncNotifierProviderElementBase<
 
   @override
   void visitListenables(
-      void Function($ElementLense element) listenableVisitor) {
+    void Function($ElementLense element) listenableVisitor,
+  ) {
     super.visitListenables(listenableVisitor);
     listenableVisitor(_notifierNotifier);
   }

--- a/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
@@ -472,15 +472,9 @@ mixin FutureHandlerProviderElementMixin<T>
   }
 
   @override
-  void visitChildren({
-    required void Function(ProviderElementBase element) elementVisitor,
-    required void Function($ElementLense element) notifierVisitor,
-  }) {
-    super.visitChildren(
-      elementVisitor: elementVisitor,
-      notifierVisitor: notifierVisitor,
-    );
-    notifierVisitor(futureNotifier);
+  void visitListenables(void Function($ElementLense element) listenableVisitor) {
+    super.visitListenables(listenableVisitor);
+    listenableVisitor(futureNotifier);
   }
 }
 
@@ -497,15 +491,9 @@ abstract class AsyncNotifierProviderElementBase<
   final _notifierNotifier = $ElementLense<NotifierT>();
 
   @override
-  void visitChildren({
-    required void Function(ProviderElementBase element) elementVisitor,
-    required void Function($ElementLense element) notifierVisitor,
-  }) {
-    super.visitChildren(
-      elementVisitor: elementVisitor,
-      notifierVisitor: notifierVisitor,
-    );
-    notifierVisitor(_notifierNotifier);
+  void visitListenables(void Function($ElementLense element) listenableVisitor) {
+    super.visitListenables(listenableVisitor);
+    listenableVisitor(_notifierNotifier);
   }
 
   @override

--- a/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
@@ -472,7 +472,8 @@ mixin FutureHandlerProviderElementMixin<T>
   }
 
   @override
-  void visitListenables(void Function($ElementLense element) listenableVisitor) {
+  void visitListenables(
+      void Function($ElementLense element) listenableVisitor) {
     super.visitListenables(listenableVisitor);
     listenableVisitor(futureNotifier);
   }
@@ -491,7 +492,8 @@ abstract class AsyncNotifierProviderElementBase<
   final _notifierNotifier = $ElementLense<NotifierT>();
 
   @override
-  void visitListenables(void Function($ElementLense element) listenableVisitor) {
+  void visitListenables(
+      void Function($ElementLense element) listenableVisitor) {
     super.visitListenables(listenableVisitor);
     listenableVisitor(_notifierNotifier);
   }

--- a/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
@@ -250,15 +250,11 @@ class StateNotifierProviderElement<NotifierT extends StateNotifier<T>, T>
   }
 
   @override
-  void visitChildren({
-    required void Function(ProviderElementBase element) elementVisitor,
-    required void Function($ElementLense element) notifierVisitor,
-  }) {
-    super.visitChildren(
-      elementVisitor: elementVisitor,
-      notifierVisitor: notifierVisitor,
-    );
-    notifierVisitor(_notifierNotifier);
+  void visitListenables(
+    void Function($ElementLense element) listenableVisitor,
+  ) {
+    super.visitListenables(listenableVisitor);
+    listenableVisitor(_notifierNotifier);
   }
 }
 

--- a/packages/riverpod/lib/src/providers/legacy/state_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_provider.dart
@@ -211,16 +211,12 @@ class StateProviderElement<T> extends ProviderElementBase<T>
   }
 
   @override
-  void visitChildren({
-    required void Function(ProviderElementBase element) elementVisitor,
-    required void Function($ElementLense element) notifierVisitor,
-  }) {
-    super.visitChildren(
-      elementVisitor: elementVisitor,
-      notifierVisitor: notifierVisitor,
-    );
-    notifierVisitor(_stateNotifier);
-    notifierVisitor(_controllerNotifier);
+  void visitListenables(
+    void Function($ElementLense element) listenableVisitor,
+  ) {
+    super.visitListenables(listenableVisitor);
+    listenableVisitor(_stateNotifier);
+    listenableVisitor(_controllerNotifier);
   }
 }
 

--- a/packages/riverpod/lib/src/providers/notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/notifier/orphan.dart
@@ -215,15 +215,11 @@ class NotifierProviderElement<NotifierT extends NotifierBase<T>, T>
   }
 
   @override
-  void visitChildren({
-    required void Function(ProviderElementBase element) elementVisitor,
-    required void Function($ElementLense element) notifierVisitor,
-  }) {
-    super.visitChildren(
-      elementVisitor: elementVisitor,
-      notifierVisitor: notifierVisitor,
-    );
-    notifierVisitor(_notifierNotifier);
+  void visitListenables(
+    void Function($ElementLense element) listenableVisitor,
+  ) {
+    super.visitListenables(listenableVisitor);
+    listenableVisitor(_notifierNotifier);
   }
 
   @override

--- a/packages/riverpod/lib/src/providers/stream_provider.dart
+++ b/packages/riverpod/lib/src/providers/stream_provider.dart
@@ -240,15 +240,11 @@ class StreamProviderElement<T> extends ProviderElementBase<AsyncValue<T>>
   }
 
   @override
-  void visitChildren({
-    required void Function(ProviderElementBase element) elementVisitor,
-    required void Function($ElementLense element) notifierVisitor,
-  }) {
-    super.visitChildren(
-      elementVisitor: elementVisitor,
-      notifierVisitor: notifierVisitor,
-    );
-    notifierVisitor(_streamNotifier);
+  void visitListenables(
+    void Function($ElementLense element) listenableVisitor,
+  ) {
+    super.visitListenables(listenableVisitor);
+    listenableVisitor(_streamNotifier);
   }
 
   @override

--- a/packages/riverpod/test/old/framework/provider_element_test.dart
+++ b/packages/riverpod/test/old/framework/provider_element_test.dart
@@ -1222,9 +1222,7 @@ void main() {
 
       final children = <ProviderElementBase<Object?>>[];
 
-      container
-          .readProviderElement(provider)
-          .visitChildren(elementVisitor: children.add, notifierVisitor: (_) {});
+      container.readProviderElement(provider).visitChildren(children.add);
       expect(
         children,
         unorderedMatches(<Object>[
@@ -1253,7 +1251,7 @@ void main() {
 
       container
           .readProviderElement(provider)
-          .visitChildren(elementVisitor: children.add, notifierVisitor: (_) {});
+          .visitChildren(children.add);
       expect(
         children,
         unorderedMatches(<Object>[

--- a/packages/riverpod/test/old/framework/provider_element_test.dart
+++ b/packages/riverpod/test/old/framework/provider_element_test.dart
@@ -1249,9 +1249,7 @@ void main() {
 
       final children = <ProviderElementBase<Object?>>[];
 
-      container
-          .readProviderElement(provider)
-          .visitChildren(children.add);
+      container.readProviderElement(provider).visitChildren(children.add);
       expect(
         children,
         unorderedMatches(<Object>[

--- a/packages/riverpod/test/old/legacy/framework2/framework_test.dart
+++ b/packages/riverpod/test/old/legacy/framework2/framework_test.dart
@@ -257,13 +257,11 @@ void main() {
     expect(sub.read(), '0');
     var firstDependents = <ProviderElementBase<Object?>>[];
     firstElement.visitChildren(
-      elementVisitor: firstDependents.add,
-      notifierVisitor: (_) {},
+      firstDependents.add,
     );
     var secondDependents = <ProviderElementBase<Object?>>[];
     secondElement.visitChildren(
-      elementVisitor: secondDependents.add,
-      notifierVisitor: (_) {},
+      secondDependents.add,
     );
 
     expect(firstDependents, [computedElement]);
@@ -275,15 +273,9 @@ void main() {
     expect(sub.read(), 'fallback');
 
     firstDependents = <ProviderElementBase<Object?>>[];
-    firstElement.visitChildren(
-      elementVisitor: firstDependents.add,
-      notifierVisitor: (_) {},
-    );
+    firstElement.visitChildren(firstDependents.add);
     secondDependents = <ProviderElementBase<Object?>>[];
-    secondElement.visitChildren(
-      elementVisitor: secondDependents.add,
-      notifierVisitor: (_) {},
-    );
+    secondElement.visitChildren(secondDependents.add);
     expect(firstDependents, [computedElement]);
     expect(firstElement.hasListeners, true);
     expect(secondDependents, <ProviderElement<Object?>>[]);
@@ -321,10 +313,7 @@ void main() {
 
     expect(sub.read(), 0);
     var firstDependents = <ProviderElementBase<Object?>>[];
-    firstElement.visitChildren(
-      elementVisitor: firstDependents.add,
-      notifierVisitor: (_) {},
-    );
+    firstElement.visitChildren(firstDependents.add);
     expect(firstDependents, {computedElement});
     expect(firstElement.hasListeners, true);
 
@@ -332,10 +321,7 @@ void main() {
     await container.pump();
 
     firstDependents = <ProviderElementBase<Object?>>[];
-    firstElement.visitChildren(
-      elementVisitor: firstDependents.add,
-      notifierVisitor: (_) {},
-    );
+    firstElement.visitChildren(firstDependents.add);
     expect(firstDependents, <ProviderElement<Object?>>{});
     expect(firstElement.hasListeners, false);
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and separated the visitation of provider elements and listenable notifiers by introducing a new method dedicated to visiting listenables.
  - Updated multiple provider classes to adopt this streamlined visitation pattern, enhancing consistency and clarity in how listenable elements are handled.
- **Tests**
  - Modified test cases to reflect the updated visitation method signatures, maintaining coverage and alignment with the new interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->