### PR TITLE
Simplify override logic

### DIFF
--- a/examples/counter/lib/main.g.dart
+++ b/examples/counter/lib/main.g.dart
@@ -22,10 +22,8 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   /// accessible using the generated [counterProvider].
   /// This class is both responsible for initializing the state (through the [build] method)
   /// and exposing ways to modify it (cf [increment]).
-  const CounterProvider._(
-      {super.runNotifierBuildOverride, Counter Function()? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -35,10 +33,18 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
           allTransitiveDependencies: null,
         );
 
-  final Counter Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  Counter create() => Counter();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Counter, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -47,35 +53,6 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Counter create() => _createCb?.call() ?? Counter();
-
-  @$internal
-  @override
-  CounterProvider $copyWithCreate(
-    Counter Function() create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Counter,
-    ) build,
-  ) {
-    return CounterProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Counter, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterHash() => r'4243b34530f53accfd9014a9f0e316fe304ada3e';

--- a/examples/pub/lib/detail.g.dart
+++ b/examples/pub/lib/detail.g.dart
@@ -224,14 +224,6 @@ final class PackageMetricsProvider
       $createElement($ProviderPointer pointer) =>
           $AsyncNotifierProviderElement(pointer);
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<PackageMetricsScore> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<PackageMetricsScore>>(value),
-    );
-  }
-
   @override
   bool operator ==(Object other) {
     return other is PackageMetricsProvider && other.argument == argument;

--- a/examples/pub/lib/detail.g.dart
+++ b/examples/pub/lib/detail.g.dart
@@ -16,24 +16,14 @@ final class FetchPackageDetailsProvider
     with $FutureModifier<Package>, $FutureProvider<Package> {
   const FetchPackageDetailsProvider._(
       {required FetchPackageDetailsFamily super.from,
-      required String super.argument,
-      FutureOr<Package> Function(
-        Ref ref, {
-        required String packageName,
-      })? create})
-      : _createCb = create,
-        super(
+      required String super.argument})
+      : super(
           retry: null,
           name: r'fetchPackageDetailsProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FutureOr<Package> Function(
-    Ref ref, {
-    required String packageName,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$fetchPackageDetailsHash();
@@ -48,29 +38,12 @@ final class FetchPackageDetailsProvider
   @$internal
   @override
   $FutureProviderElement<Package> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  FetchPackageDetailsProvider $copyWithCreate(
-    FutureOr<Package> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FetchPackageDetailsProvider._(
-        argument: argument as String,
-        from: from! as FetchPackageDetailsFamily,
-        create: (
-          ref, {
-          required String packageName,
-        }) =>
-            create(ref));
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Package> create(Ref ref) {
-    final _$cb = _createCb ?? fetchPackageDetails;
     final argument = this.argument as String;
-    return _$cb(
+    return fetchPackageDetails(
       ref,
       packageName: argument,
     );
@@ -106,31 +79,23 @@ final class FetchPackageDetailsFamily extends Family {
       FetchPackageDetailsProvider._(argument: packageName, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$fetchPackageDetailsHash();
-
-  @override
   String toString() => r'fetchPackageDetailsProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FutureOr<Package> Function(
-      Ref ref,
-      String args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FetchPackageDetailsProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<Package> Function(
+            Ref ref,
+            String args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FetchPackageDetailsProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(likedPackages)
@@ -139,12 +104,8 @@ const likedPackagesProvider = LikedPackagesProvider._();
 final class LikedPackagesProvider extends $FunctionalProvider<
         AsyncValue<List<String>>, FutureOr<List<String>>>
     with $FutureModifier<List<String>>, $FutureProvider<List<String>> {
-  const LikedPackagesProvider._(
-      {FutureOr<List<String>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const LikedPackagesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -154,10 +115,6 @@ final class LikedPackagesProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<List<String>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$likedPackagesHash();
 
@@ -165,21 +122,11 @@ final class LikedPackagesProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<List<String>> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  LikedPackagesProvider $copyWithCreate(
-    FutureOr<List<String>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return LikedPackagesProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<String>> create(Ref ref) {
-    final _$cb = _createCb ?? likedPackages;
-    return _$cb(ref);
+    return likedPackages(ref);
   }
 }
 
@@ -191,12 +138,8 @@ const pubRepositoryProvider = PubRepositoryProvider._();
 final class PubRepositoryProvider
     extends $FunctionalProvider<PubRepository, PubRepository>
     with $Provider<PubRepository> {
-  const PubRepositoryProvider._(
-      {PubRepository Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const PubRepositoryProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -206,12 +149,18 @@ final class PubRepositoryProvider
           allTransitiveDependencies: null,
         );
 
-  final PubRepository Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$pubRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<PubRepository> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  PubRepository create(Ref ref) {
+    return pubRepository(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(PubRepository value) {
@@ -219,26 +168,6 @@ final class PubRepositoryProvider
       origin: this,
       providerOverride: $ValueProvider<PubRepository>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<PubRepository> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  PubRepositoryProvider $copyWithCreate(
-    PubRepository Function(
-      Ref ref,
-    ) create,
-  ) {
-    return PubRepositoryProvider._(create: create);
-  }
-
-  @override
-  PubRepository create(Ref ref) {
-    final _$cb = _createCb ?? pubRepository;
-    return _$cb(ref);
   }
 }
 
@@ -266,19 +195,14 @@ final class PackageMetricsProvider
   /// is logged-in.
   const PackageMetricsProvider._(
       {required PackageMetricsFamily super.from,
-      required String super.argument,
-      super.runNotifierBuildOverride,
-      PackageMetrics Function()? create})
-      : _createCb = create,
-        super(
+      required String super.argument})
+      : super(
           retry: null,
           name: r'packageMetricsProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final PackageMetrics Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$packageMetricsHash();
@@ -292,38 +216,21 @@ final class PackageMetricsProvider
 
   @$internal
   @override
-  PackageMetrics create() => _createCb?.call() ?? PackageMetrics();
-
-  @$internal
-  @override
-  PackageMetricsProvider $copyWithCreate(
-    PackageMetrics Function() create,
-  ) {
-    return PackageMetricsProvider._(
-        argument: argument as String,
-        from: from! as PackageMetricsFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  PackageMetricsProvider $copyWithBuild(
-    FutureOr<PackageMetricsScore> Function(
-      Ref,
-      PackageMetrics,
-    ) build,
-  ) {
-    return PackageMetricsProvider._(
-        argument: argument as String,
-        from: from! as PackageMetricsFamily,
-        runNotifierBuildOverride: build);
-  }
+  PackageMetrics create() => PackageMetrics();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<PackageMetrics, PackageMetricsScore>
       $createElement($ProviderPointer pointer) =>
-          $AsyncNotifierProviderElement(this, pointer);
+          $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<PackageMetricsScore> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<PackageMetricsScore>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -364,50 +271,39 @@ final class PackageMetricsFamily extends Family {
       PackageMetricsProvider._(argument: packageName, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$packageMetricsHash();
-
-  @override
   String toString() => r'packageMetricsProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    PackageMetrics Function(
-      String args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as PackageMetricsProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          PackageMetrics Function(
+            String args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as PackageMetricsProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    FutureOr<PackageMetricsScore> Function(
-            Ref ref, PackageMetrics notifier, String argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as PackageMetricsProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<PackageMetricsScore> Function(
+                  Ref ref, PackageMetrics notifier, String argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as PackageMetricsProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$PackageMetrics extends $AsyncNotifier<PackageMetricsScore> {

--- a/examples/pub/lib/search.g.dart
+++ b/examples/pub/lib/search.g.dart
@@ -20,26 +20,14 @@ final class FetchPackagesProvider extends $FunctionalProvider<
         int page,
         String search,
       })
-          super.argument,
-      FutureOr<List<Package>> Function(
-        Ref ref, {
-        required int page,
-        String search,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'fetchPackagesProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FutureOr<List<Package>> Function(
-    Ref ref, {
-    required int page,
-    String search,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$fetchPackagesHash();
@@ -55,36 +43,15 @@ final class FetchPackagesProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<List<Package>> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  FetchPackagesProvider $copyWithCreate(
-    FutureOr<List<Package>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FetchPackagesProvider._(
-        argument: argument as ({
-          int page,
-          String search,
-        }),
-        from: from! as FetchPackagesFamily,
-        create: (
-          ref, {
-          required int page,
-          String search = '',
-        }) =>
-            create(ref));
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Package>> create(Ref ref) {
-    final _$cb = _createCb ?? fetchPackages;
     final argument = this.argument as ({
       int page,
       String search,
     });
-    return _$cb(
+    return fetchPackages(
       ref,
       page: argument.page,
       search: argument.search,
@@ -124,37 +91,29 @@ final class FetchPackagesFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$fetchPackagesHash();
-
-  @override
   String toString() => r'fetchPackagesProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FutureOr<List<Package>> Function(
-      Ref ref,
-      ({
-        int page,
-        String search,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FetchPackagesProvider;
-
-        final argument = provider.argument as ({
-          int page,
-          String search,
-        });
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<List<Package>> Function(
+            Ref ref,
+            ({
+              int page,
+              String search,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FetchPackagesProvider;
+            final argument = provider.argument as ({
+              int page,
+              String search,
+            });
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/examples/stackoverflow/lib/common.g.dart
+++ b/examples/stackoverflow/lib/common.g.dart
@@ -25,12 +25,8 @@ final class ThemeProvider extends $FunctionalProvider<ThemeData, ThemeData>
   ///
   /// This is unimplemented by default, and will be overridden inside [MaterialApp]
   /// with the current theme obtained using a [BuildContext].
-  const ThemeProvider._(
-      {ThemeData Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ThemeProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -40,12 +36,18 @@ final class ThemeProvider extends $FunctionalProvider<ThemeData, ThemeData>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final ThemeData Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$themeHash();
+
+  @$internal
+  @override
+  $ProviderElement<ThemeData> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  ThemeData create(Ref ref) {
+    return theme(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(ThemeData value) {
@@ -53,26 +55,6 @@ final class ThemeProvider extends $FunctionalProvider<ThemeData, ThemeData>
       origin: this,
       providerOverride: $ValueProvider<ThemeData>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<ThemeData> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ThemeProvider $copyWithCreate(
-    ThemeData Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ThemeProvider._(create: create);
-  }
-
-  @override
-  ThemeData create(Ref ref) {
-    final _$cb = _createCb ?? theme;
-    return _$cb(ref);
   }
 }
 

--- a/examples/stackoverflow/lib/question.g.dart
+++ b/examples/stackoverflow/lib/question.g.dart
@@ -65,12 +65,8 @@ const questionThemeProvider = QuestionThemeProvider._();
 final class QuestionThemeProvider
     extends $FunctionalProvider<QuestionTheme, QuestionTheme>
     with $Provider<QuestionTheme> {
-  const QuestionThemeProvider._(
-      {QuestionTheme Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const QuestionThemeProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -80,12 +76,18 @@ final class QuestionThemeProvider
           allTransitiveDependencies: null,
         );
 
-  final QuestionTheme Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$questionThemeHash();
+
+  @$internal
+  @override
+  $ProviderElement<QuestionTheme> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  QuestionTheme create(Ref ref) {
+    return questionTheme(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(QuestionTheme value) {
@@ -93,26 +95,6 @@ final class QuestionThemeProvider
       origin: this,
       providerOverride: $ValueProvider<QuestionTheme>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<QuestionTheme> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  QuestionThemeProvider $copyWithCreate(
-    QuestionTheme Function(
-      Ref ref,
-    ) create,
-  ) {
-    return QuestionThemeProvider._(create: create);
-  }
-
-  @override
-  QuestionTheme create(Ref ref) {
-    final _$cb = _createCb ?? questionTheme;
-    return _$cb(ref);
   }
 }
 
@@ -160,12 +142,8 @@ final class CurrentQuestionProvider
   ///
   /// This is an optional step. Since scoping is a fairly advanced mechanism,
   /// it's entirely fine to simply pass the [Question] to [QuestionItem] directly.
-  const CurrentQuestionProvider._(
-      {AsyncValue<Question> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CurrentQuestionProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -175,12 +153,19 @@ final class CurrentQuestionProvider
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final AsyncValue<Question> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$currentQuestionHash();
+
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<Question>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  AsyncValue<Question> create(Ref ref) {
+    return currentQuestion(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<Question> value) {
@@ -188,27 +173,6 @@ final class CurrentQuestionProvider
       origin: this,
       providerOverride: $ValueProvider<AsyncValue<Question>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<AsyncValue<Question>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CurrentQuestionProvider $copyWithCreate(
-    AsyncValue<Question> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CurrentQuestionProvider._(create: create);
-  }
-
-  @override
-  AsyncValue<Question> create(Ref ref) {
-    final _$cb = _createCb ?? currentQuestion;
-    return _$cb(ref);
   }
 }
 

--- a/examples/stackoverflow/lib/tag.g.dart
+++ b/examples/stackoverflow/lib/tag.g.dart
@@ -13,12 +13,8 @@ const tagThemeProvider = TagThemeProvider._();
 
 final class TagThemeProvider extends $FunctionalProvider<TagTheme, TagTheme>
     with $Provider<TagTheme> {
-  const TagThemeProvider._(
-      {TagTheme Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const TagThemeProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -32,12 +28,18 @@ final class TagThemeProvider extends $FunctionalProvider<TagTheme, TagTheme>
 
   static const $allTransitiveDependencies0 = themeProvider;
 
-  final TagTheme Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$tagThemeHash();
+
+  @$internal
+  @override
+  $ProviderElement<TagTheme> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  TagTheme create(Ref ref) {
+    return tagTheme(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(TagTheme value) {
@@ -45,26 +47,6 @@ final class TagThemeProvider extends $FunctionalProvider<TagTheme, TagTheme>
       origin: this,
       providerOverride: $ValueProvider<TagTheme>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<TagTheme> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  TagThemeProvider $copyWithCreate(
-    TagTheme Function(
-      Ref ref,
-    ) create,
-  ) {
-    return TagThemeProvider._(create: create);
-  }
-
-  @override
-  TagTheme create(Ref ref) {
-    final _$cb = _createCb ?? tagTheme;
-    return _$cb(ref);
   }
 }
 

--- a/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
+++ b/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
@@ -132,40 +132,22 @@ final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
   Refreshable<NotifierT> get notifier => _notifier<NotifierT>(this);
 
   final NotifierT Function(Ref ref) _createFn;
+  @override
+  NotifierT create(Ref ref) => _createFn(ref);
 
   @internal
   @override
   ChangeNotifierProviderElement<NotifierT> $createElement(
     $ProviderPointer pointer,
   ) {
-    return ChangeNotifierProviderElement<NotifierT>._(this, pointer);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  ChangeNotifierProvider<NotifierT> $copyWithCreate(
-    Create<NotifierT> create,
-  ) {
-    return ChangeNotifierProvider<NotifierT>.internal(
-      create,
-      name: name,
-      dependencies: dependencies,
-      isAutoDispose: isAutoDispose,
-      from: from,
-      argument: argument,
-      allTransitiveDependencies: allTransitiveDependencies,
-    );
+    return ChangeNotifierProviderElement<NotifierT>._(pointer);
   }
 }
 
 /// The element of [ChangeNotifierProvider].
 class ChangeNotifierProviderElement<NotifierT extends ChangeNotifier?>
-    extends ProviderElement<NotifierT> {
-  ChangeNotifierProviderElement._(this.provider, super.pointer);
-
-  @override
-  final ChangeNotifierProvider<NotifierT> provider;
+    extends $FunctionalProviderElement<NotifierT, NotifierT> {
+  ChangeNotifierProviderElement._(super.pointer);
 
   final _notifierNotifier = $ElementLense<NotifierT>();
 
@@ -174,7 +156,7 @@ class ChangeNotifierProviderElement<NotifierT extends ChangeNotifier?>
   @override
   WhenComplete create(Ref ref) {
     final notifierResult = _notifierNotifier.result = $Result.guard(
-      () => provider._createFn(ref),
+      () => provider.create(ref),
     );
 
     final notifier = notifierResult.requireState;
@@ -232,26 +214,4 @@ class ChangeNotifierProviderFamily<NotifierT extends ChangeNotifier?, Arg>
           allTransitiveDependencies:
               computeAllTransitiveDependencies(dependencies),
         );
-
-  @override
-  Override overrideWith(
-    NotifierT Function(Ref ref, Arg arg) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ChangeNotifierProvider<NotifierT>;
-
-        return ChangeNotifierProvider<NotifierT>.internal(
-          (ref) => create(ref, provider.argument as Arg),
-          from: provider.from,
-          argument: provider.argument,
-          isAutoDispose: provider.isAutoDispose,
-          dependencies: null,
-          allTransitiveDependencies: null,
-          name: null,
-        ).$createElement(pointer);
-      },
-    );
-  }
 }

--- a/packages/riverpod/lib/src/core/family.dart
+++ b/packages/riverpod/lib/src/core/family.dart
@@ -29,7 +29,6 @@ typedef ClassProviderFactory< //
   required String? name,
   required Iterable<ProviderOrFamily>? dependencies,
   required Iterable<ProviderOrFamily>? allTransitiveDependencies,
-  required RunNotifierBuild<NotifierT, CreatedT>? runNotifierBuildOverride,
   required bool isAutoDispose,
   required Family from,
   required ArgT argument,
@@ -113,9 +112,6 @@ class FunctionalFamily< //
     );
   }
 
-  @override
-  String? debugGetCreateSourceHash() => null;
-
   /// {@macro riverpod.override_with}
   Override overrideWith(
     CreatedT Function(Ref ref, ArgT arg) create,
@@ -126,7 +122,7 @@ class FunctionalFamily< //
         final provider = pointer.origin as ProviderT;
 
         return provider
-            .$copyWithCreate((ref) => create(ref, provider.argument as ArgT))
+            .$view(create: (ref) => create(ref, provider.argument as ArgT))
             .$createElement(pointer);
       },
     );
@@ -181,12 +177,8 @@ class ClassFamily< //
       argument: argument,
       dependencies: null,
       allTransitiveDependencies: null,
-      runNotifierBuildOverride: null,
     );
   }
-
-  @override
-  String? debugGetCreateSourceHash() => null;
 
   /// {@macro riverpod.override_with}
   Override overrideWith(NotifierT Function() create) {
@@ -195,7 +187,7 @@ class ClassFamily< //
       createElement: (pointer) {
         final provider = pointer.origin as ProviderT;
 
-        return provider.$copyWithCreate(create).$createElement(pointer);
+        return provider.$view(create: create).$createElement(pointer);
       },
     );
   }
@@ -209,7 +201,9 @@ class ClassFamily< //
       createElement: (pointer) {
         final provider = pointer.origin as ProviderT;
 
-        return provider.$copyWithBuild(build).$createElement(pointer);
+        return provider
+            .$view(runNotifierBuildOverride: build)
+            .$createElement(pointer);
       },
     );
   }

--- a/packages/riverpod/lib/src/core/foundation.dart
+++ b/packages/riverpod/lib/src/core/foundation.dart
@@ -104,17 +104,7 @@ sealed class ProviderOrFamily implements ProviderListenableOrFamily {
   /// automatically when the provider stops being listened.
   final bool isAutoDispose;
 
-  /// A debug-only function for obtaining a hash of the source code of the
-  /// initialization function.
-  ///
-  /// If after a hot-reload this function returns a different result, the
-  /// provider will be re-executed.
-  ///
-  /// This method only returns a non-null value when using `riverpod_generator`.
-  // This is voluntarily not implemented by default, to force all non-generated
-  // providers to apply the LegacyProviderMixin.
-  @internal
-  String? debugGetCreateSourceHash();
+
 }
 
 extension on ProviderListenableOrFamily {

--- a/packages/riverpod/lib/src/core/foundation.dart
+++ b/packages/riverpod/lib/src/core/foundation.dart
@@ -103,8 +103,6 @@ sealed class ProviderOrFamily implements ProviderListenableOrFamily {
   /// Whether the state associated to this provider should be disposed
   /// automatically when the provider stops being listened.
   final bool isAutoDispose;
-
-
 }
 
 extension on ProviderListenableOrFamily {

--- a/packages/riverpod/lib/src/core/provider/functional_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/functional_provider.dart
@@ -18,13 +18,12 @@ abstract base class $FunctionalProvider< //
     required super.retry,
   });
 
-  /// Clone a provider with a different initialization method.
-  ///
-  /// This is an implementation detail of Riverpod and should not be used.
-  @visibleForOverriding
-  $FunctionalProvider<StateT, CreatedT> $copyWithCreate(
-    Create<CreatedT> create,
-  );
+  @internal
+  $FunctionalProvider<StateT, CreatedT> $view({
+    required Create<CreatedT> create,
+  }) {
+    return _FunctionalProviderView.$FunctionalView(this, create);
+  }
 
   /// {@template riverpod.override_with}
   /// Override the provider with a new initialization function.
@@ -63,7 +62,60 @@ abstract base class $FunctionalProvider< //
   Override overrideWith(Create<CreatedT> create) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $copyWithCreate(create),
+      providerOverride: $view(create: create),
     );
   }
+
+  @internal
+  CreatedT create(Ref ref);
+
+  @override
+  $FunctionalProviderElement<StateT, CreatedT> $createElement(
+    $ProviderPointer pointer,
+  );
+}
+
+final class _FunctionalProviderView<StateT, CreatedT> //
+    extends $FunctionalProvider<StateT, CreatedT> {
+  /// Implementation detail of `riverpod_generator`.
+  /// Do not use, as this can be removed at any time.
+  _FunctionalProviderView.$FunctionalView(
+    this._inner,
+    this._createOverride,
+  ) : super(
+          name: _inner.name,
+          from: _inner.from,
+          argument: _inner.argument,
+          dependencies: _inner.dependencies,
+          allTransitiveDependencies: _inner.allTransitiveDependencies,
+          isAutoDispose: _inner.isAutoDispose,
+          retry: _inner.retry,
+        );
+
+  final $FunctionalProvider<StateT, CreatedT> _inner;
+  final Create<CreatedT> _createOverride;
+
+  @override
+  CreatedT create(Ref ref) => _createOverride(ref);
+
+  @override
+  $FunctionalProviderElement<StateT, CreatedT> $createElement(
+    $ProviderPointer pointer,
+  ) {
+    return _inner.$createElement(pointer)..provider = this;
+  }
+
+  @override
+  String? debugGetCreateSourceHash() => _inner.debugGetCreateSourceHash();
+}
+
+abstract class $FunctionalProviderElement<StateT, CreatedT>
+    extends ProviderElement<StateT> {
+  /// Implementation detail of `riverpod_generator`.
+  /// Do not use, as this can be removed at any time.
+  $FunctionalProviderElement(super.pointer)
+      : provider = pointer.origin as $FunctionalProvider<StateT, CreatedT>;
+
+  @override
+  $FunctionalProvider<StateT, CreatedT> provider;
 }

--- a/packages/riverpod/lib/src/core/provider/provider.dart
+++ b/packages/riverpod/lib/src/core/provider/provider.dart
@@ -92,6 +92,18 @@ abstract base class ProviderBase<StateT> extends ProviderOrFamily
   @visibleForOverriding
   ProviderElement<StateT> $createElement($ProviderPointer pointer);
 
+  /// A debug-only function for obtaining a hash of the source code of the
+  /// initialization function.
+  ///
+  /// If after a hot-reload this function returns a different result, the
+  /// provider will be re-executed.
+  ///
+  /// This method only returns a non-null value when using `riverpod_generator`.
+  // This is voluntarily not implemented by default, to force all non-generated
+  // providers to apply the LegacyProviderMixin.
+  @internal
+  String? debugGetCreateSourceHash();
+
   @override
   String toString() {
     var leading = '';

--- a/packages/riverpod/lib/src/providers/async_notifier.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier.dart
@@ -37,7 +37,6 @@ abstract base class $AsyncNotifierProvider< //
     required super.dependencies,
     required super.allTransitiveDependencies,
     required super.isAutoDispose,
-    required super.runNotifierBuildOverride,
     required super.retry,
   });
 }
@@ -58,10 +57,7 @@ class $AsyncNotifierProviderElement< //
         FutureModifierClassElement<NotifierT, StateT, FutureOr<StateT>> {
   /// Implementation detail of `riverpod_generator`.
   /// Do not use.
-  $AsyncNotifierProviderElement(this.provider, super.pointer);
-
-  @override
-  final $AsyncNotifierProvider<NotifierT, StateT> provider;
+  $AsyncNotifierProviderElement(super.pointer);
 
   @override
   void handleValue(Ref ref, FutureOr<StateT> created) {

--- a/packages/riverpod/lib/src/providers/async_notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/family.dart
@@ -73,26 +73,8 @@ final class FamilyAsyncNotifierProvider< //
     required super.from,
     required super.argument,
     required super.isAutoDispose,
-    required super.runNotifierBuildOverride,
     required super.retry,
   });
-
-  FamilyAsyncNotifierProvider<NotifierT, StateT, ArgT> _copyWith({
-    NotifierT Function()? create,
-    RunNotifierBuild<NotifierT, FutureOr<StateT>>? build,
-  }) {
-    return FamilyAsyncNotifierProvider<NotifierT, StateT, ArgT>._(
-      create ?? _createNotifier,
-      name: name,
-      dependencies: dependencies,
-      allTransitiveDependencies: allTransitiveDependencies,
-      from: from,
-      argument: argument,
-      isAutoDispose: isAutoDispose,
-      runNotifierBuildOverride: build ?? runNotifierBuildOverride,
-      retry: retry,
-    );
-  }
 
   final NotifierT Function() _createNotifier;
 
@@ -105,24 +87,6 @@ final class FamilyAsyncNotifierProvider< //
   $AsyncNotifierProviderElement<NotifierT, StateT> $createElement(
     $ProviderPointer pointer,
   ) {
-    return $AsyncNotifierProviderElement(this, pointer);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  FamilyAsyncNotifierProvider<NotifierT, StateT, ArgT> $copyWithBuild(
-    RunNotifierBuild<NotifierT, FutureOr<StateT>>? build,
-  ) {
-    return _copyWith(build: build);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  FamilyAsyncNotifierProvider<NotifierT, StateT, ArgT> $copyWithCreate(
-    NotifierT Function() create,
-  ) {
-    return _copyWith(create: create);
+    return $AsyncNotifierProviderElement(pointer);
   }
 }

--- a/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
@@ -76,7 +76,6 @@ final class AsyncNotifierProvider< //
               computeAllTransitiveDependencies(dependencies),
           from: null,
           argument: null,
-          runNotifierBuildOverride: null,
         );
 
   /// An implementation detail of Riverpod
@@ -89,7 +88,6 @@ final class AsyncNotifierProvider< //
     required super.from,
     required super.argument,
     required super.isAutoDispose,
-    required super.runNotifierBuildOverride,
     required super.retry,
   });
 
@@ -105,46 +103,11 @@ final class AsyncNotifierProvider< //
   @override
   NotifierT create() => _createNotifier();
 
-  AsyncNotifierProvider<NotifierT, StateT> _copyWith({
-    NotifierT Function()? create,
-    RunNotifierBuild<NotifierT, FutureOr<StateT>>? build,
-  }) {
-    return AsyncNotifierProvider<NotifierT, StateT>.internal(
-      create ?? _createNotifier,
-      name: name,
-      dependencies: dependencies,
-      allTransitiveDependencies: allTransitiveDependencies,
-      from: from,
-      argument: argument,
-      isAutoDispose: isAutoDispose,
-      runNotifierBuildOverride: build ?? runNotifierBuildOverride,
-      retry: retry,
-    );
-  }
-
   @internal
   @override
   $AsyncNotifierProviderElement<NotifierT, StateT> $createElement(
     $ProviderPointer pointer,
   ) {
-    return $AsyncNotifierProviderElement(this, pointer);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  AsyncNotifierProvider<NotifierT, StateT> $copyWithBuild(
-    RunNotifierBuild<NotifierT, FutureOr<StateT>>? build,
-  ) {
-    return _copyWith(build: build);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  AsyncNotifierProvider<NotifierT, StateT> $copyWithCreate(
-    NotifierT Function() create,
-  ) {
-    return _copyWith(create: create);
+    return $AsyncNotifierProviderElement(pointer);
   }
 }

--- a/packages/riverpod/lib/src/providers/future_provider.dart
+++ b/packages/riverpod/lib/src/providers/future_provider.dart
@@ -12,9 +12,8 @@ import 'stream_provider.dart' show StreamProvider;
 /// Implementation detail of `riverpod_generator`.
 /// Do not use, as this may be removed at any time.
 @internal
-base mixin $FutureProvider<StateT> on ProviderBase<AsyncValue<StateT>> {
-  FutureOr<StateT> create(Ref ref);
-
+base mixin $FutureProvider<StateT>
+    on $FunctionalProvider<AsyncValue<StateT>, FutureOr<StateT>> {
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<StateT> value) {
     return $ProviderOverride(
@@ -133,45 +132,26 @@ final class FutureProvider<StateT>
 
   final Create<FutureOr<StateT>> _create;
 
+  @internal
   @override
   FutureOr<StateT> create(Ref ref) => _create(ref);
 
   @internal
   @override
   $FutureProviderElement<StateT> $createElement($ProviderPointer pointer) {
-    return $FutureProviderElement(this, pointer);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  FutureProvider<StateT> $copyWithCreate(
-    Create<FutureOr<StateT>> create,
-  ) {
-    return FutureProvider<StateT>.internal(
-      create,
-      name: name,
-      dependencies: dependencies,
-      allTransitiveDependencies: allTransitiveDependencies,
-      from: from,
-      argument: argument,
-      isAutoDispose: isAutoDispose,
-      retry: retry,
-    );
+    return $FutureProviderElement(pointer);
   }
 }
 
 /// The element of a [FutureProvider]
 /// Implementation detail of `riverpod_generator`. Do not use.
 @internal
-class $FutureProviderElement<StateT> extends ProviderElement<AsyncValue<StateT>>
+class $FutureProviderElement<StateT>
+    extends $FunctionalProviderElement<AsyncValue<StateT>, FutureOr<StateT>>
     with FutureModifierElement<StateT> {
   /// The element of a [FutureProvider]
   /// Implementation detail of `riverpod_generator`. Do not use.
-  $FutureProviderElement(this.provider, super.pointer);
-
-  @override
-  final $FutureProvider<StateT> provider;
+  $FutureProviderElement(super.pointer);
 
   @override
   WhenComplete create(Ref ref) {

--- a/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
@@ -119,6 +119,8 @@ final class StateNotifierProvider< //
   static const family = StateNotifierProviderFamilyBuilder();
 
   final NotifierT Function(Ref ref) _create;
+  @override
+  NotifierT create(Ref ref) => _create(ref);
 
   /// Obtains the [StateNotifier] associated with this provider, without listening
   /// to state changes.
@@ -142,44 +144,23 @@ final class StateNotifierProvider< //
   StateNotifierProviderElement<NotifierT, StateT> $createElement(
     $ProviderPointer pointer,
   ) {
-    return StateNotifierProviderElement._(this, pointer);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  StateNotifierProvider<NotifierT, StateT> $copyWithCreate(
-    Create<NotifierT> create,
-  ) {
-    return StateNotifierProvider<NotifierT, StateT>.internal(
-      create,
-      name: name,
-      dependencies: dependencies,
-      allTransitiveDependencies: allTransitiveDependencies,
-      from: from,
-      argument: argument,
-      isAutoDispose: isAutoDispose,
-      retry: retry,
-    );
+    return StateNotifierProviderElement._(pointer);
   }
 }
 
 /// The element of [StateNotifierProvider].
 class StateNotifierProviderElement<NotifierT extends StateNotifier<StateT>,
-    StateT> extends ProviderElement<StateT> {
-  StateNotifierProviderElement._(this.provider, super.pointer);
-
-  @override
-  final StateNotifierProvider<NotifierT, StateT> provider;
+    StateT> extends $FunctionalProviderElement<StateT, NotifierT> {
+  StateNotifierProviderElement._(super.pointer);
 
   final _notifierNotifier = $ElementLense<NotifierT>();
 
   void Function()? _removeListener;
 
   @override
-  WhenComplete create(Ref ref) {
+  WhenComplete create($Ref<StateT> ref) {
     final notifier = _notifierNotifier.result = $Result.guard(
-      () => provider._create(ref),
+      () => provider.create(ref),
     );
 
     _removeListener = notifier.requireState.addListener(

--- a/packages/riverpod/lib/src/providers/legacy/state_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_provider.dart
@@ -84,6 +84,8 @@ final class StateProvider<StateT> extends $FunctionalProvider<StateT, StateT>
   static const family = StateProviderFamilyBuilder();
 
   final StateT Function(Ref ref) _createFn;
+  @override
+  StateT create(Ref ref) => _createFn(ref);
 
   Refreshable<StateController<StateT>> get notifier => _notifier(this);
 
@@ -92,32 +94,13 @@ final class StateProvider<StateT> extends $FunctionalProvider<StateT, StateT>
   StateProviderElement<StateT> $createElement(
     $ProviderPointer pointer,
   ) {
-    return StateProviderElement._(this, pointer);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  StateProvider<StateT> $copyWithCreate(Create<StateT> create) {
-    return StateProvider<StateT>.internal(
-      create,
-      name: name,
-      dependencies: dependencies,
-      allTransitiveDependencies: allTransitiveDependencies,
-      from: from,
-      argument: argument,
-      isAutoDispose: isAutoDispose,
-      retry: retry,
-    );
+    return StateProviderElement._(pointer);
   }
 }
 
 /// The element of [StateProvider].
-class StateProviderElement<T> extends ProviderElement<T> {
-  StateProviderElement._(this.provider, super.pointer);
-
-  @override
-  final StateProvider<T> provider;
+class StateProviderElement<T> extends $FunctionalProviderElement<T, T> {
+  StateProviderElement._(super.pointer);
 
   final _controllerNotifier = $ElementLense<StateController<T>>();
 
@@ -126,8 +109,8 @@ class StateProviderElement<T> extends ProviderElement<T> {
   void Function()? _removeListener;
 
   @override
-  WhenComplete create(Ref ref) {
-    final initialState = provider._createFn(ref);
+  WhenComplete create($Ref<T> ref) {
+    final initialState = provider.create(ref);
 
     final controller = StateController(initialState);
     _controllerNotifier.result = $Result.data(controller);

--- a/packages/riverpod/lib/src/providers/notifier.dart
+++ b/packages/riverpod/lib/src/providers/notifier.dart
@@ -95,7 +95,6 @@ abstract base class $NotifierProvider //
     required super.dependencies,
     required super.allTransitiveDependencies,
     required super.isAutoDispose,
-    required super.runNotifierBuildOverride,
     required super.retry,
   });
 }
@@ -113,10 +112,7 @@ class $NotifierProviderElement< //
         StateT> {
   /// An implementation detail of `riverpod_generator`.
   /// Do not use.
-  $NotifierProviderElement(this.provider, super.pointer);
-
-  @override
-  final $NotifierProvider<NotifierT, StateT> provider;
+  $NotifierProviderElement(super.pointer);
 
   @override
   void handleError(Ref ref, Object error, StackTrace stackTrace) =>

--- a/packages/riverpod/lib/src/providers/notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/notifier/family.dart
@@ -32,7 +32,6 @@ final class FamilyNotifierProvider //
     required super.from,
     required super.argument,
     required super.isAutoDispose,
-    required super.runNotifierBuildOverride,
     required super.retry,
   });
 
@@ -47,42 +46,7 @@ final class FamilyNotifierProvider //
   $NotifierProviderElement<NotifierT, StateT> $createElement(
     $ProviderPointer pointer,
   ) {
-    return $NotifierProviderElement(this, pointer);
-  }
-
-  FamilyNotifierProvider<NotifierT, StateT, ArgT> _copyWith({
-    NotifierT Function()? create,
-    RunNotifierBuild<NotifierT, StateT>? build,
-  }) {
-    return FamilyNotifierProvider._(
-      create ?? _createNotifier,
-      name: name,
-      dependencies: dependencies,
-      allTransitiveDependencies: allTransitiveDependencies,
-      isAutoDispose: isAutoDispose,
-      runNotifierBuildOverride: build ?? runNotifierBuildOverride,
-      from: from,
-      argument: argument,
-      retry: retry,
-    );
-  }
-
-  @override
-  @mustBeOverridden
-  @visibleForOverriding
-  FamilyNotifierProvider<NotifierT, StateT, ArgT> $copyWithBuild(
-    RunNotifierBuild<NotifierT, StateT> build,
-  ) {
-    return _copyWith(build: build);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  FamilyNotifierProvider<NotifierT, StateT, ArgT> $copyWithCreate(
-    NotifierT Function() create,
-  ) {
-    return _copyWith(create: create);
+    return $NotifierProviderElement(pointer);
   }
 }
 

--- a/packages/riverpod/lib/src/providers/notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/notifier/orphan.dart
@@ -93,7 +93,6 @@ final class NotifierProvider<NotifierT extends Notifier<StateT>, StateT>
               computeAllTransitiveDependencies(dependencies),
           from: null,
           argument: null,
-          runNotifierBuildOverride: null,
         );
 
   /// An implementation detail of Riverpod
@@ -106,7 +105,6 @@ final class NotifierProvider<NotifierT extends Notifier<StateT>, StateT>
     required super.from,
     required super.argument,
     required super.isAutoDispose,
-    required super.runNotifierBuildOverride,
     required super.retry,
   });
 
@@ -127,41 +125,6 @@ final class NotifierProvider<NotifierT extends Notifier<StateT>, StateT>
   $NotifierProviderElement<NotifierT, StateT> $createElement(
     $ProviderPointer pointer,
   ) {
-    return $NotifierProviderElement(this, pointer);
-  }
-
-  NotifierProvider<NotifierT, StateT> _copyWith({
-    NotifierT Function()? create,
-    RunNotifierBuild<NotifierT, StateT>? build,
-  }) {
-    return NotifierProvider<NotifierT, StateT>.internal(
-      create ?? _createNotifier,
-      name: name,
-      dependencies: dependencies,
-      allTransitiveDependencies: allTransitiveDependencies,
-      from: from,
-      argument: argument,
-      isAutoDispose: isAutoDispose,
-      runNotifierBuildOverride: build ?? runNotifierBuildOverride,
-      retry: retry,
-    );
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  NotifierProvider<NotifierT, StateT> $copyWithBuild(
-    RunNotifierBuild<NotifierT, StateT>? build,
-  ) {
-    return _copyWith(build: build);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  NotifierProvider<NotifierT, StateT> $copyWithCreate(
-    NotifierT Function() create,
-  ) {
-    return _copyWith(create: create);
+    return $NotifierProviderElement(pointer);
   }
 }

--- a/packages/riverpod/lib/src/providers/provider.dart
+++ b/packages/riverpod/lib/src/providers/provider.dart
@@ -9,9 +9,7 @@ import 'stream_provider.dart' show StreamProvider;
 /// Implementation detail of `riverpod_generator`.
 /// Do not use, as this may be removed at any time.
 @internal
-base mixin $Provider<StateT> on ProviderBase<StateT> {
-  StateT create(Ref ref);
-}
+base mixin $Provider<StateT> on $FunctionalProvider<StateT, StateT> {}
 
 /// {@macro riverpod.provider}
 base class Provider<StateT> extends $FunctionalProvider<StateT, StateT>
@@ -51,29 +49,14 @@ base class Provider<StateT> extends $FunctionalProvider<StateT, StateT>
 
   final Create<StateT> _create;
 
+  @internal
   @override
   StateT create(Ref ref) => _create(ref);
 
   @internal
   @override
   $ProviderElement<StateT> $createElement($ProviderPointer pointer) {
-    return $ProviderElement(this, pointer);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  Provider<StateT> $copyWithCreate(Create<StateT> create) {
-    return Provider<StateT>.internal(
-      create,
-      from: from,
-      argument: argument,
-      isAutoDispose: isAutoDispose,
-      retry: retry,
-      allTransitiveDependencies: null,
-      dependencies: null,
-      name: null,
-    );
+    return $ProviderElement(pointer);
   }
 
   /// {@template riverpod.override_with_value}
@@ -341,12 +324,10 @@ base class Provider<StateT> extends $FunctionalProvider<StateT, StateT>
 /// - [Provider.family], to allow providers to create a value from external parameters.
 /// {@endtemplate}
 @internal
-class $ProviderElement<StateT> extends ProviderElement<StateT> {
+class $ProviderElement<StateT>
+    extends $FunctionalProviderElement<StateT, StateT> {
   /// A [ProviderElement] for [Provider]
-  $ProviderElement(this.provider, super.pointer);
-
-  @override
-  final $Provider<StateT> provider;
+  $ProviderElement(super.pointer);
 
   @override
   WhenComplete create(Ref ref) {

--- a/packages/riverpod/lib/src/providers/stream_notifier.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier.dart
@@ -38,7 +38,6 @@ abstract base class $StreamNotifierProvider<
     required super.dependencies,
     required super.allTransitiveDependencies,
     required super.isAutoDispose,
-    required super.runNotifierBuildOverride,
     required super.retry,
   });
 }
@@ -59,10 +58,7 @@ class $StreamNotifierProviderElement< //
         FutureModifierClassElement<NotifierT, StateT, Stream<StateT>> {
   /// Implementation detail of `riverpod_generator`.
   /// Do not use.
-  $StreamNotifierProviderElement(this.provider, super.pointer);
-
-  @override
-  final $StreamNotifierProvider<NotifierT, StateT> provider;
+  $StreamNotifierProviderElement(super.pointer);
 
   @override
   void handleValue(Ref ref, Stream<StateT> created) {

--- a/packages/riverpod/lib/src/providers/stream_notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier/family.dart
@@ -45,7 +45,6 @@ final class FamilyStreamNotifierProvider< //
     required super.from,
     required super.argument,
     required super.isAutoDispose,
-    required super.runNotifierBuildOverride,
     required super.retry,
   });
 
@@ -60,42 +59,7 @@ final class FamilyStreamNotifierProvider< //
   $StreamNotifierProviderElement<NotifierT, StateT> $createElement(
     $ProviderPointer pointer,
   ) {
-    return $StreamNotifierProviderElement(this, pointer);
-  }
-
-  FamilyStreamNotifierProvider<NotifierT, StateT, ArgT> _copyWith({
-    NotifierT Function()? create,
-    RunNotifierBuild<NotifierT, Stream<StateT>>? build,
-  }) {
-    return FamilyStreamNotifierProvider._(
-      create ?? _createNotifier,
-      name: name,
-      dependencies: dependencies,
-      allTransitiveDependencies: allTransitiveDependencies,
-      isAutoDispose: isAutoDispose,
-      runNotifierBuildOverride: build ?? runNotifierBuildOverride,
-      from: from,
-      argument: argument,
-      retry: retry,
-    );
-  }
-
-  @override
-  @mustBeOverridden
-  @visibleForOverriding
-  FamilyStreamNotifierProvider<NotifierT, StateT, ArgT> $copyWithBuild(
-    RunNotifierBuild<NotifierT, Stream<StateT>> build,
-  ) {
-    return _copyWith(build: build);
-  }
-
-  @override
-  @mustBeOverridden
-  @visibleForOverriding
-  FamilyStreamNotifierProvider<NotifierT, StateT, ArgT> $copyWithCreate(
-    NotifierT Function() create,
-  ) {
-    return _copyWith(create: create);
+    return $StreamNotifierProviderElement(pointer);
   }
 }
 

--- a/packages/riverpod/lib/src/providers/stream_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier/orphan.dart
@@ -56,7 +56,6 @@ final class StreamNotifierProvider< //
     this._createNotifier, {
     super.name,
     super.dependencies,
-    super.runNotifierBuildOverride,
     super.isAutoDispose = false,
     super.retry,
   }) : super(
@@ -76,7 +75,6 @@ final class StreamNotifierProvider< //
     required super.from,
     required super.argument,
     required super.isAutoDispose,
-    required super.runNotifierBuildOverride,
     required super.retry,
   });
 
@@ -92,46 +90,11 @@ final class StreamNotifierProvider< //
   @override
   NotifierT create() => _createNotifier();
 
-  StreamNotifierProvider<NotifierT, StateT> _copyWith({
-    NotifierT Function()? create,
-    RunNotifierBuild<NotifierT, Stream<StateT>>? build,
-  }) {
-    return StreamNotifierProvider<NotifierT, StateT>.internal(
-      create ?? _createNotifier,
-      name: name,
-      dependencies: dependencies,
-      allTransitiveDependencies: allTransitiveDependencies,
-      from: from,
-      argument: argument,
-      isAutoDispose: isAutoDispose,
-      runNotifierBuildOverride: build ?? runNotifierBuildOverride,
-      retry: retry,
-    );
-  }
-
   @internal
   @override
   $StreamNotifierProviderElement<NotifierT, StateT> $createElement(
     $ProviderPointer pointer,
   ) {
-    return $StreamNotifierProviderElement(this, pointer);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  StreamNotifierProvider<NotifierT, StateT> $copyWithBuild(
-    RunNotifierBuild<NotifierT, Stream<StateT>>? build,
-  ) {
-    return _copyWith(build: build);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  StreamNotifierProvider<NotifierT, StateT> $copyWithCreate(
-    NotifierT Function() create,
-  ) {
-    return _copyWith(create: create);
+    return $StreamNotifierProviderElement(pointer);
   }
 }

--- a/packages/riverpod/lib/src/providers/stream_provider.dart
+++ b/packages/riverpod/lib/src/providers/stream_provider.dart
@@ -13,9 +13,8 @@ import 'provider.dart' show Provider;
 /// Implementation detail of `riverpod_generator`.
 /// Do not use, as this may be removed at any time.
 @internal
-base mixin $StreamProvider<StateT> on ProviderBase<AsyncValue<StateT>> {
-  Stream<StateT> create(Ref ref);
-
+base mixin $StreamProvider<StateT>
+    on $FunctionalProvider<AsyncValue<StateT>, Stream<StateT>> {
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<StateT> value) {
     return $ProviderOverride(
@@ -122,43 +121,24 @@ base class StreamProvider<StateT>
 
   final Create<Stream<StateT>> _create;
 
+  @internal
   @override
   Stream<StateT> create(Ref ref) => _create(ref);
 
   @internal
   @override
   $StreamProviderElement<StateT> $createElement($ProviderPointer pointer) {
-    return $StreamProviderElement(this, pointer);
-  }
-
-  @mustBeOverridden
-  @visibleForOverriding
-  @override
-  $FunctionalProvider<AsyncValue<StateT>, Stream<StateT>> $copyWithCreate(
-    Create<Stream<StateT>> create,
-  ) {
-    return StreamProvider<StateT>.internal(
-      create,
-      name: name,
-      dependencies: null,
-      allTransitiveDependencies: null,
-      from: from,
-      argument: argument,
-      isAutoDispose: isAutoDispose,
-      retry: retry,
-    );
+    return $StreamProviderElement(pointer);
   }
 }
 
 /// The element of [StreamProvider].
 @internal
-class $StreamProviderElement<StateT> extends ProviderElement<AsyncValue<StateT>>
+class $StreamProviderElement<StateT>
+    extends $FunctionalProviderElement<AsyncValue<StateT>, Stream<StateT>>
     with FutureModifierElement<StateT> {
   /// The element of [StreamProvider].
-  $StreamProviderElement(this.provider, super.pointer);
-
-  @override
-  final $StreamProvider<StateT> provider;
+  $StreamProviderElement(super.pointer);
 
   final _streamNotifier = $ElementLense<Stream<StateT>>();
   final StreamController<StateT> _streamController =
@@ -168,10 +148,7 @@ class $StreamProviderElement<StateT> extends ProviderElement<AsyncValue<StateT>>
   WhenComplete create(Ref ref) {
     _streamNotifier.result ??= $Result.data(_streamController.stream);
 
-    return handleStream(
-      ref,
-      () => provider.create(ref),
-    );
+    return handleStream(ref, () => provider.create(ref));
   }
 
   @override

--- a/packages/riverpod_generator/integration/build_yaml/lib/dependencies.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/dependencies.g.dart
@@ -12,14 +12,8 @@ const myFamilyCalc2ProviderFamily = Calc2Family._();
 final class Calc2Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   const Calc2Provider._(
-      {required Calc2Family super.from,
-      required String super.argument,
-      int Function(
-        Ref ref,
-        String id,
-      )? create})
-      : _createCb = create,
-        super(
+      {required Calc2Family super.from, required String super.argument})
+      : super(
           retry: null,
           name: r'myFamilyCalc2ProviderFamily',
           isAutoDispose: true,
@@ -43,11 +37,6 @@ final class Calc2Provider extends $FunctionalProvider<int, int>
   static const $allTransitiveDependencies11 =
       myFamilyCountStreamNotifier2ProviderFamily;
 
-  final int Function(
-    Ref ref,
-    String id,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$calc2Hash();
 
@@ -58,42 +47,25 @@ final class Calc2Provider extends $FunctionalProvider<int, int>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as String;
+    return calc2(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Calc2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Calc2Provider._(
-        argument: argument as String,
-        from: from! as Calc2Family,
-        create: (
-          ref,
-          String id,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? calc2;
-    final argument = this.argument as String;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -152,31 +124,23 @@ final class Calc2Family extends Family {
       Calc2Provider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$calc2Hash();
-
-  @override
   String toString() => r'myFamilyCalc2ProviderFamily';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      String args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Calc2Provider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            String args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Calc2Provider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
@@ -193,14 +193,6 @@ final class CountAsyncNotifierProvider
   $AsyncNotifierProviderElement<CountAsyncNotifier, int> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
 }
 
 String _$countAsyncNotifierHash() =>
@@ -247,14 +239,6 @@ final class CountStreamNotifierProvider
   $StreamNotifierProviderElement<CountStreamNotifier, int> $createElement(
           $ProviderPointer pointer) =>
       $StreamNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
 }
 
 String _$countStreamNotifierHash() =>
@@ -705,14 +689,6 @@ final class CountAsyncNotifier2Provider
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
-
   @override
   bool operator ==(Object other) {
     return other is CountAsyncNotifier2Provider && other.argument == argument;
@@ -834,14 +810,6 @@ final class CountStreamNotifier2Provider
   $StreamNotifierProviderElement<CountStreamNotifier2, int> $createElement(
           $ProviderPointer pointer) =>
       $StreamNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
 
   @override
   bool operator ==(Object other) {

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
@@ -11,12 +11,8 @@ const myCountPod = CountProvider._();
 
 final class CountProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const CountProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CountProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class CountProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$countHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return count(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class CountProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CountProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CountProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? count;
-    return _$cb(ref);
   }
 }
 
@@ -70,12 +52,8 @@ const myCountFuturePod = CountFutureProvider._();
 final class CountFutureProvider
     extends $FunctionalProvider<AsyncValue<int>, FutureOr<int>>
     with $FutureModifier<int>, $FutureProvider<int> {
-  const CountFutureProvider._(
-      {FutureOr<int> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CountFutureProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -85,31 +63,17 @@ final class CountFutureProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<int> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$countFutureHash();
 
   @$internal
   @override
   $FutureProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  CountFutureProvider $copyWithCreate(
-    FutureOr<int> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CountFutureProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<int> create(Ref ref) {
-    final _$cb = _createCb ?? countFuture;
-    return _$cb(ref);
+    return countFuture(ref);
   }
 }
 
@@ -121,12 +85,8 @@ const myCountStreamPod = CountStreamProvider._();
 final class CountStreamProvider
     extends $FunctionalProvider<AsyncValue<int>, Stream<int>>
     with $FutureModifier<int>, $StreamProvider<int> {
-  const CountStreamProvider._(
-      {Stream<int> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CountStreamProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -136,31 +96,17 @@ final class CountStreamProvider
           allTransitiveDependencies: null,
         );
 
-  final Stream<int> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$countStreamHash();
 
   @$internal
   @override
   $StreamProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  CountStreamProvider $copyWithCreate(
-    Stream<int> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CountStreamProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<int> create(Ref ref) {
-    final _$cb = _createCb ?? countStream;
-    return _$cb(ref);
+    return countStream(ref);
   }
 }
 
@@ -171,10 +117,8 @@ const myCountNotifierPod = CountNotifierProvider._();
 
 final class CountNotifierProvider
     extends $NotifierProvider<CountNotifier, int> {
-  const CountNotifierProvider._(
-      {super.runNotifierBuildOverride, CountNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const CountNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -184,10 +128,18 @@ final class CountNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final CountNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$countNotifierHash();
+
+  @$internal
+  @override
+  CountNotifier create() => CountNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<CountNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -196,35 +148,6 @@ final class CountNotifierProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  CountNotifier create() => _createCb?.call() ?? CountNotifier();
-
-  @$internal
-  @override
-  CountNotifierProvider $copyWithCreate(
-    CountNotifier Function() create,
-  ) {
-    return CountNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CountNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      CountNotifier,
-    ) build,
-  ) {
-    return CountNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<CountNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$countNotifierHash() => r'a8dd7a66ee0002b8af657245c4affaa206fd99ec';
@@ -247,10 +170,8 @@ const myCountAsyncNotifierPod = CountAsyncNotifierProvider._();
 
 final class CountAsyncNotifierProvider
     extends $AsyncNotifierProvider<CountAsyncNotifier, int> {
-  const CountAsyncNotifierProvider._(
-      {super.runNotifierBuildOverride, CountAsyncNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const CountAsyncNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -260,39 +181,26 @@ final class CountAsyncNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final CountAsyncNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$countAsyncNotifierHash();
 
   @$internal
   @override
-  CountAsyncNotifier create() => _createCb?.call() ?? CountAsyncNotifier();
-
-  @$internal
-  @override
-  CountAsyncNotifierProvider $copyWithCreate(
-    CountAsyncNotifier Function() create,
-  ) {
-    return CountAsyncNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CountAsyncNotifierProvider $copyWithBuild(
-    FutureOr<int> Function(
-      Ref,
-      CountAsyncNotifier,
-    ) build,
-  ) {
-    return CountAsyncNotifierProvider._(runNotifierBuildOverride: build);
-  }
+  CountAsyncNotifier create() => CountAsyncNotifier();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<CountAsyncNotifier, int> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 }
 
 String _$countAsyncNotifierHash() =>
@@ -316,10 +224,8 @@ const myCountStreamNotifierPod = CountStreamNotifierProvider._();
 
 final class CountStreamNotifierProvider
     extends $StreamNotifierProvider<CountStreamNotifier, int> {
-  const CountStreamNotifierProvider._(
-      {super.runNotifierBuildOverride, CountStreamNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const CountStreamNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -329,39 +235,26 @@ final class CountStreamNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final CountStreamNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$countStreamNotifierHash();
 
   @$internal
   @override
-  CountStreamNotifier create() => _createCb?.call() ?? CountStreamNotifier();
-
-  @$internal
-  @override
-  CountStreamNotifierProvider $copyWithCreate(
-    CountStreamNotifier Function() create,
-  ) {
-    return CountStreamNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CountStreamNotifierProvider $copyWithBuild(
-    Stream<int> Function(
-      Ref,
-      CountStreamNotifier,
-    ) build,
-  ) {
-    return CountStreamNotifierProvider._(runNotifierBuildOverride: build);
-  }
+  CountStreamNotifier create() => CountStreamNotifier();
 
   @$internal
   @override
   $StreamNotifierProviderElement<CountStreamNotifier, int> $createElement(
           $ProviderPointer pointer) =>
-      $StreamNotifierProviderElement(this, pointer);
+      $StreamNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 }
 
 String _$countStreamNotifierHash() =>
@@ -386,25 +279,14 @@ const myFamilyCount2ProviderFamily = Count2Family._();
 final class Count2Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   const Count2Provider._(
-      {required Count2Family super.from,
-      required int super.argument,
-      int Function(
-        Ref ref,
-        int a,
-      )? create})
-      : _createCb = create,
-        super(
+      {required Count2Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'myFamilyCount2ProviderFamily',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final int Function(
-    Ref ref,
-    int a,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$count2Hash();
@@ -416,42 +298,25 @@ final class Count2Provider extends $FunctionalProvider<int, int>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as int;
+    return count2(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Count2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Count2Provider._(
-        argument: argument as int,
-        from: from! as Count2Family,
-        create: (
-          ref,
-          int a,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? count2;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -484,31 +349,23 @@ final class Count2Family extends Family {
       Count2Provider._(argument: a, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$count2Hash();
-
-  @override
   String toString() => r'myFamilyCount2ProviderFamily';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Count2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Count2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(countFuture2)
@@ -518,25 +375,14 @@ final class CountFuture2Provider
     extends $FunctionalProvider<AsyncValue<int>, FutureOr<int>>
     with $FutureModifier<int>, $FutureProvider<int> {
   const CountFuture2Provider._(
-      {required CountFuture2Family super.from,
-      required int super.argument,
-      FutureOr<int> Function(
-        Ref ref,
-        int a,
-      )? create})
-      : _createCb = create,
-        super(
+      {required CountFuture2Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'myFamilyCountFuture2ProviderFamily',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FutureOr<int> Function(
-    Ref ref,
-    int a,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$countFuture2Hash();
@@ -551,29 +397,12 @@ final class CountFuture2Provider
   @$internal
   @override
   $FutureProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  CountFuture2Provider $copyWithCreate(
-    FutureOr<int> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CountFuture2Provider._(
-        argument: argument as int,
-        from: from! as CountFuture2Family,
-        create: (
-          ref,
-          int a,
-        ) =>
-            create(ref));
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<int> create(Ref ref) {
-    final _$cb = _createCb ?? countFuture2;
     final argument = this.argument as int;
-    return _$cb(
+    return countFuture2(
       ref,
       argument,
     );
@@ -608,31 +437,23 @@ final class CountFuture2Family extends Family {
       CountFuture2Provider._(argument: a, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$countFuture2Hash();
-
-  @override
   String toString() => r'myFamilyCountFuture2ProviderFamily';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FutureOr<int> Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as CountFuture2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<int> Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as CountFuture2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(countStream2)
@@ -642,25 +463,14 @@ final class CountStream2Provider
     extends $FunctionalProvider<AsyncValue<int>, Stream<int>>
     with $FutureModifier<int>, $StreamProvider<int> {
   const CountStream2Provider._(
-      {required CountStream2Family super.from,
-      required int super.argument,
-      Stream<int> Function(
-        Ref ref,
-        int a,
-      )? create})
-      : _createCb = create,
-        super(
+      {required CountStream2Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'myFamilyCountStream2ProviderFamily',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final Stream<int> Function(
-    Ref ref,
-    int a,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$countStream2Hash();
@@ -675,29 +485,12 @@ final class CountStream2Provider
   @$internal
   @override
   $StreamProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  CountStream2Provider $copyWithCreate(
-    Stream<int> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CountStream2Provider._(
-        argument: argument as int,
-        from: from! as CountStream2Family,
-        create: (
-          ref,
-          int a,
-        ) =>
-            create(ref));
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<int> create(Ref ref) {
-    final _$cb = _createCb ?? countStream2;
     final argument = this.argument as int;
-    return _$cb(
+    return countStream2(
       ref,
       argument,
     );
@@ -732,31 +525,23 @@ final class CountStream2Family extends Family {
       CountStream2Provider._(argument: a, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$countStream2Hash();
-
-  @override
   String toString() => r'myFamilyCountStream2ProviderFamily';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Stream<int> Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as CountStream2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Stream<int> Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as CountStream2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(CountNotifier2)
@@ -765,20 +550,14 @@ const myFamilyCountNotifier2ProviderFamily = CountNotifier2Family._();
 final class CountNotifier2Provider
     extends $NotifierProvider<CountNotifier2, int> {
   const CountNotifier2Provider._(
-      {required CountNotifier2Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      CountNotifier2 Function()? create})
-      : _createCb = create,
-        super(
+      {required CountNotifier2Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'myFamilyCountNotifier2ProviderFamily',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final CountNotifier2 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$countNotifier2Hash();
@@ -790,6 +569,16 @@ final class CountNotifier2Provider
         '($argument)';
   }
 
+  @$internal
+  @override
+  CountNotifier2 create() => CountNotifier2();
+
+  @$internal
+  @override
+  $NotifierProviderElement<CountNotifier2, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
@@ -797,41 +586,6 @@ final class CountNotifier2Provider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  CountNotifier2 create() => _createCb?.call() ?? CountNotifier2();
-
-  @$internal
-  @override
-  CountNotifier2Provider $copyWithCreate(
-    CountNotifier2 Function() create,
-  ) {
-    return CountNotifier2Provider._(
-        argument: argument as int,
-        from: from! as CountNotifier2Family,
-        create: create);
-  }
-
-  @$internal
-  @override
-  CountNotifier2Provider $copyWithBuild(
-    int Function(
-      Ref,
-      CountNotifier2,
-    ) build,
-  ) {
-    return CountNotifier2Provider._(
-        argument: argument as int,
-        from: from! as CountNotifier2Family,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<CountNotifier2, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -862,48 +616,37 @@ final class CountNotifier2Family extends Family {
       CountNotifier2Provider._(argument: a, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$countNotifier2Hash();
-
-  @override
   String toString() => r'myFamilyCountNotifier2ProviderFamily';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    CountNotifier2 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as CountNotifier2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          CountNotifier2 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as CountNotifier2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function(Ref ref, CountNotifier2 notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as CountNotifier2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(Ref ref, CountNotifier2 notifier, int argument) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as CountNotifier2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$CountNotifier2 extends $Notifier<int> {
@@ -933,19 +676,14 @@ final class CountAsyncNotifier2Provider
     extends $AsyncNotifierProvider<CountAsyncNotifier2, int> {
   const CountAsyncNotifier2Provider._(
       {required CountAsyncNotifier2Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      CountAsyncNotifier2 Function()? create})
-      : _createCb = create,
-        super(
+      required int super.argument})
+      : super(
           retry: null,
           name: r'myFamilyCountAsyncNotifier2ProviderFamily',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final CountAsyncNotifier2 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$countAsyncNotifier2Hash();
@@ -959,38 +697,21 @@ final class CountAsyncNotifier2Provider
 
   @$internal
   @override
-  CountAsyncNotifier2 create() => _createCb?.call() ?? CountAsyncNotifier2();
-
-  @$internal
-  @override
-  CountAsyncNotifier2Provider $copyWithCreate(
-    CountAsyncNotifier2 Function() create,
-  ) {
-    return CountAsyncNotifier2Provider._(
-        argument: argument as int,
-        from: from! as CountAsyncNotifier2Family,
-        create: create);
-  }
-
-  @$internal
-  @override
-  CountAsyncNotifier2Provider $copyWithBuild(
-    FutureOr<int> Function(
-      Ref,
-      CountAsyncNotifier2,
-    ) build,
-  ) {
-    return CountAsyncNotifier2Provider._(
-        argument: argument as int,
-        from: from! as CountAsyncNotifier2Family,
-        runNotifierBuildOverride: build);
-  }
+  CountAsyncNotifier2 create() => CountAsyncNotifier2();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<CountAsyncNotifier2, int> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -1022,49 +743,39 @@ final class CountAsyncNotifier2Family extends Family {
       CountAsyncNotifier2Provider._(argument: a, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$countAsyncNotifier2Hash();
-
-  @override
   String toString() => r'myFamilyCountAsyncNotifier2ProviderFamily';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    CountAsyncNotifier2 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as CountAsyncNotifier2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          CountAsyncNotifier2 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as CountAsyncNotifier2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    FutureOr<int> Function(Ref ref, CountAsyncNotifier2 notifier, int argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as CountAsyncNotifier2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<int> Function(
+                  Ref ref, CountAsyncNotifier2 notifier, int argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as CountAsyncNotifier2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$CountAsyncNotifier2 extends $AsyncNotifier<int> {
@@ -1095,19 +806,14 @@ final class CountStreamNotifier2Provider
     extends $StreamNotifierProvider<CountStreamNotifier2, int> {
   const CountStreamNotifier2Provider._(
       {required CountStreamNotifier2Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      CountStreamNotifier2 Function()? create})
-      : _createCb = create,
-        super(
+      required int super.argument})
+      : super(
           retry: null,
           name: r'myFamilyCountStreamNotifier2ProviderFamily',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final CountStreamNotifier2 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$countStreamNotifier2Hash();
@@ -1121,38 +827,21 @@ final class CountStreamNotifier2Provider
 
   @$internal
   @override
-  CountStreamNotifier2 create() => _createCb?.call() ?? CountStreamNotifier2();
-
-  @$internal
-  @override
-  CountStreamNotifier2Provider $copyWithCreate(
-    CountStreamNotifier2 Function() create,
-  ) {
-    return CountStreamNotifier2Provider._(
-        argument: argument as int,
-        from: from! as CountStreamNotifier2Family,
-        create: create);
-  }
-
-  @$internal
-  @override
-  CountStreamNotifier2Provider $copyWithBuild(
-    Stream<int> Function(
-      Ref,
-      CountStreamNotifier2,
-    ) build,
-  ) {
-    return CountStreamNotifier2Provider._(
-        argument: argument as int,
-        from: from! as CountStreamNotifier2Family,
-        runNotifierBuildOverride: build);
-  }
+  CountStreamNotifier2 create() => CountStreamNotifier2();
 
   @$internal
   @override
   $StreamNotifierProviderElement<CountStreamNotifier2, int> $createElement(
           $ProviderPointer pointer) =>
-      $StreamNotifierProviderElement(this, pointer);
+      $StreamNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -1184,49 +873,39 @@ final class CountStreamNotifier2Family extends Family {
       CountStreamNotifier2Provider._(argument: a, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$countStreamNotifier2Hash();
-
-  @override
   String toString() => r'myFamilyCountStreamNotifier2ProviderFamily';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    CountStreamNotifier2 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as CountStreamNotifier2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          CountStreamNotifier2 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as CountStreamNotifier2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    Stream<int> Function(Ref ref, CountStreamNotifier2 notifier, int argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as CountStreamNotifier2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Stream<int> Function(
+                  Ref ref, CountStreamNotifier2 notifier, int argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as CountStreamNotifier2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$CountStreamNotifier2 extends $StreamNotifier<int> {

--- a/packages/riverpod_generator/lib/src/templates/element.dart
+++ b/packages/riverpod_generator/lib/src/templates/element.dart
@@ -26,7 +26,7 @@ class ElementTemplate extends Template {
 
     buffer.write('''
 class ${provider.generatedElementName}$_genericsDefinition extends ${provider.internalElementName}<${provider.name}$_generics, ${provider.valueTypeDisplayString}> {
-  ${provider.generatedElementName}(super.provider, super.pointer) {
+  ${provider.generatedElementName}(super.pointer) {
 ''');
 
     _constructorBody(buffer);

--- a/packages/riverpod_generator/lib/src/templates/provider.dart
+++ b/packages/riverpod_generator/lib/src/templates/provider.dart
@@ -183,10 +183,7 @@ ${provider.doc} final class $name$_genericsDefinition
   }
 
   void _writeOverrideWithValue(StringBuffer buffer) {
-    if (provider.createdType != SupportedCreatedType.value &&
-        provider is FunctionalProviderDeclaration) {
-      return;
-    }
+    if (provider.createdType != SupportedCreatedType.value) return;
 
     buffer.writeln('''
   /// {@macro riverpod.override_with_value}

--- a/packages/riverpod_generator/test/async_test.dart
+++ b/packages/riverpod_generator/test/async_test.dart
@@ -173,10 +173,20 @@ void main() {
     final container = ProviderContainer.test(
       overrides: [
         publicProvider.overrideWithValue(const AsyncData('test')),
+        familyProvider(42, third: .2)
+            .overrideWithValue(const AsyncData('test')),
       ],
     );
 
     expect(container.read(publicProvider), const AsyncData('test'));
     expect(container.read(publicProvider.future), completion('test'));
+    expect(
+      container.read(familyProvider(42, third: .2)),
+      const AsyncData('test'),
+    );
+    expect(
+      container.read(familyProvider(42, third: .2).future),
+      completion('test'),
+    );
   });
 }

--- a/packages/riverpod_generator/test/integration/annotated.g.dart
+++ b/packages/riverpod_generator/test/integration/annotated.g.dart
@@ -15,25 +15,14 @@ const functionalProvider = FunctionalFamily._();
 final class FunctionalProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
   const FunctionalProvider._(
-      {required FunctionalFamily super.from,
-      required int super.argument,
-      String Function(
-        Ref ref,
-        @Deprecated('field') int id,
-      )? create})
-      : _createCb = create,
-        super(
+      {required FunctionalFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'functionalProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    @Deprecated('field') int id,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$functionalHash();
@@ -45,42 +34,25 @@ final class FunctionalProvider extends $FunctionalProvider<String, String>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    final argument = this.argument as int;
+    return functional(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FunctionalProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FunctionalProvider._(
-        argument: argument as int,
-        from: from! as FunctionalFamily,
-        create: (
-          ref,
-          @Deprecated('field') int id,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? functional;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -113,31 +85,23 @@ final class FunctionalFamily extends Family {
       FunctionalProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$functionalHash();
-
-  @override
   String toString() => r'functionalProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FunctionalProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FunctionalProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(ClassBased)
@@ -148,20 +112,14 @@ const classBasedProvider = ClassBasedFamily._();
 
 final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
   const ClassBasedProvider._(
-      {required ClassBasedFamily super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      ClassBased Function()? create})
-      : _createCb = create,
-        super(
+      {required ClassBasedFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'classBasedProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final ClassBased Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$classBasedHash();
@@ -173,6 +131,16 @@ final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
         '($argument)';
   }
 
+  @$internal
+  @override
+  ClassBased create() => ClassBased();
+
+  @$internal
+  @override
+  $NotifierProviderElement<ClassBased, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
@@ -180,41 +148,6 @@ final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  ClassBased create() => _createCb?.call() ?? ClassBased();
-
-  @$internal
-  @override
-  ClassBasedProvider $copyWithCreate(
-    ClassBased Function() create,
-  ) {
-    return ClassBasedProvider._(
-        argument: argument as int,
-        from: from! as ClassBasedFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  ClassBasedProvider $copyWithBuild(
-    String Function(
-      Ref,
-      ClassBased,
-    ) build,
-  ) {
-    return ClassBasedProvider._(
-        argument: argument as int,
-        from: from! as ClassBasedFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<ClassBased, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -245,48 +178,37 @@ final class ClassBasedFamily extends Family {
       ClassBasedProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$classBasedHash();
-
-  @override
   String toString() => r'classBasedProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    ClassBased Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ClassBasedProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          ClassBased Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ClassBasedProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    String Function(Ref ref, ClassBased notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ClassBasedProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(Ref ref, ClassBased notifier, int argument) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ClassBasedProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$ClassBased extends $Notifier<String> {
@@ -319,25 +241,14 @@ const familyProvider = FamilyFamily._();
 final class FamilyProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
   const FamilyProvider._(
-      {required FamilyFamily super.from,
-      required int super.argument,
-      String Function(
-        Ref ref,
-        int id,
-      )? create})
-      : _createCb = create,
-        super(
+      {required FamilyFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'familyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    int id,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyHash();
@@ -349,42 +260,25 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    final argument = this.argument as int;
+    return family(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FamilyProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyProvider._(
-        argument: argument as int,
-        from: from! as FamilyFamily,
-        create: (
-          ref,
-          int id,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? family;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -417,31 +311,23 @@ final class FamilyFamily extends Family {
       FamilyProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyHash();
-
-  @override
   String toString() => r'familyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(notCopiedFunctional)
@@ -449,12 +335,8 @@ const notCopiedFunctionalProvider = NotCopiedFunctionalProvider._();
 
 final class NotCopiedFunctionalProvider
     extends $FunctionalProvider<String, String> with $Provider<String> {
-  const NotCopiedFunctionalProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const NotCopiedFunctionalProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -464,12 +346,18 @@ final class NotCopiedFunctionalProvider
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$notCopiedFunctionalHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return notCopiedFunctional(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -477,26 +365,6 @@ final class NotCopiedFunctionalProvider
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  NotCopiedFunctionalProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return NotCopiedFunctionalProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? notCopiedFunctional;
-    return _$cb(ref);
   }
 }
 
@@ -508,10 +376,8 @@ const notCopiedClassBasedProvider = NotCopiedClassBasedProvider._();
 
 final class NotCopiedClassBasedProvider
     extends $NotifierProvider<NotCopiedClassBased, String> {
-  const NotCopiedClassBasedProvider._(
-      {super.runNotifierBuildOverride, NotCopiedClassBased Function()? create})
-      : _createCb = create,
-        super(
+  const NotCopiedClassBasedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -521,10 +387,18 @@ final class NotCopiedClassBasedProvider
           allTransitiveDependencies: null,
         );
 
-  final NotCopiedClassBased Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$notCopiedClassBasedHash();
+
+  @$internal
+  @override
+  NotCopiedClassBased create() => NotCopiedClassBased();
+
+  @$internal
+  @override
+  $NotifierProviderElement<NotCopiedClassBased, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -533,35 +407,6 @@ final class NotCopiedClassBasedProvider
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  NotCopiedClassBased create() => _createCb?.call() ?? NotCopiedClassBased();
-
-  @$internal
-  @override
-  NotCopiedClassBasedProvider $copyWithCreate(
-    NotCopiedClassBased Function() create,
-  ) {
-    return NotCopiedClassBasedProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  NotCopiedClassBasedProvider $copyWithBuild(
-    String Function(
-      Ref,
-      NotCopiedClassBased,
-    ) build,
-  ) {
-    return NotCopiedClassBasedProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<NotCopiedClassBased, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$notCopiedClassBasedHash() =>
@@ -586,25 +431,14 @@ const notCopiedFamilyProvider = NotCopiedFamilyFamily._();
 final class NotCopiedFamilyProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
   const NotCopiedFamilyProvider._(
-      {required NotCopiedFamilyFamily super.from,
-      required int super.argument,
-      String Function(
-        Ref ref,
-        int id,
-      )? create})
-      : _createCb = create,
-        super(
+      {required NotCopiedFamilyFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'notCopiedFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    int id,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$notCopiedFamilyHash();
@@ -616,42 +450,25 @@ final class NotCopiedFamilyProvider extends $FunctionalProvider<String, String>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    final argument = this.argument as int;
+    return notCopiedFamily(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  NotCopiedFamilyProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return NotCopiedFamilyProvider._(
-        argument: argument as int,
-        from: from! as NotCopiedFamilyFamily,
-        create: (
-          ref,
-          int id,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? notCopiedFamily;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -684,31 +501,23 @@ final class NotCopiedFamilyFamily extends Family {
       NotCopiedFamilyProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$notCopiedFamilyHash();
-
-  @override
   String toString() => r'notCopiedFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as NotCopiedFamilyProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as NotCopiedFamilyProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_generator/test/integration/async.g.dart
+++ b/packages/riverpod_generator/test/integration/async.g.dart
@@ -12,13 +12,8 @@ const genericProvider = GenericFamily._();
 final class GenericProvider<T extends num>
     extends $FunctionalProvider<AsyncValue<List<T>>, FutureOr<List<T>>>
     with $FutureModifier<List<T>>, $FutureProvider<List<T>> {
-  const GenericProvider._(
-      {required GenericFamily super.from,
-      FutureOr<List<T>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const GenericProvider._({required GenericFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'genericProvider',
@@ -27,21 +22,8 @@ final class GenericProvider<T extends num>
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<List<T>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericHash();
-
-  GenericProvider<T> _copyWithCreate(
-    FutureOr<List<T>> Function<T extends num>(
-      Ref ref,
-    ) create,
-  ) {
-    return GenericProvider<T>._(
-        from: from! as GenericFamily, create: create<T>);
-  }
 
   @override
   String toString() {
@@ -53,21 +35,15 @@ final class GenericProvider<T extends num>
   @$internal
   @override
   $FutureProviderElement<List<T>> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  GenericProvider<T> $copyWithCreate(
-    FutureOr<List<T>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return GenericProvider<T>._(from: from! as GenericFamily, create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<T>> create(Ref ref) {
-    final _$cb = _createCb ?? generic<T>;
-    return _$cb(ref);
+    return generic<T>(ref);
+  }
+
+  $R _captureGenerics<$R>($R Function<T extends num>() cb) {
+    return cb<T>();
   }
 
   @override
@@ -98,24 +74,20 @@ final class GenericFamily extends Family {
   GenericProvider<T> call<T extends num>() => GenericProvider<T>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$genericHash();
-
-  @override
   String toString() => r'genericProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FutureOr<List<T>> Function<T extends num>(Ref ref) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<List<T>> Function<T extends num>(Ref ref) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericProvider<T>;
+              return provider.$view(create: create<T>).$createElement(pointer);
+            });
+          });
 }
 
 @ProviderFor(GenericClass)
@@ -123,12 +95,8 @@ const genericClassProvider = GenericClassFamily._();
 
 final class GenericClassProvider<T extends num>
     extends $AsyncNotifierProvider<GenericClass<T>, List<T>> {
-  const GenericClassProvider._(
-      {required GenericClassFamily super.from,
-      super.runNotifierBuildOverride,
-      GenericClass<T> Function()? create})
-      : _createCb = create,
-        super(
+  const GenericClassProvider._({required GenericClassFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'genericClassProvider',
@@ -137,27 +105,8 @@ final class GenericClassProvider<T extends num>
           allTransitiveDependencies: null,
         );
 
-  final GenericClass<T> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericClassHash();
-
-  GenericClassProvider<T> _copyWithCreate(
-    GenericClass<T> Function<T extends num>() create,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, create: create<T>);
-  }
-
-  GenericClassProvider<T> _copyWithBuild(
-    FutureOr<List<T>> Function<T extends num>(
-      Ref,
-      GenericClass<T>,
-    ) build,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, runNotifierBuildOverride: build<T>);
-  }
 
   @override
   String toString() {
@@ -168,34 +117,25 @@ final class GenericClassProvider<T extends num>
 
   @$internal
   @override
-  GenericClass<T> create() => _createCb?.call() ?? GenericClass<T>();
-
-  @$internal
-  @override
-  GenericClassProvider<T> $copyWithCreate(
-    GenericClass<T> Function() create,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, create: create);
-  }
-
-  @$internal
-  @override
-  GenericClassProvider<T> $copyWithBuild(
-    FutureOr<List<T>> Function(
-      Ref,
-      GenericClass<T>,
-    ) build,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, runNotifierBuildOverride: build);
-  }
+  GenericClass<T> create() => GenericClass<T>();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<GenericClass<T>, List<T>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<T extends num>() cb) {
+    return cb<T>();
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<T>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<T>>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -226,39 +166,36 @@ final class GenericClassFamily extends Family {
       GenericClassProvider<T>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$genericClassHash();
-
-  @override
   String toString() => r'genericClassProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    GenericClass<T> Function<T extends num>() create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericClassProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(GenericClass<T> Function<T extends num>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericClassProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericClassProvider<T>;
+              return provider.$view(create: create<T>).$createElement(pointer);
+            });
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    FutureOr<List<T>> Function<T extends num>(Ref ref, GenericClass<T> notifier)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericClassProvider;
-
-        return provider._copyWithBuild(build).$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<List<T>> Function<T extends num>(
+                  Ref ref, GenericClass<T> notifier)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericClassProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericClassProvider<T>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<T>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$GenericClass<T extends num> extends $AsyncNotifier<List<T>> {
@@ -283,12 +220,8 @@ const publicProvider = PublicProvider._();
 final class PublicProvider
     extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
-  const PublicProvider._(
-      {FutureOr<String> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const PublicProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -298,31 +231,17 @@ final class PublicProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<String> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$publicHash();
 
   @$internal
   @override
   $FutureProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  PublicProvider $copyWithCreate(
-    FutureOr<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return PublicProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<String> create(Ref ref) {
-    final _$cb = _createCb ?? public;
-    return _$cb(ref);
+    return public(ref);
   }
 }
 
@@ -334,12 +253,8 @@ const _privateProvider = _PrivateProvider._();
 final class _PrivateProvider
     extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
-  const _PrivateProvider._(
-      {FutureOr<String> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const _PrivateProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -349,31 +264,17 @@ final class _PrivateProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<String> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$privateHash();
 
   @$internal
   @override
   $FutureProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  _PrivateProvider $copyWithCreate(
-    FutureOr<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return _PrivateProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<String> create(Ref ref) {
-    final _$cb = _createCb ?? _private;
-    return _$cb(ref);
+    return _private(ref);
   }
 }
 
@@ -386,25 +287,14 @@ final class FamilyOrProvider
     extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
   const FamilyOrProvider._(
-      {required FamilyOrFamily super.from,
-      required int super.argument,
-      FutureOr<String> Function(
-        Ref ref,
-        int first,
-      )? create})
-      : _createCb = create,
-        super(
+      {required FamilyOrFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'familyOrProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FutureOr<String> Function(
-    Ref ref,
-    int first,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyOrHash();
@@ -419,29 +309,12 @@ final class FamilyOrProvider
   @$internal
   @override
   $FutureProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  FamilyOrProvider $copyWithCreate(
-    FutureOr<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyOrProvider._(
-        argument: argument as int,
-        from: from! as FamilyOrFamily,
-        create: (
-          ref,
-          int first,
-        ) =>
-            create(ref));
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<String> create(Ref ref) {
-    final _$cb = _createCb ?? familyOr;
     final argument = this.argument as int;
-    return _$cb(
+    return familyOr(
       ref,
       argument,
     );
@@ -476,31 +349,23 @@ final class FamilyOrFamily extends Family {
       FamilyOrProvider._(argument: first, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyOrHash();
-
-  @override
   String toString() => r'familyOrProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FutureOr<String> Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyOrProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<String> Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyOrProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(family)
@@ -518,32 +383,14 @@ final class FamilyProvider
         bool fourth,
         List<String>? fifth,
       })
-          super.argument,
-      FutureOr<String> Function(
-        Ref ref,
-        int first, {
-        String? second,
-        required double third,
-        bool fourth,
-        List<String>? fifth,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'familyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FutureOr<String> Function(
-    Ref ref,
-    int first, {
-    String? second,
-    required double third,
-    bool fourth,
-    List<String>? fifth,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyHash();
@@ -558,37 +405,10 @@ final class FamilyProvider
   @$internal
   @override
   $FutureProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  FamilyProvider $copyWithCreate(
-    FutureOr<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyFamily,
-        create: (
-          ref,
-          int first, {
-          String? second,
-          required double third,
-          bool fourth = true,
-          List<String>? fifth,
-        }) =>
-            create(ref));
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<String> create(Ref ref) {
-    final _$cb = _createCb ?? family;
     final argument = this.argument as (
       int, {
       String? second,
@@ -596,7 +416,7 @@ final class FamilyProvider
       bool fourth,
       List<String>? fifth,
     });
-    return _$cb(
+    return family(
       ref,
       argument.$1,
       second: argument.second,
@@ -645,43 +465,35 @@ final class FamilyFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyHash();
-
-  @override
   String toString() => r'familyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FutureOr<String> Function(
-      Ref ref,
-      (
-        int, {
-        String? second,
-        double third,
-        bool fourth,
-        List<String>? fifth,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyProvider;
-
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<String> Function(
+            Ref ref,
+            (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(PublicClass)
@@ -689,10 +501,8 @@ const publicClassProvider = PublicClassProvider._();
 
 final class PublicClassProvider
     extends $AsyncNotifierProvider<PublicClass, String> {
-  const PublicClassProvider._(
-      {super.runNotifierBuildOverride, PublicClass Function()? create})
-      : _createCb = create,
-        super(
+  const PublicClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -702,39 +512,26 @@ final class PublicClassProvider
           allTransitiveDependencies: null,
         );
 
-  final PublicClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$publicClassHash();
 
   @$internal
   @override
-  PublicClass create() => _createCb?.call() ?? PublicClass();
-
-  @$internal
-  @override
-  PublicClassProvider $copyWithCreate(
-    PublicClass Function() create,
-  ) {
-    return PublicClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  PublicClassProvider $copyWithBuild(
-    FutureOr<String> Function(
-      Ref,
-      PublicClass,
-    ) build,
-  ) {
-    return PublicClassProvider._(runNotifierBuildOverride: build);
-  }
+  PublicClass create() => PublicClass();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<PublicClass, String> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<String>>(value),
+    );
+  }
 }
 
 String _$publicClassHash() => r'e9bc69e44b72e8ed77d423524c0d74ad460d629d';
@@ -757,10 +554,8 @@ const _privateClassProvider = _PrivateClassProvider._();
 
 final class _PrivateClassProvider
     extends $AsyncNotifierProvider<_PrivateClass, String> {
-  const _PrivateClassProvider._(
-      {super.runNotifierBuildOverride, _PrivateClass Function()? create})
-      : _createCb = create,
-        super(
+  const _PrivateClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -770,39 +565,26 @@ final class _PrivateClassProvider
           allTransitiveDependencies: null,
         );
 
-  final _PrivateClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$privateClassHash();
 
   @$internal
   @override
-  _PrivateClass create() => _createCb?.call() ?? _PrivateClass();
-
-  @$internal
-  @override
-  _PrivateClassProvider $copyWithCreate(
-    _PrivateClass Function() create,
-  ) {
-    return _PrivateClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  _PrivateClassProvider $copyWithBuild(
-    FutureOr<String> Function(
-      Ref,
-      _PrivateClass,
-    ) build,
-  ) {
-    return _PrivateClassProvider._(runNotifierBuildOverride: build);
-  }
+  _PrivateClass create() => _PrivateClass();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<_PrivateClass, String> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<String>>(value),
+    );
+  }
 }
 
 String _$privateClassHash() => r'7e69cffe8315999710e4cb6bb3de9f179d3f2f5d';
@@ -826,20 +608,14 @@ const familyOrClassProvider = FamilyOrClassFamily._();
 final class FamilyOrClassProvider
     extends $AsyncNotifierProvider<FamilyOrClass, String> {
   const FamilyOrClassProvider._(
-      {required FamilyOrClassFamily super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      FamilyOrClass Function()? create})
-      : _createCb = create,
-        super(
+      {required FamilyOrClassFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'familyOrClassProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FamilyOrClass Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyOrClassHash();
@@ -853,38 +629,21 @@ final class FamilyOrClassProvider
 
   @$internal
   @override
-  FamilyOrClass create() => _createCb?.call() ?? FamilyOrClass();
-
-  @$internal
-  @override
-  FamilyOrClassProvider $copyWithCreate(
-    FamilyOrClass Function() create,
-  ) {
-    return FamilyOrClassProvider._(
-        argument: argument as int,
-        from: from! as FamilyOrClassFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  FamilyOrClassProvider $copyWithBuild(
-    FutureOr<String> Function(
-      Ref,
-      FamilyOrClass,
-    ) build,
-  ) {
-    return FamilyOrClassProvider._(
-        argument: argument as int,
-        from: from! as FamilyOrClassFamily,
-        runNotifierBuildOverride: build);
-  }
+  FamilyOrClass create() => FamilyOrClass();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<FamilyOrClass, String> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<String>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -915,49 +674,39 @@ final class FamilyOrClassFamily extends Family {
       FamilyOrClassProvider._(argument: first, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyOrClassHash();
-
-  @override
   String toString() => r'familyOrClassProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FamilyOrClass Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyOrClassProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FamilyOrClass Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyOrClassProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    FutureOr<String> Function(Ref ref, FamilyOrClass notifier, int argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyOrClassProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<String> Function(
+                  Ref ref, FamilyOrClass notifier, int argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyOrClassProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$FamilyOrClass extends $AsyncNotifier<String> {
@@ -994,19 +743,14 @@ final class FamilyClassProvider
         bool fourth,
         List<String>? fifth,
       })
-          super.argument,
-      super.runNotifierBuildOverride,
-      FamilyClass Function()? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'familyClassProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FamilyClass Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyClassHash();
@@ -1020,50 +764,21 @@ final class FamilyClassProvider
 
   @$internal
   @override
-  FamilyClass create() => _createCb?.call() ?? FamilyClass();
-
-  @$internal
-  @override
-  FamilyClassProvider $copyWithCreate(
-    FamilyClass Function() create,
-  ) {
-    return FamilyClassProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyClassFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  FamilyClassProvider $copyWithBuild(
-    FutureOr<String> Function(
-      Ref,
-      FamilyClass,
-    ) build,
-  ) {
-    return FamilyClassProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyClassFamily,
-        runNotifierBuildOverride: build);
-  }
+  FamilyClass create() => FamilyClass();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<FamilyClass, String> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<String>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -1104,76 +819,65 @@ final class FamilyClassFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyClassHash();
-
-  @override
   String toString() => r'familyClassProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FamilyClass Function(
-      (
-        int, {
-        String? second,
-        double third,
-        bool fourth,
-        List<String>? fifth,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyClassProvider;
-
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-    FutureOr<String> Function(
-            Ref ref,
-            FamilyClass notifier,
+          FamilyClass Function(
             (
               int, {
               String? second,
               double third,
               bool fourth,
               List<String>? fifth,
-            }) argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyClassProvider;
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyClassProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+  /// {@macro riverpod.override_with_build}
+  Override overrideWithBuild(
+          FutureOr<String> Function(
+                  Ref ref,
+                  FamilyClass notifier,
+                  (
+                    int, {
+                    String? second,
+                    double third,
+                    bool fourth,
+                    List<String>? fifth,
+                  }) argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyClassProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$FamilyClass extends $AsyncNotifier<String> {
@@ -1226,11 +930,8 @@ final class Regression3490Provider<Model, Sort, Cursor>
         Regression3490Cb<Model, Sort, Cursor> getData,
         String? parentId,
       })
-          super.argument,
-      super.runNotifierBuildOverride,
-      Regression3490<Model, Sort, Cursor> Function()? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'regression3490Provider',
           isAutoDispose: true,
@@ -1238,45 +939,29 @@ final class Regression3490Provider<Model, Sort, Cursor>
           allTransitiveDependencies: null,
         );
 
-  final Regression3490<Model, Sort, Cursor> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$regression3490Hash();
-
-  Regression3490Provider<Model, Sort, Cursor> _copyWithCreate(
-    Regression3490<Model, Sort, Cursor> Function<Model, Sort, Cursor>() create,
-  ) {
-    return Regression3490Provider<Model, Sort, Cursor>._(
-        argument: argument as ({
-          String type,
-          Regression3490Cb<Model, Sort, Cursor> getData,
-          String? parentId,
-        }),
-        from: from! as Regression3490Family,
-        create: create<Model, Sort, Cursor>);
-  }
-
-  Regression3490Provider<Model, Sort, Cursor> _copyWithBuild(
-    void Function<Model, Sort, Cursor>(
-      Ref,
-      Regression3490<Model, Sort, Cursor>,
-    ) build,
-  ) {
-    return Regression3490Provider<Model, Sort, Cursor>._(
-        argument: argument as ({
-          String type,
-          Regression3490Cb<Model, Sort, Cursor> getData,
-          String? parentId,
-        }),
-        from: from! as Regression3490Family,
-        runNotifierBuildOverride: build<Model, Sort, Cursor>);
-  }
 
   @override
   String toString() {
     return r'regression3490Provider'
         '<${Model}, ${Sort}, ${Cursor}>'
         '$argument';
+  }
+
+  @$internal
+  @override
+  Regression3490<Model, Sort, Cursor> create() =>
+      Regression3490<Model, Sort, Cursor>();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Regression3490<Model, Sort, Cursor>, void>
+      $createElement($ProviderPointer pointer) =>
+          $NotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<Model, Sort, Cursor>() cb) {
+    return cb<Model, Sort, Cursor>();
   }
 
   /// {@macro riverpod.override_with_value}
@@ -1286,50 +971,6 @@ final class Regression3490Provider<Model, Sort, Cursor>
       providerOverride: $ValueProvider<void>(value),
     );
   }
-
-  @$internal
-  @override
-  Regression3490<Model, Sort, Cursor> create() =>
-      _createCb?.call() ?? Regression3490<Model, Sort, Cursor>();
-
-  @$internal
-  @override
-  Regression3490Provider<Model, Sort, Cursor> $copyWithCreate(
-    Regression3490<Model, Sort, Cursor> Function() create,
-  ) {
-    return Regression3490Provider<Model, Sort, Cursor>._(
-        argument: argument as ({
-          String type,
-          Regression3490Cb<Model, Sort, Cursor> getData,
-          String? parentId,
-        }),
-        from: from! as Regression3490Family,
-        create: create);
-  }
-
-  @$internal
-  @override
-  Regression3490Provider<Model, Sort, Cursor> $copyWithBuild(
-    void Function(
-      Ref,
-      Regression3490<Model, Sort, Cursor>,
-    ) build,
-  ) {
-    return Regression3490Provider<Model, Sort, Cursor>._(
-        argument: argument as ({
-          String type,
-          Regression3490Cb<Model, Sort, Cursor> getData,
-          String? parentId,
-        }),
-        from: from! as Regression3490Family,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Regression3490<Model, Sort, Cursor>, void>
-      $createElement($ProviderPointer pointer) =>
-          $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -1368,68 +1009,63 @@ final class Regression3490Family extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$regression3490Hash();
-
-  @override
   String toString() => r'regression3490Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Regression3490<Model, Sort, Cursor> Function<Model, Sort, Cursor>(
-      ({
-        String type,
-        Regression3490Cb<Model, Sort, Cursor> getData,
-        String? parentId,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Regression3490Provider;
-
-        return provider._copyWithCreate(<Model, Sort, Cursor>() {
-          final argument = provider.argument as ({
-            String type,
-            Regression3490Cb<Model, Sort, Cursor> getData,
-            String? parentId,
-          });
-
-          return create(argument);
-        }).$createElement(pointer);
-      },
-    );
-  }
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-    void Function<Model, Sort, Cursor>(
-            Ref ref,
-            Regression3490<Model, Sort, Cursor> notifier,
+          Regression3490<Model, Sort, Cursor> Function<Model, Sort, Cursor>(
             ({
               String type,
               Regression3490Cb<Model, Sort, Cursor> getData,
               String? parentId,
-            }) argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Regression3490Provider;
-
-        return provider._copyWithBuild(<Model, Sort, Cursor>(ref, notifier) {
-          final argument = provider.argument as ({
-            String type,
-            Regression3490Cb<Model, Sort, Cursor> getData,
-            String? parentId,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Regression3490Provider;
+            return provider._captureGenerics(<Model, Sort, Cursor>() {
+              provider as Regression3490Provider<Model, Sort, Cursor>;
+              final argument = provider.argument as ({
+                String type,
+                Regression3490Cb<Model, Sort, Cursor> getData,
+                String? parentId,
+              });
+              return provider
+                  .$view(create: () => create(argument))
+                  .$createElement(pointer);
+            });
           });
 
-          return build(ref, notifier, argument);
-        }).$createElement(pointer);
-      },
-    );
-  }
+  /// {@macro riverpod.override_with_build}
+  Override overrideWithBuild(
+          void Function<Model, Sort, Cursor>(
+                  Ref ref,
+                  Regression3490<Model, Sort, Cursor> notifier,
+                  ({
+                    String type,
+                    Regression3490Cb<Model, Sort, Cursor> getData,
+                    String? parentId,
+                  }) argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Regression3490Provider;
+            return provider._captureGenerics(<Model, Sort, Cursor>() {
+              provider as Regression3490Provider<Model, Sort, Cursor>;
+              final argument = provider.argument as ({
+                String type,
+                Regression3490Cb<Model, Sort, Cursor> getData,
+                String? parentId,
+              });
+              return provider
+                  .$view(
+                      runNotifierBuildOverride: (ref, notifier) =>
+                          build<Model, Sort, Cursor>(ref, notifier, argument))
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$Regression3490<Model, Sort, Cursor> extends $Notifier<void> {

--- a/packages/riverpod_generator/test/integration/async.g.dart
+++ b/packages/riverpod_generator/test/integration/async.g.dart
@@ -129,14 +129,6 @@ final class GenericClassProvider<T extends num>
     return cb<T>();
   }
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<T>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<T>>>(value),
-    );
-  }
-
   @override
   bool operator ==(Object other) {
     return other is GenericClassProvider &&
@@ -524,14 +516,6 @@ final class PublicClassProvider
   $AsyncNotifierProviderElement<PublicClass, String> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<String> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<String>>(value),
-    );
-  }
 }
 
 String _$publicClassHash() => r'e9bc69e44b72e8ed77d423524c0d74ad460d629d';
@@ -577,14 +561,6 @@ final class _PrivateClassProvider
   $AsyncNotifierProviderElement<_PrivateClass, String> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<String> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<String>>(value),
-    );
-  }
 }
 
 String _$privateClassHash() => r'7e69cffe8315999710e4cb6bb3de9f179d3f2f5d';
@@ -636,14 +612,6 @@ final class FamilyOrClassProvider
   $AsyncNotifierProviderElement<FamilyOrClass, String> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<String> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<String>>(value),
-    );
-  }
 
   @override
   bool operator ==(Object other) {
@@ -771,14 +739,6 @@ final class FamilyClassProvider
   $AsyncNotifierProviderElement<FamilyClass, String> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<String> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<String>>(value),
-    );
-  }
 
   @override
   bool operator ==(Object other) {

--- a/packages/riverpod_generator/test/integration/auto_dispose.g.dart
+++ b/packages/riverpod_generator/test/integration/auto_dispose.g.dart
@@ -11,12 +11,8 @@ const keepAliveProvider = KeepAliveProvider._();
 
 final class KeepAliveProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const KeepAliveProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const KeepAliveProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class KeepAliveProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$keepAliveHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return keepAlive(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class KeepAliveProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  KeepAliveProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return KeepAliveProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? keepAlive;
-    return _$cb(ref);
   }
 }
 
@@ -69,12 +51,8 @@ const notKeepAliveProvider = NotKeepAliveProvider._();
 
 final class NotKeepAliveProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const NotKeepAliveProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const NotKeepAliveProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -84,12 +62,18 @@ final class NotKeepAliveProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$notKeepAliveHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return notKeepAlive(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -97,26 +81,6 @@ final class NotKeepAliveProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  NotKeepAliveProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return NotKeepAliveProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? notKeepAlive;
-    return _$cb(ref);
   }
 }
 
@@ -127,12 +91,8 @@ const defaultKeepAliveProvider = DefaultKeepAliveProvider._();
 
 final class DefaultKeepAliveProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const DefaultKeepAliveProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DefaultKeepAliveProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -142,12 +102,18 @@ final class DefaultKeepAliveProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$defaultKeepAliveHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return defaultKeepAlive(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -155,26 +121,6 @@ final class DefaultKeepAliveProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DefaultKeepAliveProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DefaultKeepAliveProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? defaultKeepAlive;
-    return _$cb(ref);
   }
 }
 
@@ -186,25 +132,14 @@ const keepAliveFamilyProvider = KeepAliveFamilyFamily._();
 final class KeepAliveFamilyProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   const KeepAliveFamilyProvider._(
-      {required KeepAliveFamilyFamily super.from,
-      required int super.argument,
-      int Function(
-        Ref ref,
-        int a,
-      )? create})
-      : _createCb = create,
-        super(
+      {required KeepAliveFamilyFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'keepAliveFamilyProvider',
           isAutoDispose: false,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final int Function(
-    Ref ref,
-    int a,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$keepAliveFamilyHash();
@@ -216,42 +151,25 @@ final class KeepAliveFamilyProvider extends $FunctionalProvider<int, int>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as int;
+    return keepAliveFamily(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  KeepAliveFamilyProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return KeepAliveFamilyProvider._(
-        argument: argument as int,
-        from: from! as KeepAliveFamilyFamily,
-        create: (
-          ref,
-          int a,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? keepAliveFamily;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -284,31 +202,23 @@ final class KeepAliveFamilyFamily extends Family {
       KeepAliveFamilyProvider._(argument: a, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$keepAliveFamilyHash();
-
-  @override
   String toString() => r'keepAliveFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as KeepAliveFamilyProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as KeepAliveFamilyProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(notKeepAliveFamily)
@@ -318,24 +228,14 @@ final class NotKeepAliveFamilyProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   const NotKeepAliveFamilyProvider._(
       {required NotKeepAliveFamilyFamily super.from,
-      required int super.argument,
-      int Function(
-        Ref ref,
-        int a,
-      )? create})
-      : _createCb = create,
-        super(
+      required int super.argument})
+      : super(
           retry: null,
           name: r'notKeepAliveFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final int Function(
-    Ref ref,
-    int a,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$notKeepAliveFamilyHash();
@@ -347,42 +247,25 @@ final class NotKeepAliveFamilyProvider extends $FunctionalProvider<int, int>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as int;
+    return notKeepAliveFamily(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  NotKeepAliveFamilyProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return NotKeepAliveFamilyProvider._(
-        argument: argument as int,
-        from: from! as NotKeepAliveFamilyFamily,
-        create: (
-          ref,
-          int a,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? notKeepAliveFamily;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -416,31 +299,23 @@ final class NotKeepAliveFamilyFamily extends Family {
       NotKeepAliveFamilyProvider._(argument: a, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$notKeepAliveFamilyHash();
-
-  @override
   String toString() => r'notKeepAliveFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as NotKeepAliveFamilyProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as NotKeepAliveFamilyProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(defaultKeepAliveFamily)
@@ -450,24 +325,14 @@ final class DefaultKeepAliveFamilyProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   const DefaultKeepAliveFamilyProvider._(
       {required DefaultKeepAliveFamilyFamily super.from,
-      required int super.argument,
-      int Function(
-        Ref ref,
-        int a,
-      )? create})
-      : _createCb = create,
-        super(
+      required int super.argument})
+      : super(
           retry: null,
           name: r'defaultKeepAliveFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final int Function(
-    Ref ref,
-    int a,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$defaultKeepAliveFamilyHash();
@@ -479,42 +344,25 @@ final class DefaultKeepAliveFamilyProvider extends $FunctionalProvider<int, int>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as int;
+    return defaultKeepAliveFamily(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DefaultKeepAliveFamilyProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DefaultKeepAliveFamilyProvider._(
-        argument: argument as int,
-        from: from! as DefaultKeepAliveFamilyFamily,
-        create: (
-          ref,
-          int a,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? defaultKeepAliveFamily;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -549,31 +397,23 @@ final class DefaultKeepAliveFamilyFamily extends Family {
       DefaultKeepAliveFamilyProvider._(argument: a, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$defaultKeepAliveFamilyHash();
-
-  @override
   String toString() => r'defaultKeepAliveFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as DefaultKeepAliveFamilyProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as DefaultKeepAliveFamilyProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_generator/test/integration/dependencies.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies.g.dart
@@ -11,12 +11,8 @@ const depProvider = DepProvider._();
 
 final class DepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const DepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class DepProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$depHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return dep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class DepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? dep;
-    return _$cb(ref);
   }
 }
 
@@ -70,25 +52,14 @@ const familyProvider = FamilyFamily._();
 final class FamilyProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   const FamilyProvider._(
-      {required FamilyFamily super.from,
-      required int super.argument,
-      int Function(
-        Ref ref,
-        int id,
-      )? create})
-      : _createCb = create,
-        super(
+      {required FamilyFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'familyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final int Function(
-    Ref ref,
-    int id,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyHash();
@@ -100,42 +71,25 @@ final class FamilyProvider extends $FunctionalProvider<int, int>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as int;
+    return family(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FamilyProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyProvider._(
-        argument: argument as int,
-        from: from! as FamilyFamily,
-        create: (
-          ref,
-          int id,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? family;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -168,41 +122,31 @@ final class FamilyFamily extends Family {
       FamilyProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyHash();
-
-  @override
   String toString() => r'familyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(Dep2)
 const dep2Provider = Dep2Provider._();
 
 final class Dep2Provider extends $NotifierProvider<Dep2, int> {
-  const Dep2Provider._(
-      {super.runNotifierBuildOverride, Dep2 Function()? create})
-      : _createCb = create,
-        super(
+  const Dep2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -212,10 +156,18 @@ final class Dep2Provider extends $NotifierProvider<Dep2, int> {
           allTransitiveDependencies: null,
         );
 
-  final Dep2 Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$dep2Hash();
+
+  @$internal
+  @override
+  Dep2 create() => Dep2();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Dep2, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -224,35 +176,6 @@ final class Dep2Provider extends $NotifierProvider<Dep2, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Dep2 create() => _createCb?.call() ?? Dep2();
-
-  @$internal
-  @override
-  Dep2Provider $copyWithCreate(
-    Dep2 Function() create,
-  ) {
-    return Dep2Provider._(create: create);
-  }
-
-  @$internal
-  @override
-  Dep2Provider $copyWithBuild(
-    int Function(
-      Ref,
-      Dep2,
-    ) build,
-  ) {
-    return Dep2Provider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Dep2, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$dep2Hash() => r'2778537df77f6431148c2ce400724da3e2ab4b94';
@@ -275,20 +198,14 @@ const family2Provider = Family2Family._();
 
 final class Family2Provider extends $NotifierProvider<Family2, int> {
   const Family2Provider._(
-      {required Family2Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      Family2 Function()? create})
-      : _createCb = create,
-        super(
+      {required Family2Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'family2Provider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final Family2 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$family2Hash();
@@ -300,6 +217,16 @@ final class Family2Provider extends $NotifierProvider<Family2, int> {
         '($argument)';
   }
 
+  @$internal
+  @override
+  Family2 create() => Family2();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Family2, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
@@ -307,41 +234,6 @@ final class Family2Provider extends $NotifierProvider<Family2, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Family2 create() => _createCb?.call() ?? Family2();
-
-  @$internal
-  @override
-  Family2Provider $copyWithCreate(
-    Family2 Function() create,
-  ) {
-    return Family2Provider._(
-        argument: argument as int,
-        from: from! as Family2Family,
-        create: create);
-  }
-
-  @$internal
-  @override
-  Family2Provider $copyWithBuild(
-    int Function(
-      Ref,
-      Family2,
-    ) build,
-  ) {
-    return Family2Provider._(
-        argument: argument as int,
-        from: from! as Family2Family,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Family2, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -372,48 +264,37 @@ final class Family2Family extends Family {
       Family2Provider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$family2Hash();
-
-  @override
   String toString() => r'family2Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Family2 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Family2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Family2 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Family2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function(Ref ref, Family2 notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Family2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(Ref ref, Family2 notifier, int argument) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Family2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$Family2 extends $Notifier<int> {
@@ -441,12 +322,8 @@ const providerProvider = ProviderProvider._();
 
 final class ProviderProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const ProviderProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ProviderProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -471,12 +348,18 @@ final class ProviderProvider extends $FunctionalProvider<int, int>
   static const $allTransitiveDependencies2 = dep2Provider;
   static const $allTransitiveDependencies3 = family2Provider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$providerHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return provider(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -484,26 +367,6 @@ final class ProviderProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ProviderProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ProviderProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? provider;
-    return _$cb(ref);
   }
 }
 
@@ -514,12 +377,8 @@ const provider2Provider = Provider2Provider._();
 
 final class Provider2Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const Provider2Provider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Provider2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -544,12 +403,18 @@ final class Provider2Provider extends $FunctionalProvider<int, int>
   static const $allTransitiveDependencies2 = dep2Provider;
   static const $allTransitiveDependencies3 = family2Provider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$provider2Hash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return provider2(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -557,26 +422,6 @@ final class Provider2Provider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Provider2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Provider2Provider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? provider2;
-    return _$cb(ref);
   }
 }
 
@@ -586,10 +431,8 @@ String _$provider2Hash() => r'30f81430b57f0116f621a4a309c458fce0536378';
 const provider3Provider = Provider3Provider._();
 
 final class Provider3Provider extends $NotifierProvider<Provider3, int> {
-  const Provider3Provider._(
-      {super.runNotifierBuildOverride, Provider3 Function()? create})
-      : _createCb = create,
-        super(
+  const Provider3Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -614,10 +457,18 @@ final class Provider3Provider extends $NotifierProvider<Provider3, int> {
   static const $allTransitiveDependencies2 = dep2Provider;
   static const $allTransitiveDependencies3 = family2Provider;
 
-  final Provider3 Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$provider3Hash();
+
+  @$internal
+  @override
+  Provider3 create() => Provider3();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Provider3, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -626,35 +477,6 @@ final class Provider3Provider extends $NotifierProvider<Provider3, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Provider3 create() => _createCb?.call() ?? Provider3();
-
-  @$internal
-  @override
-  Provider3Provider $copyWithCreate(
-    Provider3 Function() create,
-  ) {
-    return Provider3Provider._(create: create);
-  }
-
-  @$internal
-  @override
-  Provider3Provider $copyWithBuild(
-    int Function(
-      Ref,
-      Provider3,
-    ) build,
-  ) {
-    return Provider3Provider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Provider3, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$provider3Hash() => r'dfdd6dec6cfee543c73d99593ce98d68f4db385c';
@@ -677,12 +499,8 @@ const provider4Provider = Provider4Family._();
 
 final class Provider4Provider extends $NotifierProvider<Provider4, int> {
   const Provider4Provider._(
-      {required Provider4Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      Provider4 Function()? create})
-      : _createCb = create,
-        super(
+      {required Provider4Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'provider4Provider',
           isAutoDispose: true,
@@ -695,8 +513,6 @@ final class Provider4Provider extends $NotifierProvider<Provider4, int> {
   static const $allTransitiveDependencies2 = dep2Provider;
   static const $allTransitiveDependencies3 = family2Provider;
 
-  final Provider4 Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$provider4Hash();
 
@@ -707,6 +523,16 @@ final class Provider4Provider extends $NotifierProvider<Provider4, int> {
         '($argument)';
   }
 
+  @$internal
+  @override
+  Provider4 create() => Provider4();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Provider4, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
@@ -714,41 +540,6 @@ final class Provider4Provider extends $NotifierProvider<Provider4, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Provider4 create() => _createCb?.call() ?? Provider4();
-
-  @$internal
-  @override
-  Provider4Provider $copyWithCreate(
-    Provider4 Function() create,
-  ) {
-    return Provider4Provider._(
-        argument: argument as int,
-        from: from! as Provider4Family,
-        create: create);
-  }
-
-  @$internal
-  @override
-  Provider4Provider $copyWithBuild(
-    int Function(
-      Ref,
-      Provider4,
-    ) build,
-  ) {
-    return Provider4Provider._(
-        argument: argument as int,
-        from: from! as Provider4Family,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Provider4, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -789,48 +580,37 @@ final class Provider4Family extends Family {
       Provider4Provider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$provider4Hash();
-
-  @override
   String toString() => r'provider4Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Provider4 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Provider4Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Provider4 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Provider4Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function(Ref ref, Provider4 notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Provider4Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(Ref ref, Provider4 notifier, int argument) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Provider4Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$Provider4 extends $Notifier<int> {
@@ -858,12 +638,8 @@ const transitiveDependenciesProvider = TransitiveDependenciesProvider._();
 
 final class TransitiveDependenciesProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const TransitiveDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const TransitiveDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -889,12 +665,18 @@ final class TransitiveDependenciesProvider extends $FunctionalProvider<int, int>
   static const $allTransitiveDependencies4 =
       ProviderProvider.$allTransitiveDependencies3;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$transitiveDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return transitiveDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -902,26 +684,6 @@ final class TransitiveDependenciesProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  TransitiveDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return TransitiveDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? transitiveDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -934,12 +696,8 @@ const smallTransitiveDependencyCountProvider =
 
 final class SmallTransitiveDependencyCountProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const SmallTransitiveDependencyCountProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const SmallTransitiveDependencyCountProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -961,12 +719,18 @@ final class SmallTransitiveDependencyCountProvider
   static const $allTransitiveDependencies1 = familyProvider;
   static const $allTransitiveDependencies2 = dep2Provider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$smallTransitiveDependencyCountHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return smallTransitiveDependencyCount(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -974,26 +738,6 @@ final class SmallTransitiveDependencyCountProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  SmallTransitiveDependencyCountProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return SmallTransitiveDependencyCountProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? smallTransitiveDependencyCount;
-    return _$cb(ref);
   }
 }
 
@@ -1006,12 +750,8 @@ const emptyDependenciesFunctionalProvider =
 
 final class EmptyDependenciesFunctionalProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const EmptyDependenciesFunctionalProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const EmptyDependenciesFunctionalProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1021,12 +761,18 @@ final class EmptyDependenciesFunctionalProvider
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$emptyDependenciesFunctionalHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return emptyDependenciesFunctional(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1034,26 +780,6 @@ final class EmptyDependenciesFunctionalProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  EmptyDependenciesFunctionalProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return EmptyDependenciesFunctionalProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? emptyDependenciesFunctional;
-    return _$cb(ref);
   }
 }
 
@@ -1066,11 +792,8 @@ const emptyDependenciesClassBasedProvider =
 
 final class EmptyDependenciesClassBasedProvider
     extends $NotifierProvider<EmptyDependenciesClassBased, int> {
-  const EmptyDependenciesClassBasedProvider._(
-      {super.runNotifierBuildOverride,
-      EmptyDependenciesClassBased Function()? create})
-      : _createCb = create,
-        super(
+  const EmptyDependenciesClassBasedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1080,10 +803,18 @@ final class EmptyDependenciesClassBasedProvider
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final EmptyDependenciesClassBased Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$emptyDependenciesClassBasedHash();
+
+  @$internal
+  @override
+  EmptyDependenciesClassBased create() => EmptyDependenciesClassBased();
+
+  @$internal
+  @override
+  $NotifierProviderElement<EmptyDependenciesClassBased, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1092,37 +823,6 @@ final class EmptyDependenciesClassBasedProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  EmptyDependenciesClassBased create() =>
-      _createCb?.call() ?? EmptyDependenciesClassBased();
-
-  @$internal
-  @override
-  EmptyDependenciesClassBasedProvider $copyWithCreate(
-    EmptyDependenciesClassBased Function() create,
-  ) {
-    return EmptyDependenciesClassBasedProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  EmptyDependenciesClassBasedProvider $copyWithBuild(
-    int Function(
-      Ref,
-      EmptyDependenciesClassBased,
-    ) build,
-  ) {
-    return EmptyDependenciesClassBasedProvider._(
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<EmptyDependenciesClassBased, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$emptyDependenciesClassBasedHash() =>
@@ -1146,12 +846,8 @@ const providerWithDependenciesProvider = ProviderWithDependenciesProvider._();
 
 final class ProviderWithDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const ProviderWithDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ProviderWithDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1170,12 +866,18 @@ final class ProviderWithDependenciesProvider
   static const $allTransitiveDependencies0 = _privateDepProvider;
   static const $allTransitiveDependencies1 = publicDepProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$providerWithDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return providerWithDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1183,26 +885,6 @@ final class ProviderWithDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ProviderWithDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ProviderWithDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? providerWithDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -1214,12 +896,8 @@ const _privateDepProvider = _PrivateDepProvider._();
 
 final class _PrivateDepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const _PrivateDepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const _PrivateDepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1229,12 +907,18 @@ final class _PrivateDepProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$privateDepHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return _privateDep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1242,26 +926,6 @@ final class _PrivateDepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  _PrivateDepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return _PrivateDepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? _privateDep;
-    return _$cb(ref);
   }
 }
 
@@ -1272,12 +936,8 @@ const publicDepProvider = PublicDepProvider._();
 
 final class PublicDepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const PublicDepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const PublicDepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1287,12 +947,18 @@ final class PublicDepProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$publicDepHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return publicDep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1300,26 +966,6 @@ final class PublicDepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  PublicDepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return PublicDepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? publicDep;
-    return _$cb(ref);
   }
 }
 
@@ -1330,12 +976,8 @@ const duplicateDependenciesProvider = DuplicateDependenciesProvider._();
 
 final class DuplicateDependenciesProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const DuplicateDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DuplicateDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1351,12 +993,18 @@ final class DuplicateDependenciesProvider extends $FunctionalProvider<int, int>
   static const $allTransitiveDependencies0 = depProvider;
   static const $allTransitiveDependencies1 = dep2Provider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$duplicateDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return duplicateDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1364,26 +1012,6 @@ final class DuplicateDependenciesProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DuplicateDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DuplicateDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? duplicateDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -1395,12 +1023,8 @@ const duplicateDependencies2Provider = DuplicateDependencies2Provider._();
 
 final class DuplicateDependencies2Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const DuplicateDependencies2Provider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DuplicateDependencies2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1419,12 +1043,18 @@ final class DuplicateDependencies2Provider extends $FunctionalProvider<int, int>
   static const $allTransitiveDependencies0 = familyProvider;
   static const $allTransitiveDependencies1 = family2Provider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$duplicateDependencies2Hash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return duplicateDependencies2(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1432,26 +1062,6 @@ final class DuplicateDependencies2Provider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DuplicateDependencies2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DuplicateDependencies2Provider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? duplicateDependencies2;
-    return _$cb(ref);
   }
 }
 
@@ -1464,12 +1074,8 @@ const transitiveDuplicateDependenciesProvider =
 
 final class TransitiveDuplicateDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const TransitiveDuplicateDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const TransitiveDuplicateDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1500,12 +1106,18 @@ final class TransitiveDuplicateDependenciesProvider
   static const $allTransitiveDependencies5 =
       DuplicateDependencies2Provider.$allTransitiveDependencies1;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$transitiveDuplicateDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return transitiveDuplicateDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1513,26 +1125,6 @@ final class TransitiveDuplicateDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  TransitiveDuplicateDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return TransitiveDuplicateDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? transitiveDuplicateDependencies;
-    return _$cb(ref);
   }
 }
 

--- a/packages/riverpod_generator/test/integration/dependencies2.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies2.g.dart
@@ -11,12 +11,8 @@ const providerWithDependencies2Provider = ProviderWithDependencies2Provider._();
 
 final class ProviderWithDependencies2Provider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const ProviderWithDependencies2Provider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ProviderWithDependencies2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -44,12 +40,18 @@ final class ProviderWithDependencies2Provider
   static const $allTransitiveDependencies3 = _private2Provider;
   static const $allTransitiveDependencies4 = public2Provider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$providerWithDependencies2Hash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return providerWithDependencies2(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -57,26 +59,6 @@ final class ProviderWithDependencies2Provider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ProviderWithDependencies2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ProviderWithDependencies2Provider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? providerWithDependencies2;
-    return _$cb(ref);
   }
 }
 
@@ -90,13 +72,8 @@ final class FamilyWithDependencies2Provider
     extends $FunctionalProvider<int, int> with $Provider<int> {
   const FamilyWithDependencies2Provider._(
       {required FamilyWithDependencies2Family super.from,
-      required int? super.argument,
-      int Function(
-        Ref ref, {
-        int? id,
-      })? create})
-      : _createCb = create,
-        super(
+      required int? super.argument})
+      : super(
           retry: null,
           name: r'familyWithDependencies2Provider',
           isAutoDispose: true,
@@ -112,11 +89,6 @@ final class FamilyWithDependencies2Provider
   static const $allTransitiveDependencies3 = _private2Provider;
   static const $allTransitiveDependencies4 = public2Provider;
 
-  final int Function(
-    Ref ref, {
-    int? id,
-  })? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$familyWithDependencies2Hash();
 
@@ -127,42 +99,25 @@ final class FamilyWithDependencies2Provider
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as int?;
+    return familyWithDependencies2(
+      ref,
+      id: argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FamilyWithDependencies2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyWithDependencies2Provider._(
-        argument: argument as int?,
-        from: from! as FamilyWithDependencies2Family,
-        create: (
-          ref, {
-          int? id,
-        }) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? familyWithDependencies2;
-    final argument = this.argument as int?;
-    return _$cb(
-      ref,
-      id: argument,
     );
   }
 
@@ -207,31 +162,23 @@ final class FamilyWithDependencies2Family extends Family {
       FamilyWithDependencies2Provider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyWithDependencies2Hash();
-
-  @override
   String toString() => r'familyWithDependencies2Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      int? args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyWithDependencies2Provider;
-
-        final argument = provider.argument as int?;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            int? args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyWithDependencies2Provider;
+            final argument = provider.argument as int?;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(NotifierWithDependencies)
@@ -239,11 +186,8 @@ const notifierWithDependenciesProvider = NotifierWithDependenciesProvider._();
 
 final class NotifierWithDependenciesProvider
     extends $NotifierProvider<NotifierWithDependencies, int> {
-  const NotifierWithDependenciesProvider._(
-      {super.runNotifierBuildOverride,
-      NotifierWithDependencies Function()? create})
-      : _createCb = create,
-        super(
+  const NotifierWithDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -271,10 +215,18 @@ final class NotifierWithDependenciesProvider
   static const $allTransitiveDependencies3 = _private2Provider;
   static const $allTransitiveDependencies4 = public2Provider;
 
-  final NotifierWithDependencies Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$notifierWithDependenciesHash();
+
+  @$internal
+  @override
+  NotifierWithDependencies create() => NotifierWithDependencies();
+
+  @$internal
+  @override
+  $NotifierProviderElement<NotifierWithDependencies, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -283,36 +235,6 @@ final class NotifierWithDependenciesProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  NotifierWithDependencies create() =>
-      _createCb?.call() ?? NotifierWithDependencies();
-
-  @$internal
-  @override
-  NotifierWithDependenciesProvider $copyWithCreate(
-    NotifierWithDependencies Function() create,
-  ) {
-    return NotifierWithDependenciesProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  NotifierWithDependenciesProvider $copyWithBuild(
-    int Function(
-      Ref,
-      NotifierWithDependencies,
-    ) build,
-  ) {
-    return NotifierWithDependenciesProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<NotifierWithDependencies, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$notifierWithDependenciesHash() =>
@@ -339,11 +261,8 @@ final class NotifierFamilyWithDependenciesProvider
     extends $NotifierProvider<NotifierFamilyWithDependencies, int> {
   const NotifierFamilyWithDependenciesProvider._(
       {required NotifierFamilyWithDependenciesFamily super.from,
-      required int? super.argument,
-      super.runNotifierBuildOverride,
-      NotifierFamilyWithDependencies Function()? create})
-      : _createCb = create,
-        super(
+      required int? super.argument})
+      : super(
           retry: null,
           name: r'notifierFamilyWithDependenciesProvider',
           isAutoDispose: true,
@@ -359,8 +278,6 @@ final class NotifierFamilyWithDependenciesProvider
   static const $allTransitiveDependencies3 = _private2Provider;
   static const $allTransitiveDependencies4 = public2Provider;
 
-  final NotifierFamilyWithDependencies Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$notifierFamilyWithDependenciesHash();
 
@@ -371,6 +288,16 @@ final class NotifierFamilyWithDependenciesProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  NotifierFamilyWithDependencies create() => NotifierFamilyWithDependencies();
+
+  @$internal
+  @override
+  $NotifierProviderElement<NotifierFamilyWithDependencies, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
@@ -378,42 +305,6 @@ final class NotifierFamilyWithDependenciesProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  NotifierFamilyWithDependencies create() =>
-      _createCb?.call() ?? NotifierFamilyWithDependencies();
-
-  @$internal
-  @override
-  NotifierFamilyWithDependenciesProvider $copyWithCreate(
-    NotifierFamilyWithDependencies Function() create,
-  ) {
-    return NotifierFamilyWithDependenciesProvider._(
-        argument: argument as int?,
-        from: from! as NotifierFamilyWithDependenciesFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  NotifierFamilyWithDependenciesProvider $copyWithBuild(
-    int Function(
-      Ref,
-      NotifierFamilyWithDependencies,
-    ) build,
-  ) {
-    return NotifierFamilyWithDependenciesProvider._(
-        argument: argument as int?,
-        from: from! as NotifierFamilyWithDependenciesFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<NotifierFamilyWithDependencies, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -456,52 +347,41 @@ final class NotifierFamilyWithDependenciesFamily extends Family {
       NotifierFamilyWithDependenciesProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$notifierFamilyWithDependenciesHash();
-
-  @override
   String toString() => r'notifierFamilyWithDependenciesProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    NotifierFamilyWithDependencies Function(
-      int? args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider =
-            pointer.origin as NotifierFamilyWithDependenciesProvider;
-
-        final argument = provider.argument as int?;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          NotifierFamilyWithDependencies Function(
+            int? args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider =
+                pointer.origin as NotifierFamilyWithDependenciesProvider;
+            final argument = provider.argument as int?;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function(
-            Ref ref, NotifierFamilyWithDependencies notifier, int? argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider =
-            pointer.origin as NotifierFamilyWithDependenciesProvider;
-
-        final argument = provider.argument as int?;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(Ref ref, NotifierFamilyWithDependencies notifier,
+                  int? argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider =
+                pointer.origin as NotifierFamilyWithDependenciesProvider;
+            final argument = provider.argument as int?;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$NotifierFamilyWithDependencies extends $Notifier<int> {
@@ -529,12 +409,8 @@ const _private2Provider = _Private2Provider._();
 
 final class _Private2Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const _Private2Provider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const _Private2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -544,12 +420,18 @@ final class _Private2Provider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$private2Hash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return _private2(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -557,26 +439,6 @@ final class _Private2Provider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  _Private2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return _Private2Provider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? _private2;
-    return _$cb(ref);
   }
 }
 
@@ -587,12 +449,8 @@ const public2Provider = Public2Provider._();
 
 final class Public2Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const Public2Provider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Public2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -602,12 +460,18 @@ final class Public2Provider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$public2Hash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return public2(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -615,26 +479,6 @@ final class Public2Provider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Public2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Public2Provider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? public2;
-    return _$cb(ref);
   }
 }
 

--- a/packages/riverpod_generator/test/integration/documented.g.dart
+++ b/packages/riverpod_generator/test/integration/documented.g.dart
@@ -17,12 +17,8 @@ final class FunctionalProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
   /// Hello world
 // Foo
-  const FunctionalProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FunctionalProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -32,12 +28,18 @@ final class FunctionalProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$functionalHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return functional(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -45,26 +47,6 @@ final class FunctionalProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FunctionalProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FunctionalProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? functional;
-    return _$cb(ref);
   }
 }
 
@@ -80,10 +62,8 @@ const classBasedProvider = ClassBasedProvider._();
 final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
   /// Hello world
 // Foo
-  const ClassBasedProvider._(
-      {super.runNotifierBuildOverride, ClassBased Function()? create})
-      : _createCb = create,
-        super(
+  const ClassBasedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -93,10 +73,18 @@ final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
           allTransitiveDependencies: null,
         );
 
-  final ClassBased Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$classBasedHash();
+
+  @$internal
+  @override
+  ClassBased create() => ClassBased();
+
+  @$internal
+  @override
+  $NotifierProviderElement<ClassBased, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -105,35 +93,6 @@ final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  ClassBased create() => _createCb?.call() ?? ClassBased();
-
-  @$internal
-  @override
-  ClassBasedProvider $copyWithCreate(
-    ClassBased Function() create,
-  ) {
-    return ClassBasedProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  ClassBasedProvider $copyWithBuild(
-    String Function(
-      Ref,
-      ClassBased,
-    ) build,
-  ) {
-    return ClassBasedProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<ClassBased, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$classBasedHash() => r'f1139017b1fcf38017402b514c61fb32dae40c39';
@@ -163,25 +122,14 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
   /// Hello world
 // Foo
   const FamilyProvider._(
-      {required FamilyFamily super.from,
-      required int super.argument,
-      String Function(
-        Ref ref,
-        int id,
-      )? create})
-      : _createCb = create,
-        super(
+      {required FamilyFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'familyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    int id,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyHash();
@@ -193,42 +141,25 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    final argument = this.argument as int;
+    return family(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FamilyProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyProvider._(
-        argument: argument as int,
-        from: from! as FamilyFamily,
-        create: (
-          ref,
-          int id,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? family;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -265,31 +196,23 @@ final class FamilyFamily extends Family {
       FamilyProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyHash();
-
-  @override
   String toString() => r'familyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 /// Hello world
@@ -304,20 +227,14 @@ final class ClassFamilyBasedProvider
   /// Hello world
 // Foo
   const ClassFamilyBasedProvider._(
-      {required ClassFamilyBasedFamily super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      ClassFamilyBased Function()? create})
-      : _createCb = create,
-        super(
+      {required ClassFamilyBasedFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'classFamilyBasedProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final ClassFamilyBased Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$classFamilyBasedHash();
@@ -329,6 +246,16 @@ final class ClassFamilyBasedProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  ClassFamilyBased create() => ClassFamilyBased();
+
+  @$internal
+  @override
+  $NotifierProviderElement<ClassFamilyBased, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
@@ -336,41 +263,6 @@ final class ClassFamilyBasedProvider
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  ClassFamilyBased create() => _createCb?.call() ?? ClassFamilyBased();
-
-  @$internal
-  @override
-  ClassFamilyBasedProvider $copyWithCreate(
-    ClassFamilyBased Function() create,
-  ) {
-    return ClassFamilyBasedProvider._(
-        argument: argument as int,
-        from: from! as ClassFamilyBasedFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  ClassFamilyBasedProvider $copyWithBuild(
-    String Function(
-      Ref,
-      ClassFamilyBased,
-    ) build,
-  ) {
-    return ClassFamilyBasedProvider._(
-        argument: argument as int,
-        from: from! as ClassFamilyBasedFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<ClassFamilyBased, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -405,48 +297,38 @@ final class ClassFamilyBasedFamily extends Family {
       ClassFamilyBasedProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$classFamilyBasedHash();
-
-  @override
   String toString() => r'classFamilyBasedProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    ClassFamilyBased Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ClassFamilyBasedProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          ClassFamilyBased Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ClassFamilyBasedProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    String Function(Ref ref, ClassFamilyBased notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ClassFamilyBasedProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(Ref ref, ClassFamilyBased notifier, int argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ClassFamilyBasedProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$ClassFamilyBased extends $Notifier<String> {

--- a/packages/riverpod_generator/test/integration/generated.g.dart
+++ b/packages/riverpod_generator/test/integration/generated.g.dart
@@ -11,12 +11,8 @@ const generatedProvider = GeneratedProvider._();
 
 final class GeneratedProvider extends $FunctionalProvider<_Test, _Test>
     with $Provider<_Test> {
-  const GeneratedProvider._(
-      {_Test Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const GeneratedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class GeneratedProvider extends $FunctionalProvider<_Test, _Test>
           allTransitiveDependencies: null,
         );
 
-  final _Test Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$generatedHash();
+
+  @$internal
+  @override
+  $ProviderElement<_Test> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  _Test create(Ref ref) {
+    return generated(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(_Test value) {
@@ -39,26 +41,6 @@ final class GeneratedProvider extends $FunctionalProvider<_Test, _Test>
       origin: this,
       providerOverride: $ValueProvider<_Test>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<_Test> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  GeneratedProvider $copyWithCreate(
-    _Test Function(
-      Ref ref,
-    ) create,
-  ) {
-    return GeneratedProvider._(create: create);
-  }
-
-  @override
-  _Test create(Ref ref) {
-    final _$cb = _createCb ?? generated;
-    return _$cb(ref);
   }
 }
 
@@ -71,24 +53,14 @@ final class GeneratedFamilyProvider extends $FunctionalProvider<_Test, _Test>
     with $Provider<_Test> {
   const GeneratedFamilyProvider._(
       {required GeneratedFamilyFamily super.from,
-      required _Test super.argument,
-      _Test Function(
-        Ref ref,
-        _Test test,
-      )? create})
-      : _createCb = create,
-        super(
+      required _Test super.argument})
+      : super(
           retry: null,
           name: r'generatedFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final _Test Function(
-    Ref ref,
-    _Test test,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$generatedFamilyHash();
@@ -100,42 +72,25 @@ final class GeneratedFamilyProvider extends $FunctionalProvider<_Test, _Test>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<_Test> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  _Test create(Ref ref) {
+    final argument = this.argument as _Test;
+    return generatedFamily(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(_Test value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<_Test>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<_Test> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  GeneratedFamilyProvider $copyWithCreate(
-    _Test Function(
-      Ref ref,
-    ) create,
-  ) {
-    return GeneratedFamilyProvider._(
-        argument: argument as _Test,
-        from: from! as GeneratedFamilyFamily,
-        create: (
-          ref,
-          _Test test,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  _Test create(Ref ref) {
-    final _$cb = _createCb ?? generatedFamily;
-    final argument = this.argument as _Test;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -168,31 +123,23 @@ final class GeneratedFamilyFamily extends Family {
       GeneratedFamilyProvider._(argument: test, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$generatedFamilyHash();
-
-  @override
   String toString() => r'generatedFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    _Test Function(
-      Ref ref,
-      _Test args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GeneratedFamilyProvider;
-
-        final argument = provider.argument as _Test;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          _Test Function(
+            Ref ref,
+            _Test args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GeneratedFamilyProvider;
+            final argument = provider.argument as _Test;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(GeneratedClass)
@@ -200,10 +147,8 @@ const generatedClassProvider = GeneratedClassProvider._();
 
 final class GeneratedClassProvider
     extends $NotifierProvider<GeneratedClass, _Test> {
-  const GeneratedClassProvider._(
-      {super.runNotifierBuildOverride, GeneratedClass Function()? create})
-      : _createCb = create,
-        super(
+  const GeneratedClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -213,10 +158,18 @@ final class GeneratedClassProvider
           allTransitiveDependencies: null,
         );
 
-  final GeneratedClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$generatedClassHash();
+
+  @$internal
+  @override
+  GeneratedClass create() => GeneratedClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<GeneratedClass, _Test> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(_Test value) {
@@ -225,35 +178,6 @@ final class GeneratedClassProvider
       providerOverride: $ValueProvider<_Test>(value),
     );
   }
-
-  @$internal
-  @override
-  GeneratedClass create() => _createCb?.call() ?? GeneratedClass();
-
-  @$internal
-  @override
-  GeneratedClassProvider $copyWithCreate(
-    GeneratedClass Function() create,
-  ) {
-    return GeneratedClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  GeneratedClassProvider $copyWithBuild(
-    _Test Function(
-      Ref,
-      GeneratedClass,
-    ) build,
-  ) {
-    return GeneratedClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<GeneratedClass, _Test> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$generatedClassHash() => r'984153f97e25de687d2f19756b277aabd56f6e72';
@@ -278,19 +202,14 @@ final class GeneratedClassFamilyProvider
     extends $NotifierProvider<GeneratedClassFamily, _Test> {
   const GeneratedClassFamilyProvider._(
       {required GeneratedClassFamilyFamily super.from,
-      required _Test super.argument,
-      super.runNotifierBuildOverride,
-      GeneratedClassFamily Function()? create})
-      : _createCb = create,
-        super(
+      required _Test super.argument})
+      : super(
           retry: null,
           name: r'generatedClassFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final GeneratedClassFamily Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$generatedClassFamilyHash();
@@ -302,6 +221,16 @@ final class GeneratedClassFamilyProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  GeneratedClassFamily create() => GeneratedClassFamily();
+
+  @$internal
+  @override
+  $NotifierProviderElement<GeneratedClassFamily, _Test> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(_Test value) {
     return $ProviderOverride(
@@ -309,41 +238,6 @@ final class GeneratedClassFamilyProvider
       providerOverride: $ValueProvider<_Test>(value),
     );
   }
-
-  @$internal
-  @override
-  GeneratedClassFamily create() => _createCb?.call() ?? GeneratedClassFamily();
-
-  @$internal
-  @override
-  GeneratedClassFamilyProvider $copyWithCreate(
-    GeneratedClassFamily Function() create,
-  ) {
-    return GeneratedClassFamilyProvider._(
-        argument: argument as _Test,
-        from: from! as GeneratedClassFamilyFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  GeneratedClassFamilyProvider $copyWithBuild(
-    _Test Function(
-      Ref,
-      GeneratedClassFamily,
-    ) build,
-  ) {
-    return GeneratedClassFamilyProvider._(
-        argument: argument as _Test,
-        from: from! as GeneratedClassFamilyFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<GeneratedClassFamily, _Test> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -375,49 +269,38 @@ final class GeneratedClassFamilyFamily extends Family {
       GeneratedClassFamilyProvider._(argument: test, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$generatedClassFamilyHash();
-
-  @override
   String toString() => r'generatedClassFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    GeneratedClassFamily Function(
-      _Test args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GeneratedClassFamilyProvider;
-
-        final argument = provider.argument as _Test;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          GeneratedClassFamily Function(
+            _Test args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GeneratedClassFamilyProvider;
+            final argument = provider.argument as _Test;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    _Test Function(Ref ref, GeneratedClassFamily notifier, _Test argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GeneratedClassFamilyProvider;
-
-        final argument = provider.argument as _Test;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          _Test Function(Ref ref, GeneratedClassFamily notifier, _Test argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GeneratedClassFamilyProvider;
+            final argument = provider.argument as _Test;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$GeneratedClassFamily extends $Notifier<_Test> {
@@ -445,12 +328,8 @@ const $dynamicProvider = $DynamicProvider._();
 
 final class $DynamicProvider extends $FunctionalProvider<Object?, Object?>
     with $Provider<Object?> {
-  const $DynamicProvider._(
-      {Object? Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const $DynamicProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -460,12 +339,18 @@ final class $DynamicProvider extends $FunctionalProvider<Object?, Object?>
           allTransitiveDependencies: null,
         );
 
-  final Object? Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$$dynamicHash();
+
+  @$internal
+  @override
+  $ProviderElement<Object?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Object? create(Ref ref) {
+    return $dynamic(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Object? value) {
@@ -473,26 +358,6 @@ final class $DynamicProvider extends $FunctionalProvider<Object?, Object?>
       origin: this,
       providerOverride: $ValueProvider<Object?>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Object?> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  $DynamicProvider $copyWithCreate(
-    Object? Function(
-      Ref ref,
-    ) create,
-  ) {
-    return $DynamicProvider._(create: create);
-  }
-
-  @override
-  Object? create(Ref ref) {
-    final _$cb = _createCb ?? $dynamic;
-    return _$cb(ref);
   }
 }
 
@@ -505,24 +370,14 @@ final class $DynamicFamilyProvider extends $FunctionalProvider<Object?, Object?>
     with $Provider<Object?> {
   const $DynamicFamilyProvider._(
       {required $DynamicFamilyFamily super.from,
-      required dynamic super.argument,
-      Object? Function(
-        Ref ref,
-        dynamic test,
-      )? create})
-      : _createCb = create,
-        super(
+      required dynamic super.argument})
+      : super(
           retry: null,
           name: r'$dynamicFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final Object? Function(
-    Ref ref,
-    dynamic test,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$$dynamicFamilyHash();
@@ -534,42 +389,25 @@ final class $DynamicFamilyProvider extends $FunctionalProvider<Object?, Object?>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<Object?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Object? create(Ref ref) {
+    final argument = this.argument as dynamic;
+    return $dynamicFamily(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<Object?>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Object?> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  $DynamicFamilyProvider $copyWithCreate(
-    Object? Function(
-      Ref ref,
-    ) create,
-  ) {
-    return $DynamicFamilyProvider._(
-        argument: argument as dynamic,
-        from: from! as $DynamicFamilyFamily,
-        create: (
-          ref,
-          dynamic test,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  Object? create(Ref ref) {
-    final _$cb = _createCb ?? $dynamicFamily;
-    final argument = this.argument as dynamic;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -602,31 +440,23 @@ final class $DynamicFamilyFamily extends Family {
       $DynamicFamilyProvider._(argument: test, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$$dynamicFamilyHash();
-
-  @override
   String toString() => r'$dynamicFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Object? Function(
-      Ref ref,
-      dynamic args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as $DynamicFamilyProvider;
-
-        final argument = provider.argument as dynamic;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Object? Function(
+            Ref ref,
+            dynamic args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as $DynamicFamilyProvider;
+            final argument = provider.argument as dynamic;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor($DynamicClass)
@@ -634,10 +464,8 @@ const $dynamicClassProvider = $DynamicClassProvider._();
 
 final class $DynamicClassProvider
     extends $NotifierProvider<$DynamicClass, Object?> {
-  const $DynamicClassProvider._(
-      {super.runNotifierBuildOverride, $DynamicClass Function()? create})
-      : _createCb = create,
-        super(
+  const $DynamicClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -647,10 +475,18 @@ final class $DynamicClassProvider
           allTransitiveDependencies: null,
         );
 
-  final $DynamicClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$$dynamicClassHash();
+
+  @$internal
+  @override
+  $DynamicClass create() => $DynamicClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<$DynamicClass, Object?> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Object? value) {
@@ -659,35 +495,6 @@ final class $DynamicClassProvider
       providerOverride: $ValueProvider<Object?>(value),
     );
   }
-
-  @$internal
-  @override
-  $DynamicClass create() => _createCb?.call() ?? $DynamicClass();
-
-  @$internal
-  @override
-  $DynamicClassProvider $copyWithCreate(
-    $DynamicClass Function() create,
-  ) {
-    return $DynamicClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  $DynamicClassProvider $copyWithBuild(
-    Object? Function(
-      Ref,
-      $DynamicClass,
-    ) build,
-  ) {
-    return $DynamicClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<$DynamicClass, Object?> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$$dynamicClassHash() => r'c6d8e5191c3f060df3ce3eee66107433fd4c3292';
@@ -712,19 +519,14 @@ final class $DynamicClassFamilyProvider
     extends $NotifierProvider<$DynamicClassFamily, Object?> {
   const $DynamicClassFamilyProvider._(
       {required $DynamicClassFamilyFamily super.from,
-      required dynamic super.argument,
-      super.runNotifierBuildOverride,
-      $DynamicClassFamily Function()? create})
-      : _createCb = create,
-        super(
+      required dynamic super.argument})
+      : super(
           retry: null,
           name: r'$dynamicClassFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final $DynamicClassFamily Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$$dynamicClassFamilyHash();
@@ -736,6 +538,16 @@ final class $DynamicClassFamilyProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  $DynamicClassFamily create() => $DynamicClassFamily();
+
+  @$internal
+  @override
+  $NotifierProviderElement<$DynamicClassFamily, Object?> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
@@ -743,41 +555,6 @@ final class $DynamicClassFamilyProvider
       providerOverride: $ValueProvider<Object?>(value),
     );
   }
-
-  @$internal
-  @override
-  $DynamicClassFamily create() => _createCb?.call() ?? $DynamicClassFamily();
-
-  @$internal
-  @override
-  $DynamicClassFamilyProvider $copyWithCreate(
-    $DynamicClassFamily Function() create,
-  ) {
-    return $DynamicClassFamilyProvider._(
-        argument: argument as dynamic,
-        from: from! as $DynamicClassFamilyFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  $DynamicClassFamilyProvider $copyWithBuild(
-    Object? Function(
-      Ref,
-      $DynamicClassFamily,
-    ) build,
-  ) {
-    return $DynamicClassFamilyProvider._(
-        argument: argument as dynamic,
-        from: from! as $DynamicClassFamilyFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<$DynamicClassFamily, Object?> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -809,49 +586,39 @@ final class $DynamicClassFamilyFamily extends Family {
       $DynamicClassFamilyProvider._(argument: test, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$$dynamicClassFamilyHash();
-
-  @override
   String toString() => r'$dynamicClassFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    $DynamicClassFamily Function(
-      dynamic args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as $DynamicClassFamilyProvider;
-
-        final argument = provider.argument as dynamic;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          $DynamicClassFamily Function(
+            dynamic args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as $DynamicClassFamilyProvider;
+            final argument = provider.argument as dynamic;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    Object? Function(Ref ref, $DynamicClassFamily notifier, dynamic argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as $DynamicClassFamilyProvider;
-
-        final argument = provider.argument as dynamic;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Object? Function(
+                  Ref ref, $DynamicClassFamily notifier, dynamic argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as $DynamicClassFamilyProvider;
+            final argument = provider.argument as dynamic;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$$DynamicClassFamily extends $Notifier<Object?> {
@@ -880,25 +647,14 @@ const _dynamicProvider = _DynamicFamily._();
 final class _DynamicProvider extends $FunctionalProvider<Object?, Object?>
     with $Provider<Object?> {
   const _DynamicProvider._(
-      {required _DynamicFamily super.from,
-      required dynamic super.argument,
-      Object? Function(
-        Ref ref,
-        dynamic test,
-      )? create})
-      : _createCb = create,
-        super(
+      {required _DynamicFamily super.from, required dynamic super.argument})
+      : super(
           retry: null,
           name: r'_dynamicProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final Object? Function(
-    Ref ref,
-    dynamic test,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$dynamicHash();
@@ -910,42 +666,25 @@ final class _DynamicProvider extends $FunctionalProvider<Object?, Object?>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<Object?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Object? create(Ref ref) {
+    final argument = this.argument as dynamic;
+    return _dynamic(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<Object?>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Object?> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  _DynamicProvider $copyWithCreate(
-    Object? Function(
-      Ref ref,
-    ) create,
-  ) {
-    return _DynamicProvider._(
-        argument: argument as dynamic,
-        from: from! as _DynamicFamily,
-        create: (
-          ref,
-          dynamic test,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  Object? create(Ref ref) {
-    final _$cb = _createCb ?? _dynamic;
-    final argument = this.argument as dynamic;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -978,31 +717,23 @@ final class _DynamicFamily extends Family {
       _DynamicProvider._(argument: test, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$dynamicHash();
-
-  @override
   String toString() => r'_dynamicProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Object? Function(
-      Ref ref,
-      dynamic args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as _DynamicProvider;
-
-        final argument = provider.argument as dynamic;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Object? Function(
+            Ref ref,
+            dynamic args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as _DynamicProvider;
+            final argument = provider.argument as dynamic;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(alias)
@@ -1011,12 +742,8 @@ const aliasProvider = AliasProvider._();
 final class AliasProvider
     extends $FunctionalProvider<AsyncValue<int>, AsyncValue<int>>
     with $Provider<AsyncValue<int>> {
-  const AliasProvider._(
-      {AsyncValue<int> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AliasProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1026,12 +753,18 @@ final class AliasProvider
           allTransitiveDependencies: null,
         );
 
-  final AsyncValue<int> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$aliasHash();
+
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<int>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  AsyncValue<int> create(Ref ref) {
+    return alias(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<int> value) {
@@ -1039,26 +772,6 @@ final class AliasProvider
       origin: this,
       providerOverride: $ValueProvider<AsyncValue<int>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<AsyncValue<int>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AliasProvider $copyWithCreate(
-    AsyncValue<int> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AliasProvider._(create: create);
-  }
-
-  @override
-  AsyncValue<int> create(Ref ref) {
-    final _$cb = _createCb ?? alias;
-    return _$cb(ref);
   }
 }
 
@@ -1072,24 +785,14 @@ final class AliasFamilyProvider
     with $Provider<AsyncValue<int>> {
   const AliasFamilyProvider._(
       {required AliasFamilyFamily super.from,
-      required AsyncValue<int> super.argument,
-      AsyncValue<int> Function(
-        Ref ref,
-        AsyncValue<int> test,
-      )? create})
-      : _createCb = create,
-        super(
+      required AsyncValue<int> super.argument})
+      : super(
           retry: null,
           name: r'aliasFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final AsyncValue<int> Function(
-    Ref ref,
-    AsyncValue<int> test,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$aliasFamilyHash();
@@ -1101,42 +804,25 @@ final class AliasFamilyProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<AsyncValue<int>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  AsyncValue<int> create(Ref ref) {
+    final argument = this.argument as AsyncValue<int>;
+    return aliasFamily(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<int> value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<AsyncValue<int>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AliasFamilyProvider $copyWithCreate(
-    AsyncValue<int> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AliasFamilyProvider._(
-        argument: argument as AsyncValue<int>,
-        from: from! as AliasFamilyFamily,
-        create: (
-          ref,
-          AsyncValue<int> test,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  AsyncValue<int> create(Ref ref) {
-    final _$cb = _createCb ?? aliasFamily;
-    final argument = this.argument as AsyncValue<int>;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -1169,31 +855,23 @@ final class AliasFamilyFamily extends Family {
       AliasFamilyProvider._(argument: test, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$aliasFamilyHash();
-
-  @override
   String toString() => r'aliasFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    AsyncValue<int> Function(
-      Ref ref,
-      AsyncValue<int> args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as AliasFamilyProvider;
-
-        final argument = provider.argument as AsyncValue<int>;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          AsyncValue<int> Function(
+            Ref ref,
+            AsyncValue<int> args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as AliasFamilyProvider;
+            final argument = provider.argument as AsyncValue<int>;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(AliasClass)
@@ -1201,10 +879,8 @@ const aliasClassProvider = AliasClassProvider._();
 
 final class AliasClassProvider
     extends $NotifierProvider<AliasClass, AsyncValue<int>> {
-  const AliasClassProvider._(
-      {super.runNotifierBuildOverride, AliasClass Function()? create})
-      : _createCb = create,
-        super(
+  const AliasClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1214,10 +890,18 @@ final class AliasClassProvider
           allTransitiveDependencies: null,
         );
 
-  final AliasClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$aliasClassHash();
+
+  @$internal
+  @override
+  AliasClass create() => AliasClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<AliasClass, AsyncValue<int>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<int> value) {
@@ -1226,35 +910,6 @@ final class AliasClassProvider
       providerOverride: $ValueProvider<AsyncValue<int>>(value),
     );
   }
-
-  @$internal
-  @override
-  AliasClass create() => _createCb?.call() ?? AliasClass();
-
-  @$internal
-  @override
-  AliasClassProvider $copyWithCreate(
-    AliasClass Function() create,
-  ) {
-    return AliasClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  AliasClassProvider $copyWithBuild(
-    AsyncValue<int> Function(
-      Ref,
-      AliasClass,
-    ) build,
-  ) {
-    return AliasClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<AliasClass, AsyncValue<int>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$aliasClassHash() => r'aac83936c14520c015f0fe8a0120d353c0baf602';
@@ -1279,19 +934,14 @@ final class AliasClassFamilyProvider
     extends $NotifierProvider<AliasClassFamily, AsyncValue<int>> {
   const AliasClassFamilyProvider._(
       {required AliasClassFamilyFamily super.from,
-      required AsyncValue<int> super.argument,
-      super.runNotifierBuildOverride,
-      AliasClassFamily Function()? create})
-      : _createCb = create,
-        super(
+      required AsyncValue<int> super.argument})
+      : super(
           retry: null,
           name: r'aliasClassFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final AliasClassFamily Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$aliasClassFamilyHash();
@@ -1303,6 +953,16 @@ final class AliasClassFamilyProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  AliasClassFamily create() => AliasClassFamily();
+
+  @$internal
+  @override
+  $NotifierProviderElement<AliasClassFamily, AsyncValue<int>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<int> value) {
     return $ProviderOverride(
@@ -1310,41 +970,6 @@ final class AliasClassFamilyProvider
       providerOverride: $ValueProvider<AsyncValue<int>>(value),
     );
   }
-
-  @$internal
-  @override
-  AliasClassFamily create() => _createCb?.call() ?? AliasClassFamily();
-
-  @$internal
-  @override
-  AliasClassFamilyProvider $copyWithCreate(
-    AliasClassFamily Function() create,
-  ) {
-    return AliasClassFamilyProvider._(
-        argument: argument as AsyncValue<int>,
-        from: from! as AliasClassFamilyFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  AliasClassFamilyProvider $copyWithBuild(
-    AsyncValue<int> Function(
-      Ref,
-      AliasClassFamily,
-    ) build,
-  ) {
-    return AliasClassFamilyProvider._(
-        argument: argument as AsyncValue<int>,
-        from: from! as AliasClassFamilyFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<AliasClassFamily, AsyncValue<int>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -1375,50 +1000,39 @@ final class AliasClassFamilyFamily extends Family {
       AliasClassFamilyProvider._(argument: test, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$aliasClassFamilyHash();
-
-  @override
   String toString() => r'aliasClassFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    AliasClassFamily Function(
-      AsyncValue<int> args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as AliasClassFamilyProvider;
-
-        final argument = provider.argument as AsyncValue<int>;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          AliasClassFamily Function(
+            AsyncValue<int> args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as AliasClassFamilyProvider;
+            final argument = provider.argument as AsyncValue<int>;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    AsyncValue<int> Function(
-            Ref ref, AliasClassFamily notifier, AsyncValue<int> argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as AliasClassFamilyProvider;
-
-        final argument = provider.argument as AsyncValue<int>;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          AsyncValue<int> Function(
+                  Ref ref, AliasClassFamily notifier, AsyncValue<int> argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as AliasClassFamilyProvider;
+            final argument = provider.argument as AsyncValue<int>;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$AliasClassFamily extends $Notifier<AsyncValue<int>> {

--- a/packages/riverpod_generator/test/integration/hash/hash1.g.dart
+++ b/packages/riverpod_generator/test/integration/hash/hash1.g.dart
@@ -11,12 +11,8 @@ const simpleProvider = SimpleProvider._();
 
 final class SimpleProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const SimpleProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const SimpleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class SimpleProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$simpleHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return simple(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -39,26 +41,6 @@ final class SimpleProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  SimpleProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return SimpleProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? simple;
-    return _$cb(ref);
   }
 }
 
@@ -69,12 +51,8 @@ const simple2Provider = Simple2Provider._();
 
 final class Simple2Provider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const Simple2Provider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Simple2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -84,12 +62,18 @@ final class Simple2Provider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$simple2Hash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return simple2(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -97,26 +81,6 @@ final class Simple2Provider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Simple2Provider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Simple2Provider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? simple2;
-    return _$cb(ref);
   }
 }
 
@@ -126,10 +90,8 @@ String _$simple2Hash() => r'a60a8496fc391f5adf7ad45a12d0723f14f3127c';
 const simpleClassProvider = SimpleClassProvider._();
 
 final class SimpleClassProvider extends $NotifierProvider<SimpleClass, String> {
-  const SimpleClassProvider._(
-      {super.runNotifierBuildOverride, SimpleClass Function()? create})
-      : _createCb = create,
-        super(
+  const SimpleClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -139,10 +101,18 @@ final class SimpleClassProvider extends $NotifierProvider<SimpleClass, String> {
           allTransitiveDependencies: null,
         );
 
-  final SimpleClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$simpleClassHash();
+
+  @$internal
+  @override
+  SimpleClass create() => SimpleClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<SimpleClass, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -151,35 +121,6 @@ final class SimpleClassProvider extends $NotifierProvider<SimpleClass, String> {
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  SimpleClass create() => _createCb?.call() ?? SimpleClass();
-
-  @$internal
-  @override
-  SimpleClassProvider $copyWithCreate(
-    SimpleClass Function() create,
-  ) {
-    return SimpleClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  SimpleClassProvider $copyWithBuild(
-    String Function(
-      Ref,
-      SimpleClass,
-    ) build,
-  ) {
-    return SimpleClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<SimpleClass, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$simpleClassHash() => r'958123cd6179c5b88da040cfeb71eb3061765277';

--- a/packages/riverpod_generator/test/integration/hash/retry.g.dart
+++ b/packages/riverpod_generator/test/integration/hash/retry.g.dart
@@ -11,12 +11,8 @@ const aProvider = AProvider._();
 
 final class AProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const AProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AProvider._()
+      : super(
           from: null,
           argument: null,
           retry: myRetry,
@@ -26,12 +22,18 @@ final class AProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$aHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return a(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -39,26 +41,6 @@ final class AProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? a;
-    return _$cb(ref);
   }
 }
 
@@ -69,26 +51,14 @@ const bProvider = BFamily._();
 
 final class BProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const BProvider._(
-      {required BFamily super.from,
-      required int super.argument,
-      String Function(
-        Ref ref,
-        int arg,
-      )? create})
-      : _createCb = create,
-        super(
+  const BProvider._({required BFamily super.from, required int super.argument})
+      : super(
           retry: myRetry2,
           name: r'bProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    int arg,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$bHash();
@@ -100,42 +70,25 @@ final class BProvider extends $FunctionalProvider<String, String>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    final argument = this.argument as int;
+    return b(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  BProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return BProvider._(
-        argument: argument as int,
-        from: from! as BFamily,
-        create: (
-          ref,
-          int arg,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? b;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -168,31 +121,23 @@ final class BFamily extends Family {
       BProvider._(argument: arg, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$bHash();
-
-  @override
   String toString() => r'bProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as BProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as BProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_generator/test/integration/mutation.g.dart
+++ b/packages/riverpod_generator/test/integration/mutation.g.dart
@@ -11,10 +11,8 @@ const syncTodoListProvider = SyncTodoListProvider._();
 
 final class SyncTodoListProvider
     extends $NotifierProvider<SyncTodoList, List<Todo>> {
-  const SyncTodoListProvider._(
-      {super.runNotifierBuildOverride, SyncTodoList Function()? create})
-      : _createCb = create,
-        super(
+  const SyncTodoListProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -24,46 +22,17 @@ final class SyncTodoListProvider
           allTransitiveDependencies: null,
         );
 
-  final SyncTodoList Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$syncTodoListHash();
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(List<Todo> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
-    );
-  }
-
   @$internal
   @override
-  SyncTodoList create() => _createCb?.call() ?? SyncTodoList();
-
-  @$internal
-  @override
-  SyncTodoListProvider $copyWithCreate(
-    SyncTodoList Function() create,
-  ) {
-    return SyncTodoListProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  SyncTodoListProvider $copyWithBuild(
-    List<Todo> Function(
-      Ref,
-      SyncTodoList,
-    ) build,
-  ) {
-    return SyncTodoListProvider._(runNotifierBuildOverride: build);
-  }
+  SyncTodoList create() => SyncTodoList();
 
   @$internal
   @override
   _$SyncTodoListElement $createElement($ProviderPointer pointer) =>
-      _$SyncTodoListElement(this, pointer);
+      _$SyncTodoListElement(pointer);
 
   ProviderListenable<SyncTodoList$AddSync> get addSync =>
       $LazyProxyListenable<SyncTodoList$AddSync, List<Todo>>(
@@ -84,6 +53,14 @@ final class SyncTodoListProvider
           return element._$addAsync;
         },
       );
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<Todo> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<List<Todo>>(value),
+    );
+  }
 }
 
 String _$syncTodoListHash() => r'18d459affe35603d564ac90e05c1978d4e862f40';
@@ -103,7 +80,7 @@ abstract class _$SyncTodoList extends $Notifier<List<Todo>> {
 
 class _$SyncTodoListElement
     extends $NotifierProviderElement<SyncTodoList, List<Todo>> {
-  _$SyncTodoListElement(super.provider, super.pointer) {
+  _$SyncTodoListElement(super.pointer) {
     _$addSync.result = $Result.data(_$SyncTodoList$AddSync(this));
     _$addAsync.result = $Result.data(_$SyncTodoList$AddAsync(this));
   }
@@ -226,10 +203,8 @@ const asyncTodoListProvider = AsyncTodoListProvider._();
 
 final class AsyncTodoListProvider
     extends $AsyncNotifierProvider<AsyncTodoList, List<Todo>> {
-  const AsyncTodoListProvider._(
-      {super.runNotifierBuildOverride, AsyncTodoList Function()? create})
-      : _createCb = create,
-        super(
+  const AsyncTodoListProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -239,38 +214,17 @@ final class AsyncTodoListProvider
           allTransitiveDependencies: null,
         );
 
-  final AsyncTodoList Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$asyncTodoListHash();
 
   @$internal
   @override
-  AsyncTodoList create() => _createCb?.call() ?? AsyncTodoList();
-
-  @$internal
-  @override
-  AsyncTodoListProvider $copyWithCreate(
-    AsyncTodoList Function() create,
-  ) {
-    return AsyncTodoListProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  AsyncTodoListProvider $copyWithBuild(
-    FutureOr<List<Todo>> Function(
-      Ref,
-      AsyncTodoList,
-    ) build,
-  ) {
-    return AsyncTodoListProvider._(runNotifierBuildOverride: build);
-  }
+  AsyncTodoList create() => AsyncTodoList();
 
   @$internal
   @override
   _$AsyncTodoListElement $createElement($ProviderPointer pointer) =>
-      _$AsyncTodoListElement(this, pointer);
+      _$AsyncTodoListElement(pointer);
 
   ProviderListenable<AsyncTodoList$AddSync> get addSync =>
       $LazyProxyListenable<AsyncTodoList$AddSync, AsyncValue<List<Todo>>>(
@@ -291,6 +245,14 @@ final class AsyncTodoListProvider
           return element._$addAsync;
         },
       );
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<Todo>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
+    );
+  }
 }
 
 String _$asyncTodoListHash() => r'73d9aa3b39ad5d0c157510754bfc273a98075d30';
@@ -313,7 +275,7 @@ abstract class _$AsyncTodoList extends $AsyncNotifier<List<Todo>> {
 
 class _$AsyncTodoListElement
     extends $AsyncNotifierProviderElement<AsyncTodoList, List<Todo>> {
-  _$AsyncTodoListElement(super.provider, super.pointer) {
+  _$AsyncTodoListElement(super.pointer) {
     _$addSync.result = $Result.data(_$AsyncTodoList$AddSync(this));
     _$addAsync.result = $Result.data(_$AsyncTodoList$AddAsync(this));
   }
@@ -435,10 +397,8 @@ final class _$AsyncTodoList$AddAsync
 const simpleProvider = SimpleProvider._();
 
 final class SimpleProvider extends $NotifierProvider<Simple, int> {
-  const SimpleProvider._(
-      {super.runNotifierBuildOverride, Simple Function()? create})
-      : _createCb = create,
-        super(
+  const SimpleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -448,46 +408,17 @@ final class SimpleProvider extends $NotifierProvider<Simple, int> {
           allTransitiveDependencies: null,
         );
 
-  final Simple Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$simpleHash();
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(int value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
   @$internal
   @override
-  Simple create() => _createCb?.call() ?? Simple();
-
-  @$internal
-  @override
-  SimpleProvider $copyWithCreate(
-    Simple Function() create,
-  ) {
-    return SimpleProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  SimpleProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Simple,
-    ) build,
-  ) {
-    return SimpleProvider._(runNotifierBuildOverride: build);
-  }
+  Simple create() => Simple();
 
   @$internal
   @override
   _$SimpleElement $createElement($ProviderPointer pointer) =>
-      _$SimpleElement(this, pointer);
+      _$SimpleElement(pointer);
 
   ProviderListenable<Simple$Increment> get increment =>
       $LazyProxyListenable<Simple$Increment, int>(
@@ -518,6 +449,14 @@ final class SimpleProvider extends $NotifierProvider<Simple, int> {
           return element._$delegated;
         },
       );
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(int value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<int>(value),
+    );
+  }
 }
 
 String _$simpleHash() => r'bbccebb4e8d2a097b945f6d7ab5e54ac11781c49';
@@ -536,7 +475,7 @@ abstract class _$Simple extends $Notifier<int> {
 }
 
 class _$SimpleElement extends $NotifierProviderElement<Simple, int> {
-  _$SimpleElement(super.provider, super.pointer) {
+  _$SimpleElement(super.pointer) {
     _$increment.result = $Result.data(_$Simple$Increment(this));
     _$incrementOr.result = $Result.data(_$Simple$IncrementOr(this));
     _$delegated.result = $Result.data(_$Simple$Delegated(this));
@@ -708,20 +647,14 @@ const simpleFamilyProvider = SimpleFamilyFamily._();
 
 final class SimpleFamilyProvider extends $NotifierProvider<SimpleFamily, int> {
   const SimpleFamilyProvider._(
-      {required SimpleFamilyFamily super.from,
-      required String super.argument,
-      super.runNotifierBuildOverride,
-      SimpleFamily Function()? create})
-      : _createCb = create,
-        super(
+      {required SimpleFamilyFamily super.from, required String super.argument})
+      : super(
           retry: null,
           name: r'simpleFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final SimpleFamily Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$simpleFamilyHash();
@@ -733,47 +666,14 @@ final class SimpleFamilyProvider extends $NotifierProvider<SimpleFamily, int> {
         '($argument)';
   }
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(int value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
   @$internal
   @override
-  SimpleFamily create() => _createCb?.call() ?? SimpleFamily();
-
-  @$internal
-  @override
-  SimpleFamilyProvider $copyWithCreate(
-    SimpleFamily Function() create,
-  ) {
-    return SimpleFamilyProvider._(
-        argument: argument as String,
-        from: from! as SimpleFamilyFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  SimpleFamilyProvider $copyWithBuild(
-    int Function(
-      Ref,
-      SimpleFamily,
-    ) build,
-  ) {
-    return SimpleFamilyProvider._(
-        argument: argument as String,
-        from: from! as SimpleFamilyFamily,
-        runNotifierBuildOverride: build);
-  }
+  SimpleFamily create() => SimpleFamily();
 
   @$internal
   @override
   _$SimpleFamilyElement $createElement($ProviderPointer pointer) =>
-      _$SimpleFamilyElement(this, pointer);
+      _$SimpleFamilyElement(pointer);
 
   ProviderListenable<SimpleFamily$Increment> get increment =>
       $LazyProxyListenable<SimpleFamily$Increment, int>(
@@ -794,6 +694,14 @@ final class SimpleFamilyProvider extends $NotifierProvider<SimpleFamily, int> {
           return element._$incrementOr;
         },
       );
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(int value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<int>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -824,48 +732,38 @@ final class SimpleFamilyFamily extends Family {
       SimpleFamilyProvider._(argument: arg, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$simpleFamilyHash();
-
-  @override
   String toString() => r'simpleFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    SimpleFamily Function(
-      String args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as SimpleFamilyProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          SimpleFamily Function(
+            String args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as SimpleFamilyProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function(Ref ref, SimpleFamily notifier, String argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as SimpleFamilyProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(Ref ref, SimpleFamily notifier, String argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as SimpleFamilyProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$SimpleFamily extends $Notifier<int> {
@@ -890,7 +788,7 @@ abstract class _$SimpleFamily extends $Notifier<int> {
 
 class _$SimpleFamilyElement
     extends $NotifierProviderElement<SimpleFamily, int> {
-  _$SimpleFamilyElement(super.provider, super.pointer) {
+  _$SimpleFamilyElement(super.pointer) {
     _$increment.result = $Result.data(_$SimpleFamily$Increment(this));
     _$incrementOr.result = $Result.data(_$SimpleFamily$IncrementOr(this));
   }
@@ -1013,10 +911,8 @@ const simpleAsyncProvider = SimpleAsyncProvider._();
 
 final class SimpleAsyncProvider
     extends $AsyncNotifierProvider<SimpleAsync, int> {
-  const SimpleAsyncProvider._(
-      {super.runNotifierBuildOverride, SimpleAsync Function()? create})
-      : _createCb = create,
-        super(
+  const SimpleAsyncProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1026,38 +922,17 @@ final class SimpleAsyncProvider
           allTransitiveDependencies: null,
         );
 
-  final SimpleAsync Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$simpleAsyncHash();
 
   @$internal
   @override
-  SimpleAsync create() => _createCb?.call() ?? SimpleAsync();
-
-  @$internal
-  @override
-  SimpleAsyncProvider $copyWithCreate(
-    SimpleAsync Function() create,
-  ) {
-    return SimpleAsyncProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  SimpleAsyncProvider $copyWithBuild(
-    FutureOr<int> Function(
-      Ref,
-      SimpleAsync,
-    ) build,
-  ) {
-    return SimpleAsyncProvider._(runNotifierBuildOverride: build);
-  }
+  SimpleAsync create() => SimpleAsync();
 
   @$internal
   @override
   _$SimpleAsyncElement $createElement($ProviderPointer pointer) =>
-      _$SimpleAsyncElement(this, pointer);
+      _$SimpleAsyncElement(pointer);
 
   ProviderListenable<SimpleAsync$Increment> get increment =>
       $LazyProxyListenable<SimpleAsync$Increment, AsyncValue<int>>(
@@ -1078,6 +953,14 @@ final class SimpleAsyncProvider
           return element._$delegated;
         },
       );
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 }
 
 String _$simpleAsyncHash() => r'62dd0ee93e61fa27d139247b9a899630d5d3572c';
@@ -1097,7 +980,7 @@ abstract class _$SimpleAsync extends $AsyncNotifier<int> {
 
 class _$SimpleAsyncElement
     extends $AsyncNotifierProviderElement<SimpleAsync, int> {
-  _$SimpleAsyncElement(super.provider, super.pointer) {
+  _$SimpleAsyncElement(super.pointer) {
     _$increment.result = $Result.data(_$SimpleAsync$Increment(this));
     _$delegated.result = $Result.data(_$SimpleAsync$Delegated(this));
   }
@@ -1221,20 +1104,14 @@ const simpleAsync2Provider = SimpleAsync2Family._();
 final class SimpleAsync2Provider
     extends $StreamNotifierProvider<SimpleAsync2, int> {
   const SimpleAsync2Provider._(
-      {required SimpleAsync2Family super.from,
-      required String super.argument,
-      super.runNotifierBuildOverride,
-      SimpleAsync2 Function()? create})
-      : _createCb = create,
-        super(
+      {required SimpleAsync2Family super.from, required String super.argument})
+      : super(
           retry: null,
           name: r'simpleAsync2Provider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final SimpleAsync2 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$simpleAsync2Hash();
@@ -1248,37 +1125,12 @@ final class SimpleAsync2Provider
 
   @$internal
   @override
-  SimpleAsync2 create() => _createCb?.call() ?? SimpleAsync2();
-
-  @$internal
-  @override
-  SimpleAsync2Provider $copyWithCreate(
-    SimpleAsync2 Function() create,
-  ) {
-    return SimpleAsync2Provider._(
-        argument: argument as String,
-        from: from! as SimpleAsync2Family,
-        create: create);
-  }
-
-  @$internal
-  @override
-  SimpleAsync2Provider $copyWithBuild(
-    Stream<int> Function(
-      Ref,
-      SimpleAsync2,
-    ) build,
-  ) {
-    return SimpleAsync2Provider._(
-        argument: argument as String,
-        from: from! as SimpleAsync2Family,
-        runNotifierBuildOverride: build);
-  }
+  SimpleAsync2 create() => SimpleAsync2();
 
   @$internal
   @override
   _$SimpleAsync2Element $createElement($ProviderPointer pointer) =>
-      _$SimpleAsync2Element(this, pointer);
+      _$SimpleAsync2Element(pointer);
 
   ProviderListenable<SimpleAsync2$Increment> get increment =>
       $LazyProxyListenable<SimpleAsync2$Increment, AsyncValue<int>>(
@@ -1289,6 +1141,14 @@ final class SimpleAsync2Provider
           return element._$increment;
         },
       );
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -1319,48 +1179,38 @@ final class SimpleAsync2Family extends Family {
       SimpleAsync2Provider._(argument: arg, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$simpleAsync2Hash();
-
-  @override
   String toString() => r'simpleAsync2Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    SimpleAsync2 Function(
-      String args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as SimpleAsync2Provider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          SimpleAsync2 Function(
+            String args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as SimpleAsync2Provider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    Stream<int> Function(Ref ref, SimpleAsync2 notifier, String argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as SimpleAsync2Provider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Stream<int> Function(Ref ref, SimpleAsync2 notifier, String argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as SimpleAsync2Provider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$SimpleAsync2 extends $StreamNotifier<int> {
@@ -1385,7 +1235,7 @@ abstract class _$SimpleAsync2 extends $StreamNotifier<int> {
 
 class _$SimpleAsync2Element
     extends $StreamNotifierProviderElement<SimpleAsync2, int> {
-  _$SimpleAsync2Element(super.provider, super.pointer) {
+  _$SimpleAsync2Element(super.pointer) {
     _$increment.result = $Result.data(_$SimpleAsync2$Increment(this));
   }
   final _$increment = $ElementLense<_$SimpleAsync2$Increment>();
@@ -1455,12 +1305,8 @@ const genericProvider = GenericFamily._();
 
 final class GenericProvider<T extends num>
     extends $AsyncNotifierProvider<Generic<T>, int> {
-  const GenericProvider._(
-      {required GenericFamily super.from,
-      super.runNotifierBuildOverride,
-      Generic<T> Function()? create})
-      : _createCb = create,
-        super(
+  const GenericProvider._({required GenericFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'genericProvider',
@@ -1469,27 +1315,8 @@ final class GenericProvider<T extends num>
           allTransitiveDependencies: null,
         );
 
-  final Generic<T> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericHash();
-
-  GenericProvider<T> _copyWithCreate(
-    Generic<T> Function<T extends num>() create,
-  ) {
-    return GenericProvider<T>._(
-        from: from! as GenericFamily, create: create<T>);
-  }
-
-  GenericProvider<T> _copyWithBuild(
-    FutureOr<int> Function<T extends num>(
-      Ref,
-      Generic<T>,
-    ) build,
-  ) {
-    return GenericProvider<T>._(
-        from: from! as GenericFamily, runNotifierBuildOverride: build<T>);
-  }
 
   @override
   String toString() {
@@ -1500,32 +1327,12 @@ final class GenericProvider<T extends num>
 
   @$internal
   @override
-  Generic<T> create() => _createCb?.call() ?? Generic<T>();
-
-  @$internal
-  @override
-  GenericProvider<T> $copyWithCreate(
-    Generic<T> Function() create,
-  ) {
-    return GenericProvider<T>._(from: from! as GenericFamily, create: create);
-  }
-
-  @$internal
-  @override
-  GenericProvider<T> $copyWithBuild(
-    FutureOr<int> Function(
-      Ref,
-      Generic<T>,
-    ) build,
-  ) {
-    return GenericProvider<T>._(
-        from: from! as GenericFamily, runNotifierBuildOverride: build);
-  }
+  Generic<T> create() => Generic<T>();
 
   @$internal
   @override
   _$GenericElement<T> $createElement($ProviderPointer pointer) =>
-      _$GenericElement(this, pointer);
+      _$GenericElement(pointer);
 
   ProviderListenable<Generic$Increment> get increment =>
       $LazyProxyListenable<Generic$Increment, AsyncValue<int>>(
@@ -1536,6 +1343,18 @@ final class GenericProvider<T extends num>
           return element._$increment;
         },
       );
+
+  $R _captureGenerics<$R>($R Function<T extends num>() cb) {
+    return cb<T>();
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -1565,38 +1384,35 @@ final class GenericFamily extends Family {
   GenericProvider<T> call<T extends num>() => GenericProvider<T>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$genericHash();
-
-  @override
   String toString() => r'genericProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    Generic<T> Function<T extends num>() create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(Generic<T> Function<T extends num>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericProvider<T>;
+              return provider.$view(create: create<T>).$createElement(pointer);
+            });
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    FutureOr<int> Function<T extends num>(Ref ref, Generic<T> notifier) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericProvider;
-
-        return provider._copyWithBuild(build).$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<int> Function<T extends num>(Ref ref, Generic<T> notifier)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericProvider<T>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<T>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$Generic<T extends num> extends $AsyncNotifier<int> {
@@ -1614,7 +1430,7 @@ abstract class _$Generic<T extends num> extends $AsyncNotifier<int> {
 
 class _$GenericElement<T extends num>
     extends $AsyncNotifierProviderElement<Generic<T>, int> {
-  _$GenericElement(super.provider, super.pointer) {
+  _$GenericElement(super.pointer) {
     _$increment.result = $Result.data(_$Generic$Increment(this));
   }
   final _$increment = $ElementLense<_$Generic$Increment>();
@@ -1683,10 +1499,8 @@ final class _$Generic$Increment
 const genericMutProvider = GenericMutProvider._();
 
 final class GenericMutProvider extends $AsyncNotifierProvider<GenericMut, int> {
-  const GenericMutProvider._(
-      {super.runNotifierBuildOverride, GenericMut Function()? create})
-      : _createCb = create,
-        super(
+  const GenericMutProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1696,38 +1510,17 @@ final class GenericMutProvider extends $AsyncNotifierProvider<GenericMut, int> {
           allTransitiveDependencies: null,
         );
 
-  final GenericMut Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericMutHash();
 
   @$internal
   @override
-  GenericMut create() => _createCb?.call() ?? GenericMut();
-
-  @$internal
-  @override
-  GenericMutProvider $copyWithCreate(
-    GenericMut Function() create,
-  ) {
-    return GenericMutProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  GenericMutProvider $copyWithBuild(
-    FutureOr<int> Function(
-      Ref,
-      GenericMut,
-    ) build,
-  ) {
-    return GenericMutProvider._(runNotifierBuildOverride: build);
-  }
+  GenericMut create() => GenericMut();
 
   @$internal
   @override
   _$GenericMutElement $createElement($ProviderPointer pointer) =>
-      _$GenericMutElement(this, pointer);
+      _$GenericMutElement(pointer);
 
   ProviderListenable<GenericMut$Increment> get increment =>
       $LazyProxyListenable<GenericMut$Increment, AsyncValue<int>>(
@@ -1738,6 +1531,14 @@ final class GenericMutProvider extends $AsyncNotifierProvider<GenericMut, int> {
           return element._$increment;
         },
       );
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 }
 
 String _$genericMutHash() => r'1f38b70cf937501fb313ae35c8bf824728bbd8ba';
@@ -1757,7 +1558,7 @@ abstract class _$GenericMut extends $AsyncNotifier<int> {
 
 class _$GenericMutElement
     extends $AsyncNotifierProviderElement<GenericMut, int> {
-  _$GenericMutElement(super.provider, super.pointer) {
+  _$GenericMutElement(super.pointer) {
     _$increment.result = $Result.data(_$GenericMut$Increment(this));
   }
   final _$increment = $ElementLense<_$GenericMut$Increment>();
@@ -1829,10 +1630,8 @@ final class _$GenericMut$Increment
 const failingCtorProvider = FailingCtorProvider._();
 
 final class FailingCtorProvider extends $NotifierProvider<FailingCtor, int> {
-  const FailingCtorProvider._(
-      {super.runNotifierBuildOverride, FailingCtor Function()? create})
-      : _createCb = create,
-        super(
+  const FailingCtorProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1842,46 +1641,17 @@ final class FailingCtorProvider extends $NotifierProvider<FailingCtor, int> {
           allTransitiveDependencies: null,
         );
 
-  final FailingCtor Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$failingCtorHash();
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(int value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
   @$internal
   @override
-  FailingCtor create() => _createCb?.call() ?? FailingCtor();
-
-  @$internal
-  @override
-  FailingCtorProvider $copyWithCreate(
-    FailingCtor Function() create,
-  ) {
-    return FailingCtorProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  FailingCtorProvider $copyWithBuild(
-    int Function(
-      Ref,
-      FailingCtor,
-    ) build,
-  ) {
-    return FailingCtorProvider._(runNotifierBuildOverride: build);
-  }
+  FailingCtor create() => FailingCtor();
 
   @$internal
   @override
   _$FailingCtorElement $createElement($ProviderPointer pointer) =>
-      _$FailingCtorElement(this, pointer);
+      _$FailingCtorElement(pointer);
 
   ProviderListenable<FailingCtor$Increment> get increment =>
       $LazyProxyListenable<FailingCtor$Increment, int>(
@@ -1892,6 +1662,14 @@ final class FailingCtorProvider extends $NotifierProvider<FailingCtor, int> {
           return element._$increment;
         },
       );
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(int value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<int>(value),
+    );
+  }
 }
 
 String _$failingCtorHash() => r'5d80d3b1dba058415cc8cfec17bc14e1f9c83fae';
@@ -1910,7 +1688,7 @@ abstract class _$FailingCtor extends $Notifier<int> {
 }
 
 class _$FailingCtorElement extends $NotifierProviderElement<FailingCtor, int> {
-  _$FailingCtorElement(super.provider, super.pointer) {
+  _$FailingCtorElement(super.pointer) {
     _$increment.result = $Result.data(_$FailingCtor$Increment(this));
   }
   final _$increment = $ElementLense<_$FailingCtor$Increment>();
@@ -1981,10 +1759,8 @@ final class _$FailingCtor$Increment
 const typedProvider = TypedProvider._();
 
 final class TypedProvider extends $NotifierProvider<Typed, String> {
-  const TypedProvider._(
-      {super.runNotifierBuildOverride, Typed Function()? create})
-      : _createCb = create,
-        super(
+  const TypedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1994,46 +1770,17 @@ final class TypedProvider extends $NotifierProvider<Typed, String> {
           allTransitiveDependencies: null,
         );
 
-  final Typed Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$typedHash();
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(String value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
   @$internal
   @override
-  Typed create() => _createCb?.call() ?? Typed();
-
-  @$internal
-  @override
-  TypedProvider $copyWithCreate(
-    Typed Function() create,
-  ) {
-    return TypedProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  TypedProvider $copyWithBuild(
-    String Function(
-      Ref,
-      Typed,
-    ) build,
-  ) {
-    return TypedProvider._(runNotifierBuildOverride: build);
-  }
+  Typed create() => Typed();
 
   @$internal
   @override
   _$TypedElement $createElement($ProviderPointer pointer) =>
-      _$TypedElement(this, pointer);
+      _$TypedElement(pointer);
 
   ProviderListenable<Typed$Mutate> get mutate =>
       $LazyProxyListenable<Typed$Mutate, String>(
@@ -2044,6 +1791,14 @@ final class TypedProvider extends $NotifierProvider<Typed, String> {
           return element._$mutate;
         },
       );
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(String value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<String>(value),
+    );
+  }
 }
 
 String _$typedHash() => r'1f53e16796771d14fcdfec41d2b9f5eb70d875a7';
@@ -2062,7 +1817,7 @@ abstract class _$Typed extends $Notifier<String> {
 }
 
 class _$TypedElement extends $NotifierProviderElement<Typed, String> {
-  _$TypedElement(super.provider, super.pointer) {
+  _$TypedElement(super.pointer) {
     _$mutate.result = $Result.data(_$Typed$Mutate(this));
   }
   final _$mutate = $ElementLense<_$Typed$Mutate>();

--- a/packages/riverpod_generator/test/integration/mutation.g.dart
+++ b/packages/riverpod_generator/test/integration/mutation.g.dart
@@ -245,14 +245,6 @@ final class AsyncTodoListProvider
           return element._$addAsync;
         },
       );
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<Todo>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
-    );
-  }
 }
 
 String _$asyncTodoListHash() => r'73d9aa3b39ad5d0c157510754bfc273a98075d30';
@@ -953,14 +945,6 @@ final class SimpleAsyncProvider
           return element._$delegated;
         },
       );
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
 }
 
 String _$simpleAsyncHash() => r'62dd0ee93e61fa27d139247b9a899630d5d3572c';
@@ -1141,14 +1125,6 @@ final class SimpleAsync2Provider
           return element._$increment;
         },
       );
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
 
   @override
   bool operator ==(Object other) {
@@ -1348,14 +1324,6 @@ final class GenericProvider<T extends num>
     return cb<T>();
   }
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
-
   @override
   bool operator ==(Object other) {
     return other is GenericProvider &&
@@ -1531,14 +1499,6 @@ final class GenericMutProvider extends $AsyncNotifierProvider<GenericMut, int> {
           return element._$increment;
         },
       );
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
 }
 
 String _$genericMutHash() => r'1f38b70cf937501fb313ae35c8bf824728bbd8ba';

--- a/packages/riverpod_generator/test/integration/offline.g.dart
+++ b/packages/riverpod_generator/test/integration/offline.g.dart
@@ -71,14 +71,6 @@ final class CustomAnnotationProvider
   $AsyncNotifierProviderElement<CustomAnnotation, String> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<String> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<String>>(value),
-    );
-  }
 }
 
 String _$customAnnotationHash() => r'abdbe1ad35942aef6e4017f7ebcbfcc7fc6bb986';
@@ -131,15 +123,6 @@ final class JsonProvider
   $AsyncNotifierProviderElement<Json, Map<String, List<int>>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<Map<String, List<int>>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride:
-          $ValueProvider<AsyncValue<Map<String, List<int>>>>(value),
-    );
-  }
 
   @override
   bool operator ==(Object other) {
@@ -257,15 +240,6 @@ final class Json2Provider
   $AsyncNotifierProviderElement<Json2, Map<String, List<int>>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<Map<String, List<int>>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride:
-          $ValueProvider<AsyncValue<Map<String, List<int>>>>(value),
-    );
-  }
 }
 
 String _$json2Hash() => r'3e263438daf3363cc46613c80645526c1f756796';
@@ -315,14 +289,6 @@ final class CustomJsonProvider
   $AsyncNotifierProviderElement<CustomJson, Map<String, Bar>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<Map<String, Bar>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<Map<String, Bar>>>(value),
-    );
-  }
 }
 
 String _$customJsonHash() => r'641edf92aae1f74ac7cc41db82c6a7dc88d24eb7';

--- a/packages/riverpod_generator/test/integration/offline.g.dart
+++ b/packages/riverpod_generator/test/integration/offline.g.dart
@@ -14,12 +14,8 @@ final class StorageProvider extends $FunctionalProvider<
     with
         $FutureModifier<Storage<String, String>>,
         $FutureProvider<Storage<String, String>> {
-  const StorageProvider._(
-      {FutureOr<Storage<String, String>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const StorageProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,10 +25,6 @@ final class StorageProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Storage<String, String>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$storageHash();
 
@@ -40,21 +32,11 @@ final class StorageProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<Storage<String, String>> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  StorageProvider $copyWithCreate(
-    FutureOr<Storage<String, String>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return StorageProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Storage<String, String>> create(Ref ref) {
-    final _$cb = _createCb ?? storage;
-    return _$cb(ref);
+    return storage(ref);
   }
 }
 
@@ -66,10 +48,8 @@ const customAnnotationProvider = CustomAnnotationProvider._();
 
 final class CustomAnnotationProvider
     extends $AsyncNotifierProvider<CustomAnnotation, String> {
-  const CustomAnnotationProvider._(
-      {super.runNotifierBuildOverride, CustomAnnotation Function()? create})
-      : _createCb = create,
-        super(
+  const CustomAnnotationProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -79,39 +59,26 @@ final class CustomAnnotationProvider
           allTransitiveDependencies: null,
         );
 
-  final CustomAnnotation Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$customAnnotationHash();
 
   @$internal
   @override
-  CustomAnnotation create() => _createCb?.call() ?? CustomAnnotation();
-
-  @$internal
-  @override
-  CustomAnnotationProvider $copyWithCreate(
-    CustomAnnotation Function() create,
-  ) {
-    return CustomAnnotationProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CustomAnnotationProvider $copyWithBuild(
-    FutureOr<String> Function(
-      Ref,
-      CustomAnnotation,
-    ) build,
-  ) {
-    return CustomAnnotationProvider._(runNotifierBuildOverride: build);
-  }
+  CustomAnnotation create() => CustomAnnotation();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<CustomAnnotation, String> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<String>>(value),
+    );
+  }
 }
 
 String _$customAnnotationHash() => r'abdbe1ad35942aef6e4017f7ebcbfcc7fc6bb986';
@@ -136,20 +103,14 @@ const jsonProvider = JsonFamily._();
 final class JsonProvider
     extends $AsyncNotifierProvider<Json, Map<String, List<int>>> {
   const JsonProvider._(
-      {required JsonFamily super.from,
-      required String super.argument,
-      super.runNotifierBuildOverride,
-      Json Function()? create})
-      : _createCb = create,
-        super(
+      {required JsonFamily super.from, required String super.argument})
+      : super(
           retry: null,
           name: r'jsonProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final Json Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$jsonHash();
@@ -163,38 +124,22 @@ final class JsonProvider
 
   @$internal
   @override
-  Json create() => _createCb?.call() ?? Json();
-
-  @$internal
-  @override
-  JsonProvider $copyWithCreate(
-    Json Function() create,
-  ) {
-    return JsonProvider._(
-        argument: argument as String,
-        from: from! as JsonFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  JsonProvider $copyWithBuild(
-    FutureOr<Map<String, List<int>>> Function(
-      Ref,
-      Json,
-    ) build,
-  ) {
-    return JsonProvider._(
-        argument: argument as String,
-        from: from! as JsonFamily,
-        runNotifierBuildOverride: build);
-  }
+  Json create() => Json();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<Json, Map<String, List<int>>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<Map<String, List<int>>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride:
+          $ValueProvider<AsyncValue<Map<String, List<int>>>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -225,50 +170,39 @@ final class JsonFamily extends Family {
       JsonProvider._(argument: arg, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$jsonHash();
-
-  @override
   String toString() => r'jsonProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Json Function(
-      String args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as JsonProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Json Function(
+            String args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as JsonProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    FutureOr<Map<String, List<int>>> Function(
-            Ref ref, Json notifier, String argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as JsonProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<Map<String, List<int>>> Function(
+                  Ref ref, Json notifier, String argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as JsonProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$JsonBase extends $AsyncNotifier<Map<String, List<int>>> {
@@ -300,10 +234,8 @@ const json2Provider = Json2Provider._();
 
 final class Json2Provider
     extends $AsyncNotifierProvider<Json2, Map<String, List<int>>> {
-  const Json2Provider._(
-      {super.runNotifierBuildOverride, Json2 Function()? create})
-      : _createCb = create,
-        super(
+  const Json2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -313,39 +245,27 @@ final class Json2Provider
           allTransitiveDependencies: null,
         );
 
-  final Json2 Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$json2Hash();
 
   @$internal
   @override
-  Json2 create() => _createCb?.call() ?? Json2();
-
-  @$internal
-  @override
-  Json2Provider $copyWithCreate(
-    Json2 Function() create,
-  ) {
-    return Json2Provider._(create: create);
-  }
-
-  @$internal
-  @override
-  Json2Provider $copyWithBuild(
-    FutureOr<Map<String, List<int>>> Function(
-      Ref,
-      Json2,
-    ) build,
-  ) {
-    return Json2Provider._(runNotifierBuildOverride: build);
-  }
+  Json2 create() => Json2();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<Json2, Map<String, List<int>>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<Map<String, List<int>>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride:
+          $ValueProvider<AsyncValue<Map<String, List<int>>>>(value),
+    );
+  }
 }
 
 String _$json2Hash() => r'3e263438daf3363cc46613c80645526c1f756796';
@@ -372,10 +292,8 @@ const customJsonProvider = CustomJsonProvider._();
 
 final class CustomJsonProvider
     extends $AsyncNotifierProvider<CustomJson, Map<String, Bar>> {
-  const CustomJsonProvider._(
-      {super.runNotifierBuildOverride, CustomJson Function()? create})
-      : _createCb = create,
-        super(
+  const CustomJsonProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -385,39 +303,26 @@ final class CustomJsonProvider
           allTransitiveDependencies: null,
         );
 
-  final CustomJson Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$customJsonHash();
 
   @$internal
   @override
-  CustomJson create() => _createCb?.call() ?? CustomJson();
-
-  @$internal
-  @override
-  CustomJsonProvider $copyWithCreate(
-    CustomJson Function() create,
-  ) {
-    return CustomJsonProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CustomJsonProvider $copyWithBuild(
-    FutureOr<Map<String, Bar>> Function(
-      Ref,
-      CustomJson,
-    ) build,
-  ) {
-    return CustomJsonProvider._(runNotifierBuildOverride: build);
-  }
+  CustomJson create() => CustomJson();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<CustomJson, Map<String, Bar>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<Map<String, Bar>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<Map<String, Bar>>>(value),
+    );
+  }
 }
 
 String _$customJsonHash() => r'641edf92aae1f74ac7cc41db82c6a7dc88d24eb7';

--- a/packages/riverpod_generator/test/integration/scopes.g.dart
+++ b/packages/riverpod_generator/test/integration/scopes.g.dart
@@ -10,10 +10,8 @@ part of 'scopes.dart';
 const scopedClassProvider = ScopedClassProvider._();
 
 final class ScopedClassProvider extends $NotifierProvider<ScopedClass, int> {
-  const ScopedClassProvider._(
-      {super.runNotifierBuildOverride, ScopedClass Function()? create})
-      : _createCb = create,
-        super(
+  const ScopedClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -23,10 +21,18 @@ final class ScopedClassProvider extends $NotifierProvider<ScopedClass, int> {
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final ScopedClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$scopedClassHash();
+
+  @$internal
+  @override
+  ScopedClass create() => ScopedClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<ScopedClass, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -35,35 +41,6 @@ final class ScopedClassProvider extends $NotifierProvider<ScopedClass, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  ScopedClass create() => _createCb?.call() ?? ScopedClass();
-
-  @$internal
-  @override
-  ScopedClassProvider $copyWithCreate(
-    ScopedClass Function() create,
-  ) {
-    return ScopedClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  ScopedClassProvider $copyWithBuild(
-    int Function(
-      Ref,
-      ScopedClass,
-    ) build,
-  ) {
-    return ScopedClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<ScopedClass, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$scopedClassHash() => r'113acc46a2e61abfeb61cf4b89a1dc555e915793';
@@ -88,19 +65,14 @@ final class ScopedClassFamilyProvider
     extends $NotifierProvider<ScopedClassFamily, int> {
   const ScopedClassFamilyProvider._(
       {required ScopedClassFamilyFamily super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      ScopedClassFamily Function()? create})
-      : _createCb = create,
-        super(
+      required int super.argument})
+      : super(
           retry: null,
           name: r'scopedClassFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final ScopedClassFamily Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$scopedClassFamilyHash();
@@ -112,6 +84,16 @@ final class ScopedClassFamilyProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  ScopedClassFamily create() => ScopedClassFamily();
+
+  @$internal
+  @override
+  $NotifierProviderElement<ScopedClassFamily, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
@@ -119,41 +101,6 @@ final class ScopedClassFamilyProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  ScopedClassFamily create() => _createCb?.call() ?? ScopedClassFamily();
-
-  @$internal
-  @override
-  ScopedClassFamilyProvider $copyWithCreate(
-    ScopedClassFamily Function() create,
-  ) {
-    return ScopedClassFamilyProvider._(
-        argument: argument as int,
-        from: from! as ScopedClassFamilyFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  ScopedClassFamilyProvider $copyWithBuild(
-    int Function(
-      Ref,
-      ScopedClassFamily,
-    ) build,
-  ) {
-    return ScopedClassFamilyProvider._(
-        argument: argument as int,
-        from: from! as ScopedClassFamilyFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<ScopedClassFamily, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -184,48 +131,38 @@ final class ScopedClassFamilyFamily extends Family {
       ScopedClassFamilyProvider._(argument: a, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$scopedClassFamilyHash();
-
-  @override
   String toString() => r'scopedClassFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    ScopedClassFamily Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ScopedClassFamilyProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          ScopedClassFamily Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ScopedClassFamilyProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function(Ref ref, ScopedClassFamily notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ScopedClassFamilyProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(Ref ref, ScopedClassFamily notifier, int argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ScopedClassFamilyProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$ScopedClassFamily extends $Notifier<int> {

--- a/packages/riverpod_generator/test/integration/split.g.dart
+++ b/packages/riverpod_generator/test/integration/split.g.dart
@@ -11,12 +11,8 @@ const counter2Provider = Counter2Provider._();
 
 final class Counter2Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const Counter2Provider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Counter2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class Counter2Provider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counter2Hash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return counter2(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class Counter2Provider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Counter2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Counter2Provider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? counter2;
-    return _$cb(ref);
   }
 }
 
@@ -69,12 +51,8 @@ const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const CounterProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -84,12 +62,18 @@ final class CounterProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return counter(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -97,26 +81,6 @@ final class CounterProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CounterProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? counter;
-    return _$cb(ref);
   }
 }
 

--- a/packages/riverpod_generator/test/integration/stream.g.dart
+++ b/packages/riverpod_generator/test/integration/stream.g.dart
@@ -12,13 +12,8 @@ const genericProvider = GenericFamily._();
 final class GenericProvider<T extends num>
     extends $FunctionalProvider<AsyncValue<List<T>>, Stream<List<T>>>
     with $FutureModifier<List<T>>, $StreamProvider<List<T>> {
-  const GenericProvider._(
-      {required GenericFamily super.from,
-      Stream<List<T>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const GenericProvider._({required GenericFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'genericProvider',
@@ -27,21 +22,8 @@ final class GenericProvider<T extends num>
           allTransitiveDependencies: null,
         );
 
-  final Stream<List<T>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericHash();
-
-  GenericProvider<T> _copyWithCreate(
-    Stream<List<T>> Function<T extends num>(
-      Ref ref,
-    ) create,
-  ) {
-    return GenericProvider<T>._(
-        from: from! as GenericFamily, create: create<T>);
-  }
 
   @override
   String toString() {
@@ -53,21 +35,15 @@ final class GenericProvider<T extends num>
   @$internal
   @override
   $StreamProviderElement<List<T>> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  GenericProvider<T> $copyWithCreate(
-    Stream<List<T>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return GenericProvider<T>._(from: from! as GenericFamily, create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<List<T>> create(Ref ref) {
-    final _$cb = _createCb ?? generic<T>;
-    return _$cb(ref);
+    return generic<T>(ref);
+  }
+
+  $R _captureGenerics<$R>($R Function<T extends num>() cb) {
+    return cb<T>();
   }
 
   @override
@@ -98,24 +74,20 @@ final class GenericFamily extends Family {
   GenericProvider<T> call<T extends num>() => GenericProvider<T>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$genericHash();
-
-  @override
   String toString() => r'genericProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Stream<List<T>> Function<T extends num>(Ref ref) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+          Stream<List<T>> Function<T extends num>(Ref ref) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericProvider<T>;
+              return provider.$view(create: create<T>).$createElement(pointer);
+            });
+          });
 }
 
 @ProviderFor(GenericClass)
@@ -123,12 +95,8 @@ const genericClassProvider = GenericClassFamily._();
 
 final class GenericClassProvider<T extends num>
     extends $StreamNotifierProvider<GenericClass<T>, List<T>> {
-  const GenericClassProvider._(
-      {required GenericClassFamily super.from,
-      super.runNotifierBuildOverride,
-      GenericClass<T> Function()? create})
-      : _createCb = create,
-        super(
+  const GenericClassProvider._({required GenericClassFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'genericClassProvider',
@@ -137,27 +105,8 @@ final class GenericClassProvider<T extends num>
           allTransitiveDependencies: null,
         );
 
-  final GenericClass<T> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericClassHash();
-
-  GenericClassProvider<T> _copyWithCreate(
-    GenericClass<T> Function<T extends num>() create,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, create: create<T>);
-  }
-
-  GenericClassProvider<T> _copyWithBuild(
-    Stream<List<T>> Function<T extends num>(
-      Ref,
-      GenericClass<T>,
-    ) build,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, runNotifierBuildOverride: build<T>);
-  }
 
   @override
   String toString() {
@@ -168,34 +117,25 @@ final class GenericClassProvider<T extends num>
 
   @$internal
   @override
-  GenericClass<T> create() => _createCb?.call() ?? GenericClass<T>();
-
-  @$internal
-  @override
-  GenericClassProvider<T> $copyWithCreate(
-    GenericClass<T> Function() create,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, create: create);
-  }
-
-  @$internal
-  @override
-  GenericClassProvider<T> $copyWithBuild(
-    Stream<List<T>> Function(
-      Ref,
-      GenericClass<T>,
-    ) build,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, runNotifierBuildOverride: build);
-  }
+  GenericClass<T> create() => GenericClass<T>();
 
   @$internal
   @override
   $StreamNotifierProviderElement<GenericClass<T>, List<T>> $createElement(
           $ProviderPointer pointer) =>
-      $StreamNotifierProviderElement(this, pointer);
+      $StreamNotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<T extends num>() cb) {
+    return cb<T>();
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<T>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<T>>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -226,39 +166,36 @@ final class GenericClassFamily extends Family {
       GenericClassProvider<T>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$genericClassHash();
-
-  @override
   String toString() => r'genericClassProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    GenericClass<T> Function<T extends num>() create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericClassProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(GenericClass<T> Function<T extends num>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericClassProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericClassProvider<T>;
+              return provider.$view(create: create<T>).$createElement(pointer);
+            });
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    Stream<List<T>> Function<T extends num>(Ref ref, GenericClass<T> notifier)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericClassProvider;
-
-        return provider._copyWithBuild(build).$createElement(pointer);
-      },
-    );
-  }
+          Stream<List<T>> Function<T extends num>(
+                  Ref ref, GenericClass<T> notifier)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericClassProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericClassProvider<T>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<T>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$GenericClass<T extends num> extends $StreamNotifier<List<T>> {
@@ -283,12 +220,8 @@ const publicProvider = PublicProvider._();
 final class PublicProvider
     extends $FunctionalProvider<AsyncValue<String>, Stream<String>>
     with $FutureModifier<String>, $StreamProvider<String> {
-  const PublicProvider._(
-      {Stream<String> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const PublicProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -298,31 +231,17 @@ final class PublicProvider
           allTransitiveDependencies: null,
         );
 
-  final Stream<String> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$publicHash();
 
   @$internal
   @override
   $StreamProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  PublicProvider $copyWithCreate(
-    Stream<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return PublicProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<String> create(Ref ref) {
-    final _$cb = _createCb ?? public;
-    return _$cb(ref);
+    return public(ref);
   }
 }
 
@@ -334,12 +253,8 @@ const _privateProvider = _PrivateProvider._();
 final class _PrivateProvider
     extends $FunctionalProvider<AsyncValue<String>, Stream<String>>
     with $FutureModifier<String>, $StreamProvider<String> {
-  const _PrivateProvider._(
-      {Stream<String> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const _PrivateProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -349,31 +264,17 @@ final class _PrivateProvider
           allTransitiveDependencies: null,
         );
 
-  final Stream<String> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$privateHash();
 
   @$internal
   @override
   $StreamProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  _PrivateProvider $copyWithCreate(
-    Stream<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return _PrivateProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<String> create(Ref ref) {
-    final _$cb = _createCb ?? _private;
-    return _$cb(ref);
+    return _private(ref);
   }
 }
 
@@ -394,32 +295,14 @@ final class FamilyProvider
         bool fourth,
         List<String>? fifth,
       })
-          super.argument,
-      Stream<String> Function(
-        Ref ref,
-        int first, {
-        String? second,
-        required double third,
-        bool fourth,
-        List<String>? fifth,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'familyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final Stream<String> Function(
-    Ref ref,
-    int first, {
-    String? second,
-    required double third,
-    bool fourth,
-    List<String>? fifth,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyHash();
@@ -434,37 +317,10 @@ final class FamilyProvider
   @$internal
   @override
   $StreamProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  FamilyProvider $copyWithCreate(
-    Stream<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyFamily,
-        create: (
-          ref,
-          int first, {
-          String? second,
-          required double third,
-          bool fourth = true,
-          List<String>? fifth,
-        }) =>
-            create(ref));
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<String> create(Ref ref) {
-    final _$cb = _createCb ?? family;
     final argument = this.argument as (
       int, {
       String? second,
@@ -472,7 +328,7 @@ final class FamilyProvider
       bool fourth,
       List<String>? fifth,
     });
-    return _$cb(
+    return family(
       ref,
       argument.$1,
       second: argument.second,
@@ -521,43 +377,35 @@ final class FamilyFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyHash();
-
-  @override
   String toString() => r'familyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Stream<String> Function(
-      Ref ref,
-      (
-        int, {
-        String? second,
-        double third,
-        bool fourth,
-        List<String>? fifth,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyProvider;
-
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Stream<String> Function(
+            Ref ref,
+            (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(PublicClass)
@@ -565,10 +413,8 @@ const publicClassProvider = PublicClassProvider._();
 
 final class PublicClassProvider
     extends $StreamNotifierProvider<PublicClass, String> {
-  const PublicClassProvider._(
-      {super.runNotifierBuildOverride, PublicClass Function()? create})
-      : _createCb = create,
-        super(
+  const PublicClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -578,39 +424,26 @@ final class PublicClassProvider
           allTransitiveDependencies: null,
         );
 
-  final PublicClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$publicClassHash();
 
   @$internal
   @override
-  PublicClass create() => _createCb?.call() ?? PublicClass();
-
-  @$internal
-  @override
-  PublicClassProvider $copyWithCreate(
-    PublicClass Function() create,
-  ) {
-    return PublicClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  PublicClassProvider $copyWithBuild(
-    Stream<String> Function(
-      Ref,
-      PublicClass,
-    ) build,
-  ) {
-    return PublicClassProvider._(runNotifierBuildOverride: build);
-  }
+  PublicClass create() => PublicClass();
 
   @$internal
   @override
   $StreamNotifierProviderElement<PublicClass, String> $createElement(
           $ProviderPointer pointer) =>
-      $StreamNotifierProviderElement(this, pointer);
+      $StreamNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<String>>(value),
+    );
+  }
 }
 
 String _$publicClassHash() => r'b1526943c8ff0aaa20642bf78e744e5833cf9d02';
@@ -633,10 +466,8 @@ const _privateClassProvider = _PrivateClassProvider._();
 
 final class _PrivateClassProvider
     extends $StreamNotifierProvider<_PrivateClass, String> {
-  const _PrivateClassProvider._(
-      {super.runNotifierBuildOverride, _PrivateClass Function()? create})
-      : _createCb = create,
-        super(
+  const _PrivateClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -646,39 +477,26 @@ final class _PrivateClassProvider
           allTransitiveDependencies: null,
         );
 
-  final _PrivateClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$privateClassHash();
 
   @$internal
   @override
-  _PrivateClass create() => _createCb?.call() ?? _PrivateClass();
-
-  @$internal
-  @override
-  _PrivateClassProvider $copyWithCreate(
-    _PrivateClass Function() create,
-  ) {
-    return _PrivateClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  _PrivateClassProvider $copyWithBuild(
-    Stream<String> Function(
-      Ref,
-      _PrivateClass,
-    ) build,
-  ) {
-    return _PrivateClassProvider._(runNotifierBuildOverride: build);
-  }
+  _PrivateClass create() => _PrivateClass();
 
   @$internal
   @override
   $StreamNotifierProviderElement<_PrivateClass, String> $createElement(
           $ProviderPointer pointer) =>
-      $StreamNotifierProviderElement(this, pointer);
+      $StreamNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<String>>(value),
+    );
+  }
 }
 
 String _$privateClassHash() => r'8c0d52b7ab79c0546d0c84c011bb3512609e029e';
@@ -710,19 +528,14 @@ final class FamilyClassProvider
         bool fourth,
         List<String>? fifth,
       })
-          super.argument,
-      super.runNotifierBuildOverride,
-      FamilyClass Function()? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'familyClassProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FamilyClass Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyClassHash();
@@ -736,50 +549,21 @@ final class FamilyClassProvider
 
   @$internal
   @override
-  FamilyClass create() => _createCb?.call() ?? FamilyClass();
-
-  @$internal
-  @override
-  FamilyClassProvider $copyWithCreate(
-    FamilyClass Function() create,
-  ) {
-    return FamilyClassProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyClassFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  FamilyClassProvider $copyWithBuild(
-    Stream<String> Function(
-      Ref,
-      FamilyClass,
-    ) build,
-  ) {
-    return FamilyClassProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyClassFamily,
-        runNotifierBuildOverride: build);
-  }
+  FamilyClass create() => FamilyClass();
 
   @$internal
   @override
   $StreamNotifierProviderElement<FamilyClass, String> $createElement(
           $ProviderPointer pointer) =>
-      $StreamNotifierProviderElement(this, pointer);
+      $StreamNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<String>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -820,76 +604,65 @@ final class FamilyClassFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyClassHash();
-
-  @override
   String toString() => r'familyClassProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FamilyClass Function(
-      (
-        int, {
-        String? second,
-        double third,
-        bool fourth,
-        List<String>? fifth,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyClassProvider;
-
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-    Stream<String> Function(
-            Ref ref,
-            FamilyClass notifier,
+          FamilyClass Function(
             (
               int, {
               String? second,
               double third,
               bool fourth,
               List<String>? fifth,
-            }) argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyClassProvider;
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyClassProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+  /// {@macro riverpod.override_with_build}
+  Override overrideWithBuild(
+          Stream<String> Function(
+                  Ref ref,
+                  FamilyClass notifier,
+                  (
+                    int, {
+                    String? second,
+                    double third,
+                    bool fourth,
+                    List<String>? fifth,
+                  }) argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyClassProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$FamilyClass extends $StreamNotifier<String> {

--- a/packages/riverpod_generator/test/integration/stream.g.dart
+++ b/packages/riverpod_generator/test/integration/stream.g.dart
@@ -129,14 +129,6 @@ final class GenericClassProvider<T extends num>
     return cb<T>();
   }
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<T>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<T>>>(value),
-    );
-  }
-
   @override
   bool operator ==(Object other) {
     return other is GenericClassProvider &&
@@ -436,14 +428,6 @@ final class PublicClassProvider
   $StreamNotifierProviderElement<PublicClass, String> $createElement(
           $ProviderPointer pointer) =>
       $StreamNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<String> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<String>>(value),
-    );
-  }
 }
 
 String _$publicClassHash() => r'b1526943c8ff0aaa20642bf78e744e5833cf9d02';
@@ -489,14 +473,6 @@ final class _PrivateClassProvider
   $StreamNotifierProviderElement<_PrivateClass, String> $createElement(
           $ProviderPointer pointer) =>
       $StreamNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<String> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<String>>(value),
-    );
-  }
 }
 
 String _$privateClassHash() => r'8c0d52b7ab79c0546d0c84c011bb3512609e029e';
@@ -556,14 +532,6 @@ final class FamilyClassProvider
   $StreamNotifierProviderElement<FamilyClass, String> $createElement(
           $ProviderPointer pointer) =>
       $StreamNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<String> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<String>>(value),
-    );
-  }
 
   @override
   bool operator ==(Object other) {

--- a/packages/riverpod_generator/test/integration/sync.g.dart
+++ b/packages/riverpod_generator/test/integration/sync.g.dart
@@ -11,13 +11,8 @@ const genericProvider = GenericFamily._();
 
 final class GenericProvider<T extends num>
     extends $FunctionalProvider<List<T>, List<T>> with $Provider<List<T>> {
-  const GenericProvider._(
-      {required GenericFamily super.from,
-      List<T> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const GenericProvider._({required GenericFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'genericProvider',
@@ -26,21 +21,8 @@ final class GenericProvider<T extends num>
           allTransitiveDependencies: null,
         );
 
-  final List<T> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericHash();
-
-  GenericProvider<T> _copyWithCreate(
-    List<T> Function<T extends num>(
-      Ref ref,
-    ) create,
-  ) {
-    return GenericProvider<T>._(
-        from: from! as GenericFamily, create: create<T>);
-  }
 
   @override
   String toString() {
@@ -49,32 +31,26 @@ final class GenericProvider<T extends num>
         '()';
   }
 
+  @$internal
+  @override
+  $ProviderElement<List<T>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<T> create(Ref ref) {
+    return generic<T>(ref);
+  }
+
+  $R _captureGenerics<$R>($R Function<T extends num>() cb) {
+    return cb<T>();
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<T> value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<List<T>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<List<T>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  GenericProvider<T> $copyWithCreate(
-    List<T> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return GenericProvider<T>._(from: from! as GenericFamily, create: create);
-  }
-
-  @override
-  List<T> create(Ref ref) {
-    final _$cb = _createCb ?? generic<T>;
-    return _$cb(ref);
   }
 
   @override
@@ -105,24 +81,19 @@ final class GenericFamily extends Family {
   GenericProvider<T> call<T extends num>() => GenericProvider<T>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$genericHash();
-
-  @override
   String toString() => r'genericProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    List<T> Function<T extends num>(Ref ref) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(List<T> Function<T extends num>(Ref ref) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericProvider<T>;
+              return provider.$view(create: create<T>).$createElement(pointer);
+            });
+          });
 }
 
 @ProviderFor(complexGeneric)
@@ -136,14 +107,8 @@ final class ComplexGenericProvider<T extends num, Foo extends String?>
         T param,
         Foo? otherParam,
       })
-          super.argument,
-      List<T> Function(
-        Ref ref, {
-        required T param,
-        Foo? otherParam,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'complexGenericProvider',
           isAutoDispose: true,
@@ -151,30 +116,8 @@ final class ComplexGenericProvider<T extends num, Foo extends String?>
           allTransitiveDependencies: null,
         );
 
-  final List<T> Function(
-    Ref ref, {
-    required T param,
-    Foo? otherParam,
-  })? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$complexGenericHash();
-
-  ComplexGenericProvider<T, Foo> _copyWithCreate(
-    List<T> Function<T extends num, Foo extends String?>(
-      Ref ref, {
-      required T param,
-      Foo? otherParam,
-    }) create,
-  ) {
-    return ComplexGenericProvider<T, Foo>._(
-        argument: argument as ({
-          T param,
-          Foo? otherParam,
-        }),
-        from: from! as ComplexGenericFamily,
-        create: create<T, Foo>);
-  }
 
   @override
   String toString() {
@@ -183,50 +126,34 @@ final class ComplexGenericProvider<T extends num, Foo extends String?>
         '$argument';
   }
 
+  @$internal
+  @override
+  $ProviderElement<List<T>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<T> create(Ref ref) {
+    final argument = this.argument as ({
+      T param,
+      Foo? otherParam,
+    });
+    return complexGeneric<T, Foo>(
+      ref,
+      param: argument.param,
+      otherParam: argument.otherParam,
+    );
+  }
+
+  $R _captureGenerics<$R>(
+      $R Function<T extends num, Foo extends String?>() cb) {
+    return cb<T, Foo>();
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<T> value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<List<T>>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<List<T>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ComplexGenericProvider<T, Foo> $copyWithCreate(
-    List<T> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ComplexGenericProvider<T, Foo>._(
-        argument: argument as ({
-          T param,
-          Foo? otherParam,
-        }),
-        from: from! as ComplexGenericFamily,
-        create: (
-          ref, {
-          required T param,
-          Foo? otherParam,
-        }) =>
-            create(ref));
-  }
-
-  @override
-  List<T> create(Ref ref) {
-    final _$cb = _createCb ?? complexGeneric<T, Foo>;
-    final argument = this.argument as ({
-      T param,
-      Foo? otherParam,
-    });
-    return _$cb(
-      ref,
-      param: argument.param,
-      otherParam: argument.otherParam,
     );
   }
 
@@ -265,39 +192,33 @@ final class ComplexGenericFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$complexGenericHash();
-
-  @override
   String toString() => r'complexGenericProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    List<T> Function<T extends num, Foo extends String?>(
-      Ref ref,
-      ({
-        T param,
-        Foo? otherParam,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ComplexGenericProvider;
-
-        return provider._copyWithCreate(<T extends num, Foo extends String?>(
-          ref, {
-          required T param,
-          Foo? otherParam,
-        }) {
-          return create(ref, (
-            param: param,
-            otherParam: otherParam,
-          ));
-        }).$createElement(pointer);
-      },
-    );
-  }
+          List<T> Function<T extends num, Foo extends String?>(
+            Ref ref,
+            ({
+              T param,
+              Foo? otherParam,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ComplexGenericProvider;
+            return provider
+                ._captureGenerics(<T extends num, Foo extends String?>() {
+              provider as ComplexGenericProvider<T, Foo>;
+              final argument = provider.argument as ({
+                T param,
+                Foo? otherParam,
+              });
+              return provider
+                  .$view(create: (ref) => create(ref, argument))
+                  .$createElement(pointer);
+            });
+          });
 }
 
 @ProviderFor(GenericClass)
@@ -305,12 +226,8 @@ const genericClassProvider = GenericClassFamily._();
 
 final class GenericClassProvider<T extends num>
     extends $NotifierProvider<GenericClass<T>, List<T>> {
-  const GenericClassProvider._(
-      {required GenericClassFamily super.from,
-      super.runNotifierBuildOverride,
-      GenericClass<T> Function()? create})
-      : _createCb = create,
-        super(
+  const GenericClassProvider._({required GenericClassFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'genericClassProvider',
@@ -319,33 +236,28 @@ final class GenericClassProvider<T extends num>
           allTransitiveDependencies: null,
         );
 
-  final GenericClass<T> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericClassHash();
-
-  GenericClassProvider<T> _copyWithCreate(
-    GenericClass<T> Function<T extends num>() create,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, create: create<T>);
-  }
-
-  GenericClassProvider<T> _copyWithBuild(
-    List<T> Function<T extends num>(
-      Ref,
-      GenericClass<T>,
-    ) build,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, runNotifierBuildOverride: build<T>);
-  }
 
   @override
   String toString() {
     return r'genericClassProvider'
         '<${T}>'
         '()';
+  }
+
+  @$internal
+  @override
+  GenericClass<T> create() => GenericClass<T>();
+
+  @$internal
+  @override
+  $NotifierProviderElement<GenericClass<T>, List<T>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<T extends num>() cb) {
+    return cb<T>();
   }
 
   /// {@macro riverpod.override_with_value}
@@ -355,37 +267,6 @@ final class GenericClassProvider<T extends num>
       providerOverride: $ValueProvider<List<T>>(value),
     );
   }
-
-  @$internal
-  @override
-  GenericClass<T> create() => _createCb?.call() ?? GenericClass<T>();
-
-  @$internal
-  @override
-  GenericClassProvider<T> $copyWithCreate(
-    GenericClass<T> Function() create,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, create: create);
-  }
-
-  @$internal
-  @override
-  GenericClassProvider<T> $copyWithBuild(
-    List<T> Function(
-      Ref,
-      GenericClass<T>,
-    ) build,
-  ) {
-    return GenericClassProvider<T>._(
-        from: from! as GenericClassFamily, runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<GenericClass<T>, List<T>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -416,38 +297,35 @@ final class GenericClassFamily extends Family {
       GenericClassProvider<T>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$genericClassHash();
-
-  @override
   String toString() => r'genericClassProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    GenericClass<T> Function<T extends num>() create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericClassProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(GenericClass<T> Function<T extends num>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericClassProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericClassProvider<T>;
+              return provider.$view(create: create<T>).$createElement(pointer);
+            });
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    List<T> Function<T extends num>(Ref ref, GenericClass<T> notifier) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericClassProvider;
-
-        return provider._copyWithBuild(build).$createElement(pointer);
-      },
-    );
-  }
+          List<T> Function<T extends num>(Ref ref, GenericClass<T> notifier)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericClassProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericClassProvider<T>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<T>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$GenericClass<T extends num> extends $Notifier<List<T>> {
@@ -469,12 +347,8 @@ const rawFutureProvider = RawFutureProvider._();
 final class RawFutureProvider
     extends $FunctionalProvider<Raw<Future<String>>, Raw<Future<String>>>
     with $Provider<Raw<Future<String>>> {
-  const RawFutureProvider._(
-      {Raw<Future<String>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RawFutureProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -484,12 +358,19 @@ final class RawFutureProvider
           allTransitiveDependencies: null,
         );
 
-  final Raw<Future<String>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rawFutureHash();
+
+  @$internal
+  @override
+  $ProviderElement<Raw<Future<String>>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<Future<String>> create(Ref ref) {
+    return rawFuture(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Future<String>> value) {
@@ -497,27 +378,6 @@ final class RawFutureProvider
       origin: this,
       providerOverride: $ValueProvider<Raw<Future<String>>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<Future<String>>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RawFutureProvider $copyWithCreate(
-    Raw<Future<String>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RawFutureProvider._(create: create);
-  }
-
-  @override
-  Raw<Future<String>> create(Ref ref) {
-    final _$cb = _createCb ?? rawFuture;
-    return _$cb(ref);
   }
 }
 
@@ -529,12 +389,8 @@ const rawStreamProvider = RawStreamProvider._();
 final class RawStreamProvider
     extends $FunctionalProvider<Raw<Stream<String>>, Raw<Stream<String>>>
     with $Provider<Raw<Stream<String>>> {
-  const RawStreamProvider._(
-      {Raw<Stream<String>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RawStreamProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -544,12 +400,19 @@ final class RawStreamProvider
           allTransitiveDependencies: null,
         );
 
-  final Raw<Stream<String>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rawStreamHash();
+
+  @$internal
+  @override
+  $ProviderElement<Raw<Stream<String>>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<Stream<String>> create(Ref ref) {
+    return rawStream(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Stream<String>> value) {
@@ -557,27 +420,6 @@ final class RawStreamProvider
       origin: this,
       providerOverride: $ValueProvider<Raw<Stream<String>>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<Stream<String>>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RawStreamProvider $copyWithCreate(
-    Raw<Stream<String>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RawStreamProvider._(create: create);
-  }
-
-  @override
-  Raw<Stream<String>> create(Ref ref) {
-    final _$cb = _createCb ?? rawStream;
-    return _$cb(ref);
   }
 }
 
@@ -588,10 +430,8 @@ const rawFutureClassProvider = RawFutureClassProvider._();
 
 final class RawFutureClassProvider
     extends $NotifierProvider<RawFutureClass, Raw<Future<String>>> {
-  const RawFutureClassProvider._(
-      {super.runNotifierBuildOverride, RawFutureClass Function()? create})
-      : _createCb = create,
-        super(
+  const RawFutureClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -601,10 +441,18 @@ final class RawFutureClassProvider
           allTransitiveDependencies: null,
         );
 
-  final RawFutureClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rawFutureClassHash();
+
+  @$internal
+  @override
+  RawFutureClass create() => RawFutureClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<RawFutureClass, Raw<Future<String>>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Future<String>> value) {
@@ -613,35 +461,6 @@ final class RawFutureClassProvider
       providerOverride: $ValueProvider<Raw<Future<String>>>(value),
     );
   }
-
-  @$internal
-  @override
-  RawFutureClass create() => _createCb?.call() ?? RawFutureClass();
-
-  @$internal
-  @override
-  RawFutureClassProvider $copyWithCreate(
-    RawFutureClass Function() create,
-  ) {
-    return RawFutureClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  RawFutureClassProvider $copyWithBuild(
-    Raw<Future<String>> Function(
-      Ref,
-      RawFutureClass,
-    ) build,
-  ) {
-    return RawFutureClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<RawFutureClass, Raw<Future<String>>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$rawFutureClassHash() => r'bf66f1cdbd99118b8845d206e6a2611b3101f45c';
@@ -667,10 +486,8 @@ const rawStreamClassProvider = RawStreamClassProvider._();
 
 final class RawStreamClassProvider
     extends $NotifierProvider<RawStreamClass, Raw<Stream<String>>> {
-  const RawStreamClassProvider._(
-      {super.runNotifierBuildOverride, RawStreamClass Function()? create})
-      : _createCb = create,
-        super(
+  const RawStreamClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -680,10 +497,18 @@ final class RawStreamClassProvider
           allTransitiveDependencies: null,
         );
 
-  final RawStreamClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rawStreamClassHash();
+
+  @$internal
+  @override
+  RawStreamClass create() => RawStreamClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<RawStreamClass, Raw<Stream<String>>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Stream<String>> value) {
@@ -692,35 +517,6 @@ final class RawStreamClassProvider
       providerOverride: $ValueProvider<Raw<Stream<String>>>(value),
     );
   }
-
-  @$internal
-  @override
-  RawStreamClass create() => _createCb?.call() ?? RawStreamClass();
-
-  @$internal
-  @override
-  RawStreamClassProvider $copyWithCreate(
-    RawStreamClass Function() create,
-  ) {
-    return RawStreamClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  RawStreamClassProvider $copyWithBuild(
-    Raw<Stream<String>> Function(
-      Ref,
-      RawStreamClass,
-    ) build,
-  ) {
-    return RawStreamClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<RawStreamClass, Raw<Stream<String>>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$rawStreamClassHash() => r'712cffcb2018cfb4ff45012c1aa6e43c8cbe9d5d';
@@ -748,25 +544,14 @@ final class RawFamilyFutureProvider
     extends $FunctionalProvider<Raw<Future<String>>, Raw<Future<String>>>
     with $Provider<Raw<Future<String>>> {
   const RawFamilyFutureProvider._(
-      {required RawFamilyFutureFamily super.from,
-      required int super.argument,
-      Raw<Future<String>> Function(
-        Ref ref,
-        int id,
-      )? create})
-      : _createCb = create,
-        super(
+      {required RawFamilyFutureFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'rawFamilyFutureProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final Raw<Future<String>> Function(
-    Ref ref,
-    int id,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$rawFamilyFutureHash();
@@ -778,43 +563,26 @@ final class RawFamilyFutureProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<Raw<Future<String>>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<Future<String>> create(Ref ref) {
+    final argument = this.argument as int;
+    return rawFamilyFuture(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Future<String>> value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<Raw<Future<String>>>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<Future<String>>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RawFamilyFutureProvider $copyWithCreate(
-    Raw<Future<String>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RawFamilyFutureProvider._(
-        argument: argument as int,
-        from: from! as RawFamilyFutureFamily,
-        create: (
-          ref,
-          int id,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  Raw<Future<String>> create(Ref ref) {
-    final _$cb = _createCb ?? rawFamilyFuture;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -847,31 +615,23 @@ final class RawFamilyFutureFamily extends Family {
       RawFamilyFutureProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$rawFamilyFutureHash();
-
-  @override
   String toString() => r'rawFamilyFutureProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Raw<Future<String>> Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as RawFamilyFutureProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Raw<Future<String>> Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as RawFamilyFutureProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(rawFamilyStream)
@@ -881,25 +641,14 @@ final class RawFamilyStreamProvider
     extends $FunctionalProvider<Raw<Stream<String>>, Raw<Stream<String>>>
     with $Provider<Raw<Stream<String>>> {
   const RawFamilyStreamProvider._(
-      {required RawFamilyStreamFamily super.from,
-      required int super.argument,
-      Raw<Stream<String>> Function(
-        Ref ref,
-        int id,
-      )? create})
-      : _createCb = create,
-        super(
+      {required RawFamilyStreamFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'rawFamilyStreamProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final Raw<Stream<String>> Function(
-    Ref ref,
-    int id,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$rawFamilyStreamHash();
@@ -911,43 +660,26 @@ final class RawFamilyStreamProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<Raw<Stream<String>>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<Stream<String>> create(Ref ref) {
+    final argument = this.argument as int;
+    return rawFamilyStream(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Stream<String>> value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<Raw<Stream<String>>>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<Stream<String>>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RawFamilyStreamProvider $copyWithCreate(
-    Raw<Stream<String>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RawFamilyStreamProvider._(
-        argument: argument as int,
-        from: from! as RawFamilyStreamFamily,
-        create: (
-          ref,
-          int id,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  Raw<Stream<String>> create(Ref ref) {
-    final _$cb = _createCb ?? rawFamilyStream;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -980,31 +712,23 @@ final class RawFamilyStreamFamily extends Family {
       RawFamilyStreamProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$rawFamilyStreamHash();
-
-  @override
   String toString() => r'rawFamilyStreamProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Raw<Stream<String>> Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as RawFamilyStreamProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Raw<Stream<String>> Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as RawFamilyStreamProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(RawFamilyFutureClass)
@@ -1014,19 +738,14 @@ final class RawFamilyFutureClassProvider
     extends $NotifierProvider<RawFamilyFutureClass, Raw<Future<String>>> {
   const RawFamilyFutureClassProvider._(
       {required RawFamilyFutureClassFamily super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      RawFamilyFutureClass Function()? create})
-      : _createCb = create,
-        super(
+      required int super.argument})
+      : super(
           retry: null,
           name: r'rawFamilyFutureClassProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final RawFamilyFutureClass Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$rawFamilyFutureClassHash();
@@ -1038,6 +757,16 @@ final class RawFamilyFutureClassProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  RawFamilyFutureClass create() => RawFamilyFutureClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<RawFamilyFutureClass, Raw<Future<String>>>
+      $createElement($ProviderPointer pointer) =>
+          $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Future<String>> value) {
     return $ProviderOverride(
@@ -1045,41 +774,6 @@ final class RawFamilyFutureClassProvider
       providerOverride: $ValueProvider<Raw<Future<String>>>(value),
     );
   }
-
-  @$internal
-  @override
-  RawFamilyFutureClass create() => _createCb?.call() ?? RawFamilyFutureClass();
-
-  @$internal
-  @override
-  RawFamilyFutureClassProvider $copyWithCreate(
-    RawFamilyFutureClass Function() create,
-  ) {
-    return RawFamilyFutureClassProvider._(
-        argument: argument as int,
-        from: from! as RawFamilyFutureClassFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  RawFamilyFutureClassProvider $copyWithBuild(
-    Raw<Future<String>> Function(
-      Ref,
-      RawFamilyFutureClass,
-    ) build,
-  ) {
-    return RawFamilyFutureClassProvider._(
-        argument: argument as int,
-        from: from! as RawFamilyFutureClassFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<RawFamilyFutureClass, Raw<Future<String>>>
-      $createElement($ProviderPointer pointer) =>
-          $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -1111,50 +805,39 @@ final class RawFamilyFutureClassFamily extends Family {
       RawFamilyFutureClassProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$rawFamilyFutureClassHash();
-
-  @override
   String toString() => r'rawFamilyFutureClassProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    RawFamilyFutureClass Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as RawFamilyFutureClassProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          RawFamilyFutureClass Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as RawFamilyFutureClassProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    Raw<Future<String>> Function(
-            Ref ref, RawFamilyFutureClass notifier, int argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as RawFamilyFutureClassProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Raw<Future<String>> Function(
+                  Ref ref, RawFamilyFutureClass notifier, int argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as RawFamilyFutureClassProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$RawFamilyFutureClass extends $Notifier<Raw<Future<String>>> {
@@ -1187,19 +870,14 @@ final class RawFamilyStreamClassProvider
     extends $NotifierProvider<RawFamilyStreamClass, Raw<Stream<String>>> {
   const RawFamilyStreamClassProvider._(
       {required RawFamilyStreamClassFamily super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      RawFamilyStreamClass Function()? create})
-      : _createCb = create,
-        super(
+      required int super.argument})
+      : super(
           retry: null,
           name: r'rawFamilyStreamClassProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final RawFamilyStreamClass Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$rawFamilyStreamClassHash();
@@ -1211,6 +889,16 @@ final class RawFamilyStreamClassProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  RawFamilyStreamClass create() => RawFamilyStreamClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<RawFamilyStreamClass, Raw<Stream<String>>>
+      $createElement($ProviderPointer pointer) =>
+          $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Stream<String>> value) {
     return $ProviderOverride(
@@ -1218,41 +906,6 @@ final class RawFamilyStreamClassProvider
       providerOverride: $ValueProvider<Raw<Stream<String>>>(value),
     );
   }
-
-  @$internal
-  @override
-  RawFamilyStreamClass create() => _createCb?.call() ?? RawFamilyStreamClass();
-
-  @$internal
-  @override
-  RawFamilyStreamClassProvider $copyWithCreate(
-    RawFamilyStreamClass Function() create,
-  ) {
-    return RawFamilyStreamClassProvider._(
-        argument: argument as int,
-        from: from! as RawFamilyStreamClassFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  RawFamilyStreamClassProvider $copyWithBuild(
-    Raw<Stream<String>> Function(
-      Ref,
-      RawFamilyStreamClass,
-    ) build,
-  ) {
-    return RawFamilyStreamClassProvider._(
-        argument: argument as int,
-        from: from! as RawFamilyStreamClassFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<RawFamilyStreamClass, Raw<Stream<String>>>
-      $createElement($ProviderPointer pointer) =>
-          $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -1284,50 +937,39 @@ final class RawFamilyStreamClassFamily extends Family {
       RawFamilyStreamClassProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$rawFamilyStreamClassHash();
-
-  @override
   String toString() => r'rawFamilyStreamClassProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    RawFamilyStreamClass Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as RawFamilyStreamClassProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          RawFamilyStreamClass Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as RawFamilyStreamClassProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    Raw<Stream<String>> Function(
-            Ref ref, RawFamilyStreamClass notifier, int argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as RawFamilyStreamClassProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Raw<Stream<String>> Function(
+                  Ref ref, RawFamilyStreamClass notifier, int argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as RawFamilyStreamClassProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$RawFamilyStreamClass extends $Notifier<Raw<Stream<String>>> {
@@ -1361,12 +1003,8 @@ const publicProvider = PublicProvider._();
 final class PublicProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
   /// This is some documentation
-  const PublicProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const PublicProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1376,12 +1014,18 @@ final class PublicProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$publicHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return public(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -1389,26 +1033,6 @@ final class PublicProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  PublicProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return PublicProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? public;
-    return _$cb(ref);
   }
 }
 
@@ -1419,12 +1043,8 @@ const supports$inNamesProvider = Supports$inNamesProvider._();
 
 final class Supports$inNamesProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const Supports$inNamesProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Supports$inNamesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1434,12 +1054,18 @@ final class Supports$inNamesProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$supports$inNamesHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return supports$inNames(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -1447,26 +1073,6 @@ final class Supports$inNamesProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Supports$inNamesProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Supports$inNamesProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? supports$inNames;
-    return _$cb(ref);
   }
 }
 
@@ -1489,32 +1095,14 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
         bool fourth,
         List<String>? fifth,
       })
-          super.argument,
-      String Function(
-        Ref ref,
-        int first, {
-        String? second,
-        required double third,
-        bool fourth,
-        List<String>? fifth,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'familyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    int first, {
-    String? second,
-    required double third,
-    bool fourth,
-    List<String>? fifth,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyHash();
@@ -1526,48 +1114,13 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
         '$argument';
   }
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(String value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
   @$internal
   @override
   $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FamilyProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyFamily,
-        create: (
-          ref,
-          int first, {
-          String? second,
-          required double third,
-          bool fourth = true,
-          List<String>? fifth,
-        }) =>
-            create(ref));
-  }
+      $ProviderElement(pointer);
 
   @override
   String create(Ref ref) {
-    final _$cb = _createCb ?? family;
     final argument = this.argument as (
       int, {
       String? second,
@@ -1575,13 +1128,21 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
       bool fourth,
       List<String>? fifth,
     });
-    return _$cb(
+    return family(
       ref,
       argument.$1,
       second: argument.second,
       third: argument.third,
       fourth: argument.fourth,
       fifth: argument.fifth,
+    );
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(String value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<String>(value),
     );
   }
 
@@ -1626,43 +1187,35 @@ final class FamilyFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyHash();
-
-  @override
   String toString() => r'familyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      (
-        int, {
-        String? second,
-        double third,
-        bool fourth,
-        List<String>? fifth,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyProvider;
-
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(_private)
@@ -1670,12 +1223,8 @@ const _privateProvider = _PrivateProvider._();
 
 final class _PrivateProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const _PrivateProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const _PrivateProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1685,12 +1234,18 @@ final class _PrivateProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$privateHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return _private(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -1698,26 +1253,6 @@ final class _PrivateProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  _PrivateProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return _PrivateProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? _private;
-    return _$cb(ref);
   }
 }
 
@@ -1730,10 +1265,8 @@ const publicClassProvider = PublicClassProvider._();
 /// This is some documentation
 final class PublicClassProvider extends $NotifierProvider<PublicClass, String> {
   /// This is some documentation
-  const PublicClassProvider._(
-      {super.runNotifierBuildOverride, PublicClass Function()? create})
-      : _createCb = create,
-        super(
+  const PublicClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1743,10 +1276,18 @@ final class PublicClassProvider extends $NotifierProvider<PublicClass, String> {
           allTransitiveDependencies: null,
         );
 
-  final PublicClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$publicClassHash();
+
+  @$internal
+  @override
+  PublicClass create() => PublicClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<PublicClass, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -1755,35 +1296,6 @@ final class PublicClassProvider extends $NotifierProvider<PublicClass, String> {
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  PublicClass create() => _createCb?.call() ?? PublicClass();
-
-  @$internal
-  @override
-  PublicClassProvider $copyWithCreate(
-    PublicClass Function() create,
-  ) {
-    return PublicClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  PublicClassProvider $copyWithBuild(
-    String Function(
-      Ref,
-      PublicClass,
-    ) build,
-  ) {
-    return PublicClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<PublicClass, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$publicClassHash() => r'92fd83ba5c01942344a9fa94e170629da3588946';
@@ -1806,10 +1318,8 @@ const _privateClassProvider = _PrivateClassProvider._();
 
 final class _PrivateClassProvider
     extends $NotifierProvider<_PrivateClass, String> {
-  const _PrivateClassProvider._(
-      {super.runNotifierBuildOverride, _PrivateClass Function()? create})
-      : _createCb = create,
-        super(
+  const _PrivateClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1819,10 +1329,18 @@ final class _PrivateClassProvider
           allTransitiveDependencies: null,
         );
 
-  final _PrivateClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$privateClassHash();
+
+  @$internal
+  @override
+  _PrivateClass create() => _PrivateClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<_PrivateClass, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -1831,35 +1349,6 @@ final class _PrivateClassProvider
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  _PrivateClass create() => _createCb?.call() ?? _PrivateClass();
-
-  @$internal
-  @override
-  _PrivateClassProvider $copyWithCreate(
-    _PrivateClass Function() create,
-  ) {
-    return _PrivateClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  _PrivateClassProvider $copyWithBuild(
-    String Function(
-      Ref,
-      _PrivateClass,
-    ) build,
-  ) {
-    return _PrivateClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<_PrivateClass, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$privateClassHash() => r'be63bcdd570d32ecebb62262f4f04215ea0b3ab2';
@@ -1893,19 +1382,14 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
         bool fourth,
         List<String>? fifth,
       })
-          super.argument,
-      super.runNotifierBuildOverride,
-      FamilyClass Function()? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'familyClassProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FamilyClass Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyClassHash();
@@ -1917,6 +1401,16 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
         '$argument';
   }
 
+  @$internal
+  @override
+  FamilyClass create() => FamilyClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<FamilyClass, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
@@ -1924,53 +1418,6 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  FamilyClass create() => _createCb?.call() ?? FamilyClass();
-
-  @$internal
-  @override
-  FamilyClassProvider $copyWithCreate(
-    FamilyClass Function() create,
-  ) {
-    return FamilyClassProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyClassFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  FamilyClassProvider $copyWithBuild(
-    String Function(
-      Ref,
-      FamilyClass,
-    ) build,
-  ) {
-    return FamilyClassProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyClassFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<FamilyClass, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -2013,76 +1460,65 @@ final class FamilyClassFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyClassHash();
-
-  @override
   String toString() => r'familyClassProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FamilyClass Function(
-      (
-        int, {
-        String? second,
-        double third,
-        bool fourth,
-        List<String>? fifth,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyClassProvider;
-
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-    String Function(
-            Ref ref,
-            FamilyClass notifier,
+          FamilyClass Function(
             (
               int, {
               String? second,
               double third,
               bool fourth,
               List<String>? fifth,
-            }) argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyClassProvider;
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyClassProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool fourth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+  /// {@macro riverpod.override_with_build}
+  Override overrideWithBuild(
+          String Function(
+                  Ref ref,
+                  FamilyClass notifier,
+                  (
+                    int, {
+                    String? second,
+                    double third,
+                    bool fourth,
+                    List<String>? fifth,
+                  }) argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyClassProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$FamilyClass extends $Notifier<String> {
@@ -2129,12 +1565,8 @@ const supports$InFnNameProvider = Supports$InFnNameFamily._();
 final class Supports$InFnNameProvider<And$InT>
     extends $FunctionalProvider<String, String> with $Provider<String> {
   const Supports$InFnNameProvider._(
-      {required Supports$InFnNameFamily super.from,
-      String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+      {required Supports$InFnNameFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'supports$InFnNameProvider',
@@ -2143,21 +1575,8 @@ final class Supports$InFnNameProvider<And$InT>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$supports$InFnNameHash();
-
-  Supports$InFnNameProvider<And$InT> _copyWithCreate(
-    String Function<And$InT>(
-      Ref ref,
-    ) create,
-  ) {
-    return Supports$InFnNameProvider<And$InT>._(
-        from: from! as Supports$InFnNameFamily, create: create<And$InT>);
-  }
 
   @override
   String toString() {
@@ -2166,33 +1585,26 @@ final class Supports$InFnNameProvider<And$InT>
         '()';
   }
 
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return supports$InFnName<And$InT>(ref);
+  }
+
+  $R _captureGenerics<$R>($R Function<And$InT>() cb) {
+    return cb<And$InT>();
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Supports$InFnNameProvider<And$InT> $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Supports$InFnNameProvider<And$InT>._(
-        from: from! as Supports$InFnNameFamily, create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? supports$InFnName<And$InT>;
-    return _$cb(ref);
   }
 
   @override
@@ -2224,24 +1636,21 @@ final class Supports$InFnNameFamily extends Family {
       Supports$InFnNameProvider<And$InT>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$supports$InFnNameHash();
-
-  @override
   String toString() => r'supports$InFnNameProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    String Function<And$InT>(Ref ref) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Supports$InFnNameProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(String Function<And$InT>(Ref ref) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Supports$InFnNameProvider;
+            return provider._captureGenerics(<And$InT>() {
+              provider as Supports$InFnNameProvider<And$InT>;
+              return provider
+                  .$view(create: create<And$InT>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 @ProviderFor(supports$InFnNameFamily)
@@ -2256,15 +1665,8 @@ final class Supports$InFnNameFamilyProvider<And$InT>
         And$InT named$arg,
         String defaultArg,
       })
-          super.argument,
-      String Function(
-        Ref ref,
-        And$InT positional$arg, {
-        required And$InT named$arg,
-        String defaultArg,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'supports$InFnNameFamilyProvider',
           isAutoDispose: true,
@@ -2272,33 +1674,8 @@ final class Supports$InFnNameFamilyProvider<And$InT>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-    And$InT positional$arg, {
-    required And$InT named$arg,
-    String defaultArg,
-  })? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$supports$InFnNameFamilyHash();
-
-  Supports$InFnNameFamilyProvider<And$InT> _copyWithCreate(
-    String Function<And$InT>(
-      Ref ref,
-      And$InT positional$arg, {
-      required And$InT named$arg,
-      String defaultArg,
-    }) create,
-  ) {
-    return Supports$InFnNameFamilyProvider<And$InT>._(
-        argument: argument as (
-          And$InT, {
-          And$InT named$arg,
-          String defaultArg,
-        }),
-        from: from! as Supports$InFnNameFamilyFamily,
-        create: create<And$InT>);
-  }
 
   @override
   String toString() {
@@ -2307,54 +1684,35 @@ final class Supports$InFnNameFamilyProvider<And$InT>
         '$argument';
   }
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(String value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
   @$internal
   @override
   $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Supports$InFnNameFamilyProvider<And$InT> $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Supports$InFnNameFamilyProvider<And$InT>._(
-        argument: argument as (
-          And$InT, {
-          And$InT named$arg,
-          String defaultArg,
-        }),
-        from: from! as Supports$InFnNameFamilyFamily,
-        create: (
-          ref,
-          And$InT positional$arg, {
-          required And$InT named$arg,
-          String defaultArg = default$value,
-        }) =>
-            create(ref));
-  }
+      $ProviderElement(pointer);
 
   @override
   String create(Ref ref) {
-    final _$cb = _createCb ?? supports$InFnNameFamily<And$InT>;
     final argument = this.argument as (
       And$InT, {
       And$InT named$arg,
       String defaultArg,
     });
-    return _$cb(
+    return supports$InFnNameFamily<And$InT>(
       ref,
       argument.$1,
       named$arg: argument.named$arg,
       defaultArg: argument.defaultArg,
+    );
+  }
+
+  $R _captureGenerics<$R>($R Function<And$InT>() cb) {
+    return cb<And$InT>();
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(String value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<String>(value),
     );
   }
 
@@ -2396,42 +1754,34 @@ final class Supports$InFnNameFamilyFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$supports$InFnNameFamilyHash();
-
-  @override
   String toString() => r'supports$InFnNameFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function<And$InT>(
-      Ref ref,
-      (
-        And$InT, {
-        And$InT named$arg,
-        String defaultArg,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Supports$InFnNameFamilyProvider;
-
-        return provider._copyWithCreate(<And$InT>(
-          ref,
-          And$InT positional$arg, {
-          required And$InT named$arg,
-          String defaultArg = default$value,
-        }) {
-          return create(ref, (
-            positional$arg,
-            named$arg: named$arg,
-            defaultArg: defaultArg,
-          ));
-        }).$createElement(pointer);
-      },
-    );
-  }
+          String Function<And$InT>(
+            Ref ref,
+            (
+              And$InT, {
+              And$InT named$arg,
+              String defaultArg,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Supports$InFnNameFamilyProvider;
+            return provider._captureGenerics(<And$InT>() {
+              provider as Supports$InFnNameFamilyProvider<And$InT>;
+              final argument = provider.argument as (
+                And$InT, {
+                And$InT named$arg,
+                String defaultArg,
+              });
+              return provider
+                  .$view(create: (ref) => create(ref, argument))
+                  .$createElement(pointer);
+            });
+          });
 }
 
 @ProviderFor(Supports$InClassName)
@@ -2440,11 +1790,8 @@ const supports$InClassNameProvider = Supports$InClassNameFamily._();
 final class Supports$InClassNameProvider<And$InT>
     extends $NotifierProvider<Supports$InClassName<And$InT>, String> {
   const Supports$InClassNameProvider._(
-      {required Supports$InClassNameFamily super.from,
-      super.runNotifierBuildOverride,
-      Supports$InClassName<And$InT> Function()? create})
-      : _createCb = create,
-        super(
+      {required Supports$InClassNameFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'supports$InClassNameProvider',
@@ -2453,34 +1800,28 @@ final class Supports$InClassNameProvider<And$InT>
           allTransitiveDependencies: null,
         );
 
-  final Supports$InClassName<And$InT> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$supports$InClassNameHash();
-
-  Supports$InClassNameProvider<And$InT> _copyWithCreate(
-    Supports$InClassName<And$InT> Function<And$InT>() create,
-  ) {
-    return Supports$InClassNameProvider<And$InT>._(
-        from: from! as Supports$InClassNameFamily, create: create<And$InT>);
-  }
-
-  Supports$InClassNameProvider<And$InT> _copyWithBuild(
-    String Function<And$InT>(
-      Ref,
-      Supports$InClassName<And$InT>,
-    ) build,
-  ) {
-    return Supports$InClassNameProvider<And$InT>._(
-        from: from! as Supports$InClassNameFamily,
-        runNotifierBuildOverride: build<And$InT>);
-  }
 
   @override
   String toString() {
     return r'supports$InClassNameProvider'
         '<${And$InT}>'
         '()';
+  }
+
+  @$internal
+  @override
+  Supports$InClassName<And$InT> create() => Supports$InClassName<And$InT>();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Supports$InClassName<And$InT>, String>
+      $createElement($ProviderPointer pointer) =>
+          $NotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<And$InT>() cb) {
+    return cb<And$InT>();
   }
 
   /// {@macro riverpod.override_with_value}
@@ -2490,39 +1831,6 @@ final class Supports$InClassNameProvider<And$InT>
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  Supports$InClassName<And$InT> create() =>
-      _createCb?.call() ?? Supports$InClassName<And$InT>();
-
-  @$internal
-  @override
-  Supports$InClassNameProvider<And$InT> $copyWithCreate(
-    Supports$InClassName<And$InT> Function() create,
-  ) {
-    return Supports$InClassNameProvider<And$InT>._(
-        from: from! as Supports$InClassNameFamily, create: create);
-  }
-
-  @$internal
-  @override
-  Supports$InClassNameProvider<And$InT> $copyWithBuild(
-    String Function(
-      Ref,
-      Supports$InClassName<And$InT>,
-    ) build,
-  ) {
-    return Supports$InClassNameProvider<And$InT>._(
-        from: from! as Supports$InClassNameFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Supports$InClassName<And$InT>, String>
-      $createElement($ProviderPointer pointer) =>
-          $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -2554,39 +1862,39 @@ final class Supports$InClassNameFamily extends Family {
       Supports$InClassNameProvider<And$InT>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$supports$InClassNameHash();
-
-  @override
   String toString() => r'supports$InClassNameProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Supports$InClassName<And$InT> Function<And$InT>() create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Supports$InClassNameProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+          Supports$InClassName<And$InT> Function<And$InT>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Supports$InClassNameProvider;
+            return provider._captureGenerics(<And$InT>() {
+              provider as Supports$InClassNameProvider<And$InT>;
+              return provider
+                  .$view(create: create<And$InT>)
+                  .$createElement(pointer);
+            });
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    String Function<And$InT>(Ref ref, Supports$InClassName<And$InT> notifier)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Supports$InClassNameProvider;
-
-        return provider._copyWithBuild(build).$createElement(pointer);
-      },
-    );
-  }
+          String Function<And$InT>(
+                  Ref ref, Supports$InClassName<And$InT> notifier)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as Supports$InClassNameProvider;
+            return provider._captureGenerics(<And$InT>() {
+              provider as Supports$InClassNameProvider<And$InT>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<And$InT>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$Supports$InClassName<And$InT> extends $Notifier<String> {
@@ -2614,11 +1922,8 @@ final class Supports$InClassFamilyNameProvider<And$InT>
         And$InT named$arg,
         String defaultArg,
       })
-          super.argument,
-      super.runNotifierBuildOverride,
-      Supports$InClassFamilyName<And$InT> Function()? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'supports$InClassFamilyNameProvider',
           isAutoDispose: true,
@@ -2626,45 +1931,29 @@ final class Supports$InClassFamilyNameProvider<And$InT>
           allTransitiveDependencies: null,
         );
 
-  final Supports$InClassFamilyName<And$InT> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$supports$InClassFamilyNameHash();
-
-  Supports$InClassFamilyNameProvider<And$InT> _copyWithCreate(
-    Supports$InClassFamilyName<And$InT> Function<And$InT>() create,
-  ) {
-    return Supports$InClassFamilyNameProvider<And$InT>._(
-        argument: argument as (
-          And$InT, {
-          And$InT named$arg,
-          String defaultArg,
-        }),
-        from: from! as Supports$InClassFamilyNameFamily,
-        create: create<And$InT>);
-  }
-
-  Supports$InClassFamilyNameProvider<And$InT> _copyWithBuild(
-    String Function<And$InT>(
-      Ref,
-      Supports$InClassFamilyName<And$InT>,
-    ) build,
-  ) {
-    return Supports$InClassFamilyNameProvider<And$InT>._(
-        argument: argument as (
-          And$InT, {
-          And$InT named$arg,
-          String defaultArg,
-        }),
-        from: from! as Supports$InClassFamilyNameFamily,
-        runNotifierBuildOverride: build<And$InT>);
-  }
 
   @override
   String toString() {
     return r'supports$InClassFamilyNameProvider'
         '<${And$InT}>'
         '$argument';
+  }
+
+  @$internal
+  @override
+  Supports$InClassFamilyName<And$InT> create() =>
+      Supports$InClassFamilyName<And$InT>();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Supports$InClassFamilyName<And$InT>, String>
+      $createElement($ProviderPointer pointer) =>
+          $NotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<And$InT>() cb) {
+    return cb<And$InT>();
   }
 
   /// {@macro riverpod.override_with_value}
@@ -2674,50 +1963,6 @@ final class Supports$InClassFamilyNameProvider<And$InT>
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  Supports$InClassFamilyName<And$InT> create() =>
-      _createCb?.call() ?? Supports$InClassFamilyName<And$InT>();
-
-  @$internal
-  @override
-  Supports$InClassFamilyNameProvider<And$InT> $copyWithCreate(
-    Supports$InClassFamilyName<And$InT> Function() create,
-  ) {
-    return Supports$InClassFamilyNameProvider<And$InT>._(
-        argument: argument as (
-          And$InT, {
-          And$InT named$arg,
-          String defaultArg,
-        }),
-        from: from! as Supports$InClassFamilyNameFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  Supports$InClassFamilyNameProvider<And$InT> $copyWithBuild(
-    String Function(
-      Ref,
-      Supports$InClassFamilyName<And$InT>,
-    ) build,
-  ) {
-    return Supports$InClassFamilyNameProvider<And$InT>._(
-        argument: argument as (
-          And$InT, {
-          And$InT named$arg,
-          String defaultArg,
-        }),
-        from: from! as Supports$InClassFamilyNameFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Supports$InClassFamilyName<And$InT>, String>
-      $createElement($ProviderPointer pointer) =>
-          $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -2757,68 +2002,65 @@ final class Supports$InClassFamilyNameFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$supports$InClassFamilyNameHash();
-
-  @override
   String toString() => r'supports$InClassFamilyNameProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Supports$InClassFamilyName<And$InT> Function<And$InT>(
-      (
-        And$InT, {
-        And$InT named$arg,
-        String defaultArg,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Supports$InClassFamilyNameProvider;
-
-        return provider._copyWithCreate(<And$InT>() {
-          final argument = provider.argument as (
-            And$InT, {
-            And$InT named$arg,
-            String defaultArg,
-          });
-
-          return create(argument);
-        }).$createElement(pointer);
-      },
-    );
-  }
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-    String Function<And$InT>(
-            Ref ref,
-            Supports$InClassFamilyName<And$InT> notifier,
+          Supports$InClassFamilyName<And$InT> Function<And$InT>(
             (
               And$InT, {
               And$InT named$arg,
               String defaultArg,
-            }) argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as Supports$InClassFamilyNameProvider;
-
-        return provider._copyWithBuild(<And$InT>(ref, notifier) {
-          final argument = provider.argument as (
-            And$InT, {
-            And$InT named$arg,
-            String defaultArg,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider =
+                pointer.origin as Supports$InClassFamilyNameProvider;
+            return provider._captureGenerics(<And$InT>() {
+              provider as Supports$InClassFamilyNameProvider<And$InT>;
+              final argument = provider.argument as (
+                And$InT, {
+                And$InT named$arg,
+                String defaultArg,
+              });
+              return provider
+                  .$view(create: () => create(argument))
+                  .$createElement(pointer);
+            });
           });
 
-          return build(ref, notifier, argument);
-        }).$createElement(pointer);
-      },
-    );
-  }
+  /// {@macro riverpod.override_with_build}
+  Override overrideWithBuild(
+          String Function<And$InT>(
+                  Ref ref,
+                  Supports$InClassFamilyName<And$InT> notifier,
+                  (
+                    And$InT, {
+                    And$InT named$arg,
+                    String defaultArg,
+                  }) argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider =
+                pointer.origin as Supports$InClassFamilyNameProvider;
+            return provider._captureGenerics(<And$InT>() {
+              provider as Supports$InClassFamilyNameProvider<And$InT>;
+              final argument = provider.argument as (
+                And$InT, {
+                And$InT named$arg,
+                String defaultArg,
+              });
+              return provider
+                  .$view(
+                      runNotifierBuildOverride: (ref, notifier) =>
+                          build<And$InT>(ref, notifier, argument))
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$Supports$InClassFamilyName<And$InT> extends $Notifier<String> {
@@ -2856,12 +2098,8 @@ const generatedProvider = GeneratedProvider._();
 
 final class GeneratedProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const GeneratedProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const GeneratedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -2871,12 +2109,18 @@ final class GeneratedProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$generatedHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return generated(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -2884,26 +2128,6 @@ final class GeneratedProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  GeneratedProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return GeneratedProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? generated;
-    return _$cb(ref);
   }
 }
 
@@ -2916,24 +2140,14 @@ final class UnnecessaryCastProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
   const UnnecessaryCastProvider._(
       {required UnnecessaryCastFamily super.from,
-      required Object? super.argument,
-      String Function(
-        Ref ref,
-        Object? arg,
-      )? create})
-      : _createCb = create,
-        super(
+      required Object? super.argument})
+      : super(
           retry: null,
           name: r'unnecessaryCastProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    Object? arg,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$unnecessaryCastHash();
@@ -2945,42 +2159,25 @@ final class UnnecessaryCastProvider extends $FunctionalProvider<String, String>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    final argument = this.argument;
+    return unnecessaryCast(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  UnnecessaryCastProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return UnnecessaryCastProvider._(
-        argument: argument,
-        from: from! as UnnecessaryCastFamily,
-        create: (
-          ref,
-          Object? arg,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? unnecessaryCast;
-    final argument = this.argument;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -3013,31 +2210,23 @@ final class UnnecessaryCastFamily extends Family {
       UnnecessaryCastProvider._(argument: arg, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$unnecessaryCastHash();
-
-  @override
   String toString() => r'unnecessaryCastProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      Object? args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as UnnecessaryCastProvider;
-
-        final argument = provider.argument;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            Object? args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as UnnecessaryCastProvider;
+            final argument = provider.argument;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(UnnecessaryCastClass)
@@ -3047,19 +2236,14 @@ final class UnnecessaryCastClassProvider
     extends $NotifierProvider<UnnecessaryCastClass, String> {
   const UnnecessaryCastClassProvider._(
       {required UnnecessaryCastClassFamily super.from,
-      required Object? super.argument,
-      super.runNotifierBuildOverride,
-      UnnecessaryCastClass Function()? create})
-      : _createCb = create,
-        super(
+      required Object? super.argument})
+      : super(
           retry: null,
           name: r'unnecessaryCastClassProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final UnnecessaryCastClass Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$unnecessaryCastClassHash();
@@ -3071,6 +2255,16 @@ final class UnnecessaryCastClassProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  UnnecessaryCastClass create() => UnnecessaryCastClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<UnnecessaryCastClass, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
@@ -3078,41 +2272,6 @@ final class UnnecessaryCastClassProvider
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  UnnecessaryCastClass create() => _createCb?.call() ?? UnnecessaryCastClass();
-
-  @$internal
-  @override
-  UnnecessaryCastClassProvider $copyWithCreate(
-    UnnecessaryCastClass Function() create,
-  ) {
-    return UnnecessaryCastClassProvider._(
-        argument: argument,
-        from: from! as UnnecessaryCastClassFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  UnnecessaryCastClassProvider $copyWithBuild(
-    String Function(
-      Ref,
-      UnnecessaryCastClass,
-    ) build,
-  ) {
-    return UnnecessaryCastClassProvider._(
-        argument: argument,
-        from: from! as UnnecessaryCastClassFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<UnnecessaryCastClass, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -3144,49 +2303,39 @@ final class UnnecessaryCastClassFamily extends Family {
       UnnecessaryCastClassProvider._(argument: arg, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$unnecessaryCastClassHash();
-
-  @override
   String toString() => r'unnecessaryCastClassProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    UnnecessaryCastClass Function(
-      Object? args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as UnnecessaryCastClassProvider;
-
-        final argument = provider.argument;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          UnnecessaryCastClass Function(
+            Object? args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as UnnecessaryCastClassProvider;
+            final argument = provider.argument;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    String Function(Ref ref, UnnecessaryCastClass notifier, Object? argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as UnnecessaryCastClassProvider;
-
-        final argument = provider.argument;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+                  Ref ref, UnnecessaryCastClass notifier, Object? argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as UnnecessaryCastClassProvider;
+            final argument = provider.argument;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$UnnecessaryCastClass extends $Notifier<String> {
@@ -3217,13 +2366,8 @@ final class ManyDataStreamProvider<T extends Object, S extends Object>
     with $FutureModifier<List<T>>, $StreamProvider<List<T>> {
   const ManyDataStreamProvider._(
       {required ManyDataStreamFamily super.from,
-      required ManyProviderData<T, S> super.argument,
-      Stream<List<T>> Function(
-        Ref ref,
-        ManyProviderData<T, S> pData,
-      )? create})
-      : _createCb = create,
-        super(
+      required ManyProviderData<T, S> super.argument})
+      : super(
           retry: null,
           name: r'manyDataStreamProvider',
           isAutoDispose: true,
@@ -3231,25 +2375,8 @@ final class ManyDataStreamProvider<T extends Object, S extends Object>
           allTransitiveDependencies: null,
         );
 
-  final Stream<List<T>> Function(
-    Ref ref,
-    ManyProviderData<T, S> pData,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$manyDataStreamHash();
-
-  ManyDataStreamProvider<T, S> _copyWithCreate(
-    Stream<List<T>> Function<T extends Object, S extends Object>(
-      Ref ref,
-      ManyProviderData<T, S> pData,
-    ) create,
-  ) {
-    return ManyDataStreamProvider<T, S>._(
-        argument: argument as ManyProviderData<T, S>,
-        from: from! as ManyDataStreamFamily,
-        create: create<T, S>);
-  }
 
   @override
   String toString() {
@@ -3261,32 +2388,20 @@ final class ManyDataStreamProvider<T extends Object, S extends Object>
   @$internal
   @override
   $StreamProviderElement<List<T>> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  ManyDataStreamProvider<T, S> $copyWithCreate(
-    Stream<List<T>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ManyDataStreamProvider<T, S>._(
-        argument: argument as ManyProviderData<T, S>,
-        from: from! as ManyDataStreamFamily,
-        create: (
-          ref,
-          ManyProviderData<T, S> pData,
-        ) =>
-            create(ref));
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<List<T>> create(Ref ref) {
-    final _$cb = _createCb ?? manyDataStream<T, S>;
     final argument = this.argument as ManyProviderData<T, S>;
-    return _$cb(
+    return manyDataStream<T, S>(
       ref,
       argument,
     );
+  }
+
+  $R _captureGenerics<$R>(
+      $R Function<T extends Object, S extends Object>() cb) {
+    return cb<T, S>();
   }
 
   @override
@@ -3320,32 +2435,27 @@ final class ManyDataStreamFamily extends Family {
       ManyDataStreamProvider<T, S>._(argument: pData, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$manyDataStreamHash();
-
-  @override
   String toString() => r'manyDataStreamProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Stream<List<T>> Function<T extends Object, S extends Object>(
-      Ref ref,
-      ManyProviderData<T, S> args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ManyDataStreamProvider;
-
-        return provider._copyWithCreate(<T extends Object, S extends Object>(
-          ref,
-          ManyProviderData<T, S> pData,
-        ) {
-          return create(ref, pData);
-        }).$createElement(pointer);
-      },
-    );
-  }
+          Stream<List<T>> Function<T extends Object, S extends Object>(
+            Ref ref,
+            ManyProviderData<T, S> args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ManyDataStreamProvider;
+            return provider
+                ._captureGenerics(<T extends Object, S extends Object>() {
+              provider as ManyDataStreamProvider<T, S>;
+              final argument = provider.argument as ManyProviderData<T, S>;
+              return provider
+                  .$view(create: (ref) => create(ref, argument))
+                  .$createElement(pointer);
+            });
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_generator/test/stream_test.dart
+++ b/packages/riverpod_generator/test/stream_test.dart
@@ -173,10 +173,20 @@ void main() {
     final container = ProviderContainer.test(
       overrides: [
         publicProvider.overrideWithValue(const AsyncData('test')),
+        familyProvider(42, third: .2)
+            .overrideWithValue(const AsyncData('test')),
       ],
     );
 
     expect(container.read(publicProvider), const AsyncData('test'));
     expect(container.read(publicProvider.future), completion('test'));
+    expect(
+      container.read(familyProvider(42, third: .2)),
+      const AsyncData('test'),
+    );
+    expect(
+      container.read(familyProvider(42, third: .2).future),
+      completion('test'),
+    );
   });
 }

--- a/packages/riverpod_generator/test/sync_test.dart
+++ b/packages/riverpod_generator/test/sync_test.dart
@@ -136,10 +136,6 @@ void main() {
     );
 
     expect(
-      publicProvider.overrideWithValue('foo').toString(),
-      'publicProvider.overrideWithValue(foo)',
-    );
-    expect(
       familyProvider.overrideWith((ref, _) => 'foo').toString(),
       'familyProvider.overrideWith(...)',
     );
@@ -319,7 +315,6 @@ void main() {
           (ref, args) =>
               'test (first: ${args.$1}, second: ${args.second}, third: ${args.third}, fourth: ${args.fourth}, fifth: ${args.fifth})',
         ),
-        familyProvider(21, third: .21).overrideWithValue('Override'),
         familyClassProvider.overrideWith(FamilyClass.new),
       ],
     );
@@ -341,7 +336,6 @@ void main() {
       container.read(familyProvider(42, second: '42', third: .42)),
       'test (first: 42, second: 42, third: 0.42, fourth: true, fifth: null)',
     );
-    expect(container.read(familyProvider(21, third: .21)), 'Override');
     expect(
       container
           .read(familyClassProvider(42, second: '42', third: .42).notifier)

--- a/packages/riverpod_generator/test/sync_test.dart
+++ b/packages/riverpod_generator/test/sync_test.dart
@@ -136,6 +136,10 @@ void main() {
     );
 
     expect(
+      publicProvider.overrideWithValue('foo').toString(),
+      'publicProvider.overrideWithValue(foo)',
+    );
+    expect(
       familyProvider.overrideWith((ref, _) => 'foo').toString(),
       'familyProvider.overrideWith(...)',
     );
@@ -315,6 +319,7 @@ void main() {
           (ref, args) =>
               'test (first: ${args.$1}, second: ${args.second}, third: ${args.third}, fourth: ${args.fourth}, fifth: ${args.fifth})',
         ),
+        familyProvider(21, third: .21).overrideWithValue('Override'),
         familyClassProvider.overrideWith(FamilyClass.new),
       ],
     );
@@ -336,6 +341,7 @@ void main() {
       container.read(familyProvider(42, second: '42', third: .42)),
       'test (first: 42, second: 42, third: 0.42, fourth: true, fifth: null)',
     );
+    expect(container.read(familyProvider(21, third: .21)), 'Override');
     expect(
       container
           .read(familyClassProvider(42, second: '42', third: .42).notifier)

--- a/packages/riverpod_graph/test/integration/generated/golden/lib/sync.g.dart
+++ b/packages/riverpod_graph/test/integration/generated/golden/lib/sync.g.dart
@@ -14,12 +14,8 @@ const publicProvider = PublicProvider._();
 final class PublicProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
   /// A public generated provider.
-  const PublicProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const PublicProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,12 +25,18 @@ final class PublicProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$publicHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return public(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -42,26 +44,6 @@ final class PublicProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  PublicProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return PublicProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? public;
-    return _$cb(ref);
   }
 }
 
@@ -75,12 +57,8 @@ const supports$inNamesProvider = Supports$inNamesProvider._();
 final class Supports$inNamesProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
   /// A generated provider with a '$' in its name.
-  const Supports$inNamesProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Supports$inNamesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -90,12 +68,18 @@ final class Supports$inNamesProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$supports$inNamesHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return supports$inNames(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -103,26 +87,6 @@ final class Supports$inNamesProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Supports$inNamesProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Supports$inNamesProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? supports$inNames;
-    return _$cb(ref);
   }
 }
 
@@ -145,32 +109,14 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
         bool forth,
         List<String>? fifth,
       })
-          super.argument,
-      String Function(
-        Ref ref,
-        int first, {
-        String? second,
-        required double third,
-        bool forth,
-        List<String>? fifth,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'familyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    int first, {
-    String? second,
-    required double third,
-    bool forth,
-    List<String>? fifth,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyHash();
@@ -182,48 +128,13 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
         '$argument';
   }
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(String value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
   @$internal
   @override
   $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FamilyProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool forth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyFamily,
-        create: (
-          ref,
-          int first, {
-          String? second,
-          required double third,
-          bool forth = true,
-          List<String>? fifth,
-        }) =>
-            create(ref));
-  }
+      $ProviderElement(pointer);
 
   @override
   String create(Ref ref) {
-    final _$cb = _createCb ?? family;
     final argument = this.argument as (
       int, {
       String? second,
@@ -231,13 +142,21 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
       bool forth,
       List<String>? fifth,
     });
-    return _$cb(
+    return family(
       ref,
       argument.$1,
       second: argument.second,
       third: argument.third,
       forth: argument.forth,
       fifth: argument.fifth,
+    );
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(String value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<String>(value),
     );
   }
 
@@ -282,43 +201,35 @@ final class FamilyFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyHash();
-
-  @override
   String toString() => r'familyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      (
-        int, {
-        String? second,
-        double third,
-        bool forth,
-        List<String>? fifth,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyProvider;
-
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool forth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            (
+              int, {
+              String? second,
+              double third,
+              bool forth,
+              List<String>? fifth,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool forth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(_private)
@@ -326,12 +237,8 @@ const _privateProvider = _PrivateProvider._();
 
 final class _PrivateProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const _PrivateProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const _PrivateProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -341,12 +248,18 @@ final class _PrivateProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$privateHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return _private(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -354,26 +267,6 @@ final class _PrivateProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  _PrivateProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return _PrivateProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? _private;
-    return _$cb(ref);
   }
 }
 
@@ -386,10 +279,8 @@ const publicClassProvider = PublicClassProvider._();
 /// A generated public provider from a class
 final class PublicClassProvider extends $NotifierProvider<PublicClass, String> {
   /// A generated public provider from a class
-  const PublicClassProvider._(
-      {super.runNotifierBuildOverride, PublicClass Function()? create})
-      : _createCb = create,
-        super(
+  const PublicClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -399,10 +290,18 @@ final class PublicClassProvider extends $NotifierProvider<PublicClass, String> {
           allTransitiveDependencies: null,
         );
 
-  final PublicClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$publicClassHash();
+
+  @$internal
+  @override
+  PublicClass create() => PublicClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<PublicClass, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -411,35 +310,6 @@ final class PublicClassProvider extends $NotifierProvider<PublicClass, String> {
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  PublicClass create() => _createCb?.call() ?? PublicClass();
-
-  @$internal
-  @override
-  PublicClassProvider $copyWithCreate(
-    PublicClass Function() create,
-  ) {
-    return PublicClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  PublicClassProvider $copyWithBuild(
-    String Function(
-      Ref,
-      PublicClass,
-    ) build,
-  ) {
-    return PublicClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<PublicClass, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$publicClassHash() => r'c27eae39f455b986e570abb84f1471de7445ef3b';
@@ -462,10 +332,8 @@ const _privateClassProvider = _PrivateClassProvider._();
 
 final class _PrivateClassProvider
     extends $NotifierProvider<_PrivateClass, String> {
-  const _PrivateClassProvider._(
-      {super.runNotifierBuildOverride, _PrivateClass Function()? create})
-      : _createCb = create,
-        super(
+  const _PrivateClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -475,10 +343,18 @@ final class _PrivateClassProvider
           allTransitiveDependencies: null,
         );
 
-  final _PrivateClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$privateClassHash();
+
+  @$internal
+  @override
+  _PrivateClass create() => _PrivateClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<_PrivateClass, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -487,35 +363,6 @@ final class _PrivateClassProvider
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  _PrivateClass create() => _createCb?.call() ?? _PrivateClass();
-
-  @$internal
-  @override
-  _PrivateClassProvider $copyWithCreate(
-    _PrivateClass Function() create,
-  ) {
-    return _PrivateClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  _PrivateClassProvider $copyWithBuild(
-    String Function(
-      Ref,
-      _PrivateClass,
-    ) build,
-  ) {
-    return _PrivateClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<_PrivateClass, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$privateClassHash() => r'3b08af72c6d4f24aed264efcf181572525b75603';
@@ -549,19 +396,14 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
         bool forth,
         List<String>? fifth,
       })
-          super.argument,
-      super.runNotifierBuildOverride,
-      FamilyClass Function()? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'familyClassProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FamilyClass Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyClassHash();
@@ -573,6 +415,16 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
         '$argument';
   }
 
+  @$internal
+  @override
+  FamilyClass create() => FamilyClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<FamilyClass, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
@@ -580,53 +432,6 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  FamilyClass create() => _createCb?.call() ?? FamilyClass();
-
-  @$internal
-  @override
-  FamilyClassProvider $copyWithCreate(
-    FamilyClass Function() create,
-  ) {
-    return FamilyClassProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool forth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyClassFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  FamilyClassProvider $copyWithBuild(
-    String Function(
-      Ref,
-      FamilyClass,
-    ) build,
-  ) {
-    return FamilyClassProvider._(
-        argument: argument as (
-          int, {
-          String? second,
-          double third,
-          bool forth,
-          List<String>? fifth,
-        }),
-        from: from! as FamilyClassFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<FamilyClass, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -669,76 +474,65 @@ final class FamilyClassFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyClassHash();
-
-  @override
   String toString() => r'familyClassProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FamilyClass Function(
-      (
-        int, {
-        String? second,
-        double third,
-        bool forth,
-        List<String>? fifth,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyClassProvider;
-
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool forth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-    String Function(
-            Ref ref,
-            FamilyClass notifier,
+          FamilyClass Function(
             (
               int, {
               String? second,
               double third,
               bool forth,
               List<String>? fifth,
-            }) argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyClassProvider;
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyClassProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool forth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
-        final argument = provider.argument as (
-          int, {
-          String? second,
-          double third,
-          bool forth,
-          List<String>? fifth,
-        });
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+  /// {@macro riverpod.override_with_build}
+  Override overrideWithBuild(
+          String Function(
+                  Ref ref,
+                  FamilyClass notifier,
+                  (
+                    int, {
+                    String? second,
+                    double third,
+                    bool forth,
+                    List<String>? fifth,
+                  }) argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyClassProvider;
+            final argument = provider.argument as (
+              int, {
+              String? second,
+              double third,
+              bool forth,
+              List<String>? fifth,
+            });
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$FamilyClass extends $Notifier<String> {
@@ -787,10 +581,8 @@ const supports$InClassNameProvider = Supports$InClassNameProvider._();
 final class Supports$InClassNameProvider
     extends $NotifierProvider<Supports$InClassName, String> {
   /// A generated provider from a class with a '$' in its name.
-  const Supports$InClassNameProvider._(
-      {super.runNotifierBuildOverride, Supports$InClassName Function()? create})
-      : _createCb = create,
-        super(
+  const Supports$InClassNameProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -800,10 +592,18 @@ final class Supports$InClassNameProvider
           allTransitiveDependencies: null,
         );
 
-  final Supports$InClassName Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$supports$InClassNameHash();
+
+  @$internal
+  @override
+  Supports$InClassName create() => Supports$InClassName();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Supports$InClassName, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -812,35 +612,6 @@ final class Supports$InClassNameProvider
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  Supports$InClassName create() => _createCb?.call() ?? Supports$InClassName();
-
-  @$internal
-  @override
-  Supports$InClassNameProvider $copyWithCreate(
-    Supports$InClassName Function() create,
-  ) {
-    return Supports$InClassNameProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  Supports$InClassNameProvider $copyWithBuild(
-    String Function(
-      Ref,
-      Supports$InClassName,
-    ) build,
-  ) {
-    return Supports$InClassNameProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Supports$InClassName, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$supports$InClassNameHash() =>

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional/convert_class_based_provider_to_functional.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional/convert_class_based_provider_to_functional.g.dart
@@ -13,10 +13,8 @@ const exampleProvider = ExampleProvider._();
 /// Some comment
 final class ExampleProvider extends $NotifierProvider<Example, int> {
   /// Some comment
-  const ExampleProvider._(
-      {super.runNotifierBuildOverride, Example Function()? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,10 +24,18 @@ final class ExampleProvider extends $NotifierProvider<Example, int> {
           allTransitiveDependencies: null,
         );
 
-  final Example Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  Example create() => Example();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Example, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -38,35 +44,6 @@ final class ExampleProvider extends $NotifierProvider<Example, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Example create() => _createCb?.call() ?? Example();
-
-  @$internal
-  @override
-  ExampleProvider $copyWithCreate(
-    Example Function() create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  ExampleProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Example,
-    ) build,
-  ) {
-    return ExampleProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Example, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$exampleHash() => r'081776126bafed3e1583bba9c1fadef798215ad7';
@@ -98,19 +75,14 @@ final class ExampleFamilyProvider
         int a,
         String b,
       })
-          super.argument,
-      super.runNotifierBuildOverride,
-      ExampleFamily Function()? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'exampleFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final ExampleFamily Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$exampleFamilyHash();
@@ -122,6 +94,16 @@ final class ExampleFamilyProvider
         '$argument';
   }
 
+  @$internal
+  @override
+  ExampleFamily create() => ExampleFamily();
+
+  @$internal
+  @override
+  $NotifierProviderElement<ExampleFamily, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
@@ -129,47 +111,6 @@ final class ExampleFamilyProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  ExampleFamily create() => _createCb?.call() ?? ExampleFamily();
-
-  @$internal
-  @override
-  ExampleFamilyProvider $copyWithCreate(
-    ExampleFamily Function() create,
-  ) {
-    return ExampleFamilyProvider._(
-        argument: argument as ({
-          int a,
-          String b,
-        }),
-        from: from! as ExampleFamilyFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  ExampleFamilyProvider $copyWithBuild(
-    int Function(
-      Ref,
-      ExampleFamily,
-    ) build,
-  ) {
-    return ExampleFamilyProvider._(
-        argument: argument as ({
-          int a,
-          String b,
-        }),
-        from: from! as ExampleFamilyFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<ExampleFamily, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -206,64 +147,53 @@ final class ExampleFamilyFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$exampleFamilyHash();
-
-  @override
   String toString() => r'exampleFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    ExampleFamily Function(
-      ({
-        int a,
-        String b,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ExampleFamilyProvider;
-
-        final argument = provider.argument as ({
-          int a,
-          String b,
-        });
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-    int Function(
-            Ref ref,
-            ExampleFamily notifier,
+          ExampleFamily Function(
             ({
               int a,
               String b,
-            }) argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ExampleFamilyProvider;
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ExampleFamilyProvider;
+            final argument = provider.argument as ({
+              int a,
+              String b,
+            });
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
-        final argument = provider.argument as ({
-          int a,
-          String b,
-        });
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+  /// {@macro riverpod.override_with_build}
+  Override overrideWithBuild(
+          int Function(
+                  Ref ref,
+                  ExampleFamily notifier,
+                  ({
+                    int a,
+                    String b,
+                  }) argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ExampleFamilyProvider;
+            final argument = provider.argument as ({
+              int a,
+              String b,
+            });
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$ExampleFamily extends $Notifier<int> {
@@ -297,12 +227,8 @@ const genericProvider = GenericFamily._();
 
 final class GenericProvider<A, B>
     extends $NotifierProvider<Generic<A, B>, int> {
-  const GenericProvider._(
-      {required GenericFamily super.from,
-      super.runNotifierBuildOverride,
-      Generic<A, B> Function()? create})
-      : _createCb = create,
-        super(
+  const GenericProvider._({required GenericFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'genericProvider',
@@ -311,33 +237,28 @@ final class GenericProvider<A, B>
           allTransitiveDependencies: null,
         );
 
-  final Generic<A, B> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericHash();
-
-  GenericProvider<A, B> _copyWithCreate(
-    Generic<A, B> Function<A, B>() create,
-  ) {
-    return GenericProvider<A, B>._(
-        from: from! as GenericFamily, create: create<A, B>);
-  }
-
-  GenericProvider<A, B> _copyWithBuild(
-    int Function<A, B>(
-      Ref,
-      Generic<A, B>,
-    ) build,
-  ) {
-    return GenericProvider<A, B>._(
-        from: from! as GenericFamily, runNotifierBuildOverride: build<A, B>);
-  }
 
   @override
   String toString() {
     return r'genericProvider'
         '<${A}, ${B}>'
         '()';
+  }
+
+  @$internal
+  @override
+  Generic<A, B> create() => Generic<A, B>();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Generic<A, B>, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<A, B>() cb) {
+    return cb<A, B>();
   }
 
   /// {@macro riverpod.override_with_value}
@@ -347,37 +268,6 @@ final class GenericProvider<A, B>
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Generic<A, B> create() => _createCb?.call() ?? Generic<A, B>();
-
-  @$internal
-  @override
-  GenericProvider<A, B> $copyWithCreate(
-    Generic<A, B> Function() create,
-  ) {
-    return GenericProvider<A, B>._(
-        from: from! as GenericFamily, create: create);
-  }
-
-  @$internal
-  @override
-  GenericProvider<A, B> $copyWithBuild(
-    int Function(
-      Ref,
-      Generic<A, B>,
-    ) build,
-  ) {
-    return GenericProvider<A, B>._(
-        from: from! as GenericFamily, runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Generic<A, B>, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -407,38 +297,36 @@ final class GenericFamily extends Family {
   GenericProvider<A, B> call<A, B>() => GenericProvider<A, B>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$genericHash();
-
-  @override
   String toString() => r'genericProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    Generic<A, B> Function<A, B>() create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(Generic<A, B> Function<A, B>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericProvider;
+            return provider._captureGenerics(<A, B>() {
+              provider as GenericProvider<A, B>;
+              return provider
+                  .$view(create: create<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function<A, B>(Ref ref, Generic<A, B> notifier) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericProvider;
-
-        return provider._copyWithBuild(build).$createElement(pointer);
-      },
-    );
-  }
+          int Function<A, B>(Ref ref, Generic<A, B> notifier) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericProvider;
+            return provider._captureGenerics(<A, B>() {
+              provider as GenericProvider<A, B>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$Generic<A, B> extends $Notifier<int> {

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based/convert_functional_provider_to_class_based.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based/convert_functional_provider_to_class_based.g.dart
@@ -14,12 +14,8 @@ const exampleProvider = ExampleProvider._();
 final class ExampleProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   /// Some comment
-  const ExampleProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,12 +25,18 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return example(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -42,26 +44,6 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
   }
 }
 
@@ -81,26 +63,14 @@ final class ExampleFamilyProvider extends $FunctionalProvider<int, int>
         int a,
         String b,
       })
-          super.argument,
-      int Function(
-        Ref ref, {
-        required int a,
-        String b,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'exampleFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final int Function(
-    Ref ref, {
-    required int a,
-    String b,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$exampleFamilyHash();
@@ -112,50 +82,29 @@ final class ExampleFamilyProvider extends $FunctionalProvider<int, int>
         '$argument';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as ({
+      int a,
+      String b,
+    });
+    return exampleFamily(
+      ref,
+      a: argument.a,
+      b: argument.b,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleFamilyProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleFamilyProvider._(
-        argument: argument as ({
-          int a,
-          String b,
-        }),
-        from: from! as ExampleFamilyFamily,
-        create: (
-          ref, {
-          required int a,
-          String b = '42',
-        }) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? exampleFamily;
-    final argument = this.argument as ({
-      int a,
-      String b,
-    });
-    return _$cb(
-      ref,
-      a: argument.a,
-      b: argument.b,
     );
   }
 
@@ -194,37 +143,29 @@ final class ExampleFamilyFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$exampleFamilyHash();
-
-  @override
   String toString() => r'exampleFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      ({
-        int a,
-        String b,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ExampleFamilyProvider;
-
-        final argument = provider.argument as ({
-          int a,
-          String b,
-        });
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            ({
+              int a,
+              String b,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ExampleFamilyProvider;
+            final argument = provider.argument as ({
+              int a,
+              String b,
+            });
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_lint_flutter_test/test/lints/avoid_build_context_in_providers.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/avoid_build_context_in_providers.g.dart
@@ -17,26 +17,14 @@ final class FnProvider extends $FunctionalProvider<int, int>
         BuildContext, {
         BuildContext context2,
       })
-          super.argument,
-      int Function(
-        Ref ref,
-        BuildContext context1, {
-        required BuildContext context2,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'fnProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final int Function(
-    Ref ref,
-    BuildContext context1, {
-    required BuildContext context2,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$fnHash();
@@ -48,50 +36,29 @@ final class FnProvider extends $FunctionalProvider<int, int>
         '$argument';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as (
+      BuildContext, {
+      BuildContext context2,
+    });
+    return fn(
+      ref,
+      argument.$1,
+      context2: argument.context2,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FnProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FnProvider._(
-        argument: argument as (
-          BuildContext, {
-          BuildContext context2,
-        }),
-        from: from! as FnFamily,
-        create: (
-          ref,
-          BuildContext context1, {
-          required BuildContext context2,
-        }) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? fn;
-    final argument = this.argument as (
-      BuildContext, {
-      BuildContext context2,
-    });
-    return _$cb(
-      ref,
-      argument.$1,
-      context2: argument.context2,
     );
   }
 
@@ -128,37 +95,29 @@ final class FnFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$fnHash();
-
-  @override
   String toString() => r'fnProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      (
-        BuildContext, {
-        BuildContext context2,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FnProvider;
-
-        final argument = provider.argument as (
-          BuildContext, {
-          BuildContext context2,
-        });
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            (
+              BuildContext, {
+              BuildContext context2,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FnProvider;
+            final argument = provider.argument as (
+              BuildContext, {
+              BuildContext context2,
+            });
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(MyNotifier)
@@ -171,19 +130,14 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
         BuildContext, {
         BuildContext context2,
       })
-          super.argument,
-      super.runNotifierBuildOverride,
-      MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'myNotifierProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final MyNotifier Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
@@ -195,6 +149,16 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
         '$argument';
   }
 
+  @$internal
+  @override
+  MyNotifier create() => MyNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<MyNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
@@ -202,47 +166,6 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(
-        argument: argument as (
-          BuildContext, {
-          BuildContext context2,
-        }),
-        from: from! as MyNotifierFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(
-        argument: argument as (
-          BuildContext, {
-          BuildContext context2,
-        }),
-        from: from! as MyNotifierFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<MyNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -277,64 +200,53 @@ final class MyNotifierFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$myNotifierHash();
-
-  @override
   String toString() => r'myNotifierProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    MyNotifier Function(
-      (
-        BuildContext, {
-        BuildContext context2,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as MyNotifierProvider;
-
-        final argument = provider.argument as (
-          BuildContext, {
-          BuildContext context2,
-        });
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-    int Function(
-            Ref ref,
-            MyNotifier notifier,
+          MyNotifier Function(
             (
               BuildContext, {
               BuildContext context2,
-            }) argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as MyNotifierProvider;
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as MyNotifierProvider;
+            final argument = provider.argument as (
+              BuildContext, {
+              BuildContext context2,
+            });
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
-        final argument = provider.argument as (
-          BuildContext, {
-          BuildContext context2,
-        });
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+  /// {@macro riverpod.override_with_build}
+  Override overrideWithBuild(
+          int Function(
+                  Ref ref,
+                  MyNotifier notifier,
+                  (
+                    BuildContext, {
+                    BuildContext context2,
+                  }) argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as MyNotifierProvider;
+            final argument = provider.argument as (
+              BuildContext, {
+              BuildContext context2,
+            });
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$MyNotifier extends $Notifier<int> {
@@ -369,10 +281,8 @@ const regression2959Provider = Regression2959Provider._();
 
 final class Regression2959Provider
     extends $NotifierProvider<Regression2959, void> {
-  const Regression2959Provider._(
-      {super.runNotifierBuildOverride, Regression2959 Function()? create})
-      : _createCb = create,
-        super(
+  const Regression2959Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -382,10 +292,18 @@ final class Regression2959Provider
           allTransitiveDependencies: null,
         );
 
-  final Regression2959 Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$regression2959Hash();
+
+  @$internal
+  @override
+  Regression2959 create() => Regression2959();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Regression2959, void> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(void value) {
@@ -394,35 +312,6 @@ final class Regression2959Provider
       providerOverride: $ValueProvider<void>(value),
     );
   }
-
-  @$internal
-  @override
-  Regression2959 create() => _createCb?.call() ?? Regression2959();
-
-  @$internal
-  @override
-  Regression2959Provider $copyWithCreate(
-    Regression2959 Function() create,
-  ) {
-    return Regression2959Provider._(create: create);
-  }
-
-  @$internal
-  @override
-  Regression2959Provider $copyWithBuild(
-    void Function(
-      Ref,
-      Regression2959,
-    ) build,
-  ) {
-    return Regression2959Provider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Regression2959, void> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$regression2959Hash() => r'e58855125577a855d642da1ef85f35178ad95afd';

--- a/packages/riverpod_lint_flutter_test/test/lints/avoid_public_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/avoid_public_notifier_properties.g.dart
@@ -13,19 +13,14 @@ final class GeneratedNotifierProvider
     extends $NotifierProvider<GeneratedNotifier, int> {
   const GeneratedNotifierProvider._(
       {required GeneratedNotifierFamily super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      GeneratedNotifier Function()? create})
-      : _createCb = create,
-        super(
+      required int super.argument})
+      : super(
           retry: null,
           name: r'generatedNotifierProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final GeneratedNotifier Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$generatedNotifierHash();
@@ -37,6 +32,16 @@ final class GeneratedNotifierProvider
         '($argument)';
   }
 
+  @$internal
+  @override
+  GeneratedNotifier create() => GeneratedNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<GeneratedNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
@@ -44,41 +49,6 @@ final class GeneratedNotifierProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  GeneratedNotifier create() => _createCb?.call() ?? GeneratedNotifier();
-
-  @$internal
-  @override
-  GeneratedNotifierProvider $copyWithCreate(
-    GeneratedNotifier Function() create,
-  ) {
-    return GeneratedNotifierProvider._(
-        argument: argument as int,
-        from: from! as GeneratedNotifierFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  GeneratedNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      GeneratedNotifier,
-    ) build,
-  ) {
-    return GeneratedNotifierProvider._(
-        argument: argument as int,
-        from: from! as GeneratedNotifierFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<GeneratedNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -109,48 +79,38 @@ final class GeneratedNotifierFamily extends Family {
       GeneratedNotifierProvider._(argument: param, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$generatedNotifierHash();
-
-  @override
   String toString() => r'generatedNotifierProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    GeneratedNotifier Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GeneratedNotifierProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          GeneratedNotifier Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GeneratedNotifierProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function(Ref ref, GeneratedNotifier notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GeneratedNotifierProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(Ref ref, GeneratedNotifier notifier, int argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GeneratedNotifierProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$GeneratedNotifier extends $Notifier<int> {

--- a/packages/riverpod_lint_flutter_test/test/lints/functional_ref/functional_ref.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/functional_ref/functional_ref.g.dart
@@ -11,12 +11,8 @@ const namelessProvider = NamelessProvider._();
 
 final class NamelessProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const NamelessProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const NamelessProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class NamelessProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$namelessHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return nameless(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class NamelessProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  NamelessProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return NamelessProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? nameless;
-    return _$cb(ref);
   }
 }
 
@@ -69,13 +51,8 @@ const genericsProvider = GenericsFamily._();
 
 final class GenericsProvider<A extends num, B>
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const GenericsProvider._(
-      {required GenericsFamily super.from,
-      int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const GenericsProvider._({required GenericsFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'genericsProvider',
@@ -84,21 +61,8 @@ final class GenericsProvider<A extends num, B>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericsHash();
-
-  GenericsProvider<A, B> _copyWithCreate(
-    int Function<A extends num, B>(
-      Ref ref,
-    ) create,
-  ) {
-    return GenericsProvider<A, B>._(
-        from: from! as GenericsFamily, create: create<A, B>);
-  }
 
   @override
   String toString() {
@@ -107,33 +71,26 @@ final class GenericsProvider<A extends num, B>
         '()';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return generics<A, B>(ref);
+  }
+
+  $R _captureGenerics<$R>($R Function<A extends num, B>() cb) {
+    return cb<A, B>();
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  GenericsProvider<A, B> $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return GenericsProvider<A, B>._(
-        from: from! as GenericsFamily, create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? generics<A, B>;
-    return _$cb(ref);
   }
 
   @override
@@ -165,24 +122,21 @@ final class GenericsFamily extends Family {
       GenericsProvider<A, B>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$genericsHash();
-
-  @override
   String toString() => r'genericsProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    int Function<A extends num, B>(Ref ref) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericsProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(int Function<A extends num, B>(Ref ref) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericsProvider;
+            return provider._captureGenerics(<A extends num, B>() {
+              provider as GenericsProvider<A, B>;
+              return provider
+                  .$view(create: create<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 @ProviderFor(valid)
@@ -190,12 +144,8 @@ const validProvider = ValidProvider._();
 
 final class ValidProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const ValidProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ValidProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -205,12 +155,18 @@ final class ValidProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$validHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return valid(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -218,26 +174,6 @@ final class ValidProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ValidProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ValidProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? valid;
-    return _$cb(ref);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.g.dart
@@ -10,10 +10,8 @@ part of 'notifier_extends.dart';
 const myNotifierProvider = MyNotifierProvider._();
 
 final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
-  const MyNotifierProvider._(
-      {super.runNotifierBuildOverride, MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const MyNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -23,10 +21,18 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
+
+  @$internal
+  @override
+  MyNotifier create() => MyNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<MyNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -35,35 +41,6 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<MyNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$myNotifierHash() => r'58f5439a3b1036ba7804f63a5a6ebe0114125039';
@@ -86,10 +63,8 @@ const _privateClassProvider = _PrivateClassProvider._();
 
 final class _PrivateClassProvider
     extends $NotifierProvider<_PrivateClass, String> {
-  const _PrivateClassProvider._(
-      {super.runNotifierBuildOverride, _PrivateClass Function()? create})
-      : _createCb = create,
-        super(
+  const _PrivateClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -99,10 +74,18 @@ final class _PrivateClassProvider
           allTransitiveDependencies: null,
         );
 
-  final _PrivateClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$privateClassHash();
+
+  @$internal
+  @override
+  _PrivateClass create() => _PrivateClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<_PrivateClass, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -111,35 +94,6 @@ final class _PrivateClassProvider
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  _PrivateClass create() => _createCb?.call() ?? _PrivateClass();
-
-  @$internal
-  @override
-  _PrivateClassProvider $copyWithCreate(
-    _PrivateClass Function() create,
-  ) {
-    return _PrivateClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  _PrivateClassProvider $copyWithBuild(
-    String Function(
-      Ref,
-      _PrivateClass,
-    ) build,
-  ) {
-    return _PrivateClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<_PrivateClass, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$privateClassHash() => r'ba68a29a609566bb8bc0792391f842762356e124';
@@ -162,12 +116,8 @@ const genericsProvider = GenericsFamily._();
 
 final class GenericsProvider<A extends num, B>
     extends $NotifierProvider<Generics<A, B>, int> {
-  const GenericsProvider._(
-      {required GenericsFamily super.from,
-      super.runNotifierBuildOverride,
-      Generics<A, B> Function()? create})
-      : _createCb = create,
-        super(
+  const GenericsProvider._({required GenericsFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'genericsProvider',
@@ -176,33 +126,28 @@ final class GenericsProvider<A extends num, B>
           allTransitiveDependencies: null,
         );
 
-  final Generics<A, B> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$genericsHash();
-
-  GenericsProvider<A, B> _copyWithCreate(
-    Generics<A, B> Function<A extends num, B>() create,
-  ) {
-    return GenericsProvider<A, B>._(
-        from: from! as GenericsFamily, create: create<A, B>);
-  }
-
-  GenericsProvider<A, B> _copyWithBuild(
-    int Function<A extends num, B>(
-      Ref,
-      Generics<A, B>,
-    ) build,
-  ) {
-    return GenericsProvider<A, B>._(
-        from: from! as GenericsFamily, runNotifierBuildOverride: build<A, B>);
-  }
 
   @override
   String toString() {
     return r'genericsProvider'
         '<${A}, ${B}>'
         '()';
+  }
+
+  @$internal
+  @override
+  Generics<A, B> create() => Generics<A, B>();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Generics<A, B>, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<A extends num, B>() cb) {
+    return cb<A, B>();
   }
 
   /// {@macro riverpod.override_with_value}
@@ -212,37 +157,6 @@ final class GenericsProvider<A extends num, B>
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Generics<A, B> create() => _createCb?.call() ?? Generics<A, B>();
-
-  @$internal
-  @override
-  GenericsProvider<A, B> $copyWithCreate(
-    Generics<A, B> Function() create,
-  ) {
-    return GenericsProvider<A, B>._(
-        from: from! as GenericsFamily, create: create);
-  }
-
-  @$internal
-  @override
-  GenericsProvider<A, B> $copyWithBuild(
-    int Function(
-      Ref,
-      Generics<A, B>,
-    ) build,
-  ) {
-    return GenericsProvider<A, B>._(
-        from: from! as GenericsFamily, runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Generics<A, B>, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -273,38 +187,37 @@ final class GenericsFamily extends Family {
       GenericsProvider<A, B>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$genericsHash();
-
-  @override
   String toString() => r'genericsProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    Generics<A, B> Function<A extends num, B>() create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericsProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(Generics<A, B> Function<A extends num, B>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericsProvider;
+            return provider._captureGenerics(<A extends num, B>() {
+              provider as GenericsProvider<A, B>;
+              return provider
+                  .$view(create: create<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function<A extends num, B>(Ref ref, Generics<A, B> notifier) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GenericsProvider;
-
-        return provider._copyWithBuild(build).$createElement(pointer);
-      },
-    );
-  }
+          int Function<A extends num, B>(Ref ref, Generics<A, B> notifier)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericsProvider;
+            return provider._captureGenerics(<A extends num, B>() {
+              provider as GenericsProvider<A, B>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$Generics<A extends num, B> extends $Notifier<int> {
@@ -325,12 +238,8 @@ const noGenericsProvider = NoGenericsFamily._();
 
 final class NoGenericsProvider<A extends num, B>
     extends $NotifierProvider<NoGenerics<A, B>, int> {
-  const NoGenericsProvider._(
-      {required NoGenericsFamily super.from,
-      super.runNotifierBuildOverride,
-      NoGenerics<A, B> Function()? create})
-      : _createCb = create,
-        super(
+  const NoGenericsProvider._({required NoGenericsFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'noGenericsProvider',
@@ -339,33 +248,28 @@ final class NoGenericsProvider<A extends num, B>
           allTransitiveDependencies: null,
         );
 
-  final NoGenerics<A, B> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$noGenericsHash();
-
-  NoGenericsProvider<A, B> _copyWithCreate(
-    NoGenerics<A, B> Function<A extends num, B>() create,
-  ) {
-    return NoGenericsProvider<A, B>._(
-        from: from! as NoGenericsFamily, create: create<A, B>);
-  }
-
-  NoGenericsProvider<A, B> _copyWithBuild(
-    int Function<A extends num, B>(
-      Ref,
-      NoGenerics<A, B>,
-    ) build,
-  ) {
-    return NoGenericsProvider<A, B>._(
-        from: from! as NoGenericsFamily, runNotifierBuildOverride: build<A, B>);
-  }
 
   @override
   String toString() {
     return r'noGenericsProvider'
         '<${A}, ${B}>'
         '()';
+  }
+
+  @$internal
+  @override
+  NoGenerics<A, B> create() => NoGenerics<A, B>();
+
+  @$internal
+  @override
+  $NotifierProviderElement<NoGenerics<A, B>, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<A extends num, B>() cb) {
+    return cb<A, B>();
   }
 
   /// {@macro riverpod.override_with_value}
@@ -375,37 +279,6 @@ final class NoGenericsProvider<A extends num, B>
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  NoGenerics<A, B> create() => _createCb?.call() ?? NoGenerics<A, B>();
-
-  @$internal
-  @override
-  NoGenericsProvider<A, B> $copyWithCreate(
-    NoGenerics<A, B> Function() create,
-  ) {
-    return NoGenericsProvider<A, B>._(
-        from: from! as NoGenericsFamily, create: create);
-  }
-
-  @$internal
-  @override
-  NoGenericsProvider<A, B> $copyWithBuild(
-    int Function(
-      Ref,
-      NoGenerics<A, B>,
-    ) build,
-  ) {
-    return NoGenericsProvider<A, B>._(
-        from: from! as NoGenericsFamily, runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<NoGenerics<A, B>, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -436,38 +309,37 @@ final class NoGenericsFamily extends Family {
       NoGenericsProvider<A, B>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$noGenericsHash();
-
-  @override
   String toString() => r'noGenericsProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    NoGenerics<A, B> Function<A extends num, B>() create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as NoGenericsProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(NoGenerics<A, B> Function<A extends num, B>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as NoGenericsProvider;
+            return provider._captureGenerics(<A extends num, B>() {
+              provider as NoGenericsProvider<A, B>;
+              return provider
+                  .$view(create: create<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function<A extends num, B>(Ref ref, NoGenerics<A, B> notifier) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as NoGenericsProvider;
-
-        return provider._copyWithBuild(build).$createElement(pointer);
-      },
-    );
-  }
+          int Function<A extends num, B>(Ref ref, NoGenerics<A, B> notifier)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as NoGenericsProvider;
+            return provider._captureGenerics(<A extends num, B>() {
+              provider as NoGenericsProvider<A, B>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$NoGenerics<A extends num, B> extends $Notifier<int> {
@@ -488,12 +360,8 @@ const missingGenericsProvider = MissingGenericsFamily._();
 
 final class MissingGenericsProvider<A, B>
     extends $NotifierProvider<MissingGenerics<A, B>, int> {
-  const MissingGenericsProvider._(
-      {required MissingGenericsFamily super.from,
-      super.runNotifierBuildOverride,
-      MissingGenerics<A, B> Function()? create})
-      : _createCb = create,
-        super(
+  const MissingGenericsProvider._({required MissingGenericsFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'missingGenericsProvider',
@@ -502,34 +370,28 @@ final class MissingGenericsProvider<A, B>
           allTransitiveDependencies: null,
         );
 
-  final MissingGenerics<A, B> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$missingGenericsHash();
-
-  MissingGenericsProvider<A, B> _copyWithCreate(
-    MissingGenerics<A, B> Function<A, B>() create,
-  ) {
-    return MissingGenericsProvider<A, B>._(
-        from: from! as MissingGenericsFamily, create: create<A, B>);
-  }
-
-  MissingGenericsProvider<A, B> _copyWithBuild(
-    int Function<A, B>(
-      Ref,
-      MissingGenerics<A, B>,
-    ) build,
-  ) {
-    return MissingGenericsProvider<A, B>._(
-        from: from! as MissingGenericsFamily,
-        runNotifierBuildOverride: build<A, B>);
-  }
 
   @override
   String toString() {
     return r'missingGenericsProvider'
         '<${A}, ${B}>'
         '()';
+  }
+
+  @$internal
+  @override
+  MissingGenerics<A, B> create() => MissingGenerics<A, B>();
+
+  @$internal
+  @override
+  $NotifierProviderElement<MissingGenerics<A, B>, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<A, B>() cb) {
+    return cb<A, B>();
   }
 
   /// {@macro riverpod.override_with_value}
@@ -539,38 +401,6 @@ final class MissingGenericsProvider<A, B>
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  MissingGenerics<A, B> create() =>
-      _createCb?.call() ?? MissingGenerics<A, B>();
-
-  @$internal
-  @override
-  MissingGenericsProvider<A, B> $copyWithCreate(
-    MissingGenerics<A, B> Function() create,
-  ) {
-    return MissingGenericsProvider<A, B>._(
-        from: from! as MissingGenericsFamily, create: create);
-  }
-
-  @$internal
-  @override
-  MissingGenericsProvider<A, B> $copyWithBuild(
-    int Function(
-      Ref,
-      MissingGenerics<A, B>,
-    ) build,
-  ) {
-    return MissingGenericsProvider<A, B>._(
-        from: from! as MissingGenericsFamily, runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<MissingGenerics<A, B>, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -601,38 +431,36 @@ final class MissingGenericsFamily extends Family {
       MissingGenericsProvider<A, B>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$missingGenericsHash();
-
-  @override
   String toString() => r'missingGenericsProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    MissingGenerics<A, B> Function<A, B>() create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as MissingGenericsProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(MissingGenerics<A, B> Function<A, B>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as MissingGenericsProvider;
+            return provider._captureGenerics(<A, B>() {
+              provider as MissingGenericsProvider<A, B>;
+              return provider
+                  .$view(create: create<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function<A, B>(Ref ref, MissingGenerics<A, B> notifier) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as MissingGenericsProvider;
-
-        return provider._copyWithBuild(build).$createElement(pointer);
-      },
-    );
-  }
+          int Function<A, B>(Ref ref, MissingGenerics<A, B> notifier) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as MissingGenericsProvider;
+            return provider._captureGenerics(<A, B>() {
+              provider as MissingGenericsProvider<A, B>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$MissingGenerics<A, B> extends $Notifier<int> {
@@ -653,12 +481,8 @@ const wrongOrderProvider = WrongOrderFamily._();
 
 final class WrongOrderProvider<A, B>
     extends $NotifierProvider<WrongOrder<A, B>, int> {
-  const WrongOrderProvider._(
-      {required WrongOrderFamily super.from,
-      super.runNotifierBuildOverride,
-      WrongOrder<A, B> Function()? create})
-      : _createCb = create,
-        super(
+  const WrongOrderProvider._({required WrongOrderFamily super.from})
+      : super(
           argument: null,
           retry: null,
           name: r'wrongOrderProvider',
@@ -667,33 +491,28 @@ final class WrongOrderProvider<A, B>
           allTransitiveDependencies: null,
         );
 
-  final WrongOrder<A, B> Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$wrongOrderHash();
-
-  WrongOrderProvider<A, B> _copyWithCreate(
-    WrongOrder<A, B> Function<A, B>() create,
-  ) {
-    return WrongOrderProvider<A, B>._(
-        from: from! as WrongOrderFamily, create: create<A, B>);
-  }
-
-  WrongOrderProvider<A, B> _copyWithBuild(
-    int Function<A, B>(
-      Ref,
-      WrongOrder<A, B>,
-    ) build,
-  ) {
-    return WrongOrderProvider<A, B>._(
-        from: from! as WrongOrderFamily, runNotifierBuildOverride: build<A, B>);
-  }
 
   @override
   String toString() {
     return r'wrongOrderProvider'
         '<${A}, ${B}>'
         '()';
+  }
+
+  @$internal
+  @override
+  WrongOrder<A, B> create() => WrongOrder<A, B>();
+
+  @$internal
+  @override
+  $NotifierProviderElement<WrongOrder<A, B>, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<A, B>() cb) {
+    return cb<A, B>();
   }
 
   /// {@macro riverpod.override_with_value}
@@ -703,37 +522,6 @@ final class WrongOrderProvider<A, B>
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  WrongOrder<A, B> create() => _createCb?.call() ?? WrongOrder<A, B>();
-
-  @$internal
-  @override
-  WrongOrderProvider<A, B> $copyWithCreate(
-    WrongOrder<A, B> Function() create,
-  ) {
-    return WrongOrderProvider<A, B>._(
-        from: from! as WrongOrderFamily, create: create);
-  }
-
-  @$internal
-  @override
-  WrongOrderProvider<A, B> $copyWithBuild(
-    int Function(
-      Ref,
-      WrongOrder<A, B>,
-    ) build,
-  ) {
-    return WrongOrderProvider<A, B>._(
-        from: from! as WrongOrderFamily, runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<WrongOrder<A, B>, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -764,38 +552,36 @@ final class WrongOrderFamily extends Family {
       WrongOrderProvider<A, B>._(from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$wrongOrderHash();
-
-  @override
   String toString() => r'wrongOrderProvider';
 
   /// {@macro riverpod.override_with}
-  Override overrideWith(
-    WrongOrder<A, B> Function<A, B>() create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as WrongOrderProvider;
-
-        return provider._copyWithCreate(create).$createElement(pointer);
-      },
-    );
-  }
+  Override overrideWith(WrongOrder<A, B> Function<A, B>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as WrongOrderProvider;
+            return provider._captureGenerics(<A, B>() {
+              provider as WrongOrderProvider<A, B>;
+              return provider
+                  .$view(create: create<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function<A, B>(Ref ref, WrongOrder<A, B> notifier) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as WrongOrderProvider;
-
-        return provider._copyWithBuild(build).$createElement(pointer);
-      },
-    );
-  }
+          int Function<A, B>(Ref ref, WrongOrder<A, B> notifier) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as WrongOrderProvider;
+            return provider._captureGenerics(<A, B>() {
+              provider as WrongOrderProvider<A, B>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<A, B>)
+                  .$createElement(pointer);
+            });
+          });
 }
 
 abstract class _$WrongOrder<A, B> extends $Notifier<int> {

--- a/packages/riverpod_lint_flutter_test/test/lints/only_use_keep_alive_inside_keep_alive.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/only_use_keep_alive_inside_keep_alive.g.dart
@@ -11,12 +11,8 @@ const keepAliveProvider = KeepAliveProvider._();
 
 final class KeepAliveProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const KeepAliveProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const KeepAliveProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class KeepAliveProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$keepAliveHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return keepAlive(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class KeepAliveProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  KeepAliveProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return KeepAliveProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? keepAlive;
-    return _$cb(ref);
   }
 }
 
@@ -69,10 +51,8 @@ const keepAliveClassProvider = KeepAliveClassProvider._();
 
 final class KeepAliveClassProvider
     extends $NotifierProvider<KeepAliveClass, int> {
-  const KeepAliveClassProvider._(
-      {super.runNotifierBuildOverride, KeepAliveClass Function()? create})
-      : _createCb = create,
-        super(
+  const KeepAliveClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -82,10 +62,18 @@ final class KeepAliveClassProvider
           allTransitiveDependencies: null,
         );
 
-  final KeepAliveClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$keepAliveClassHash();
+
+  @$internal
+  @override
+  KeepAliveClass create() => KeepAliveClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<KeepAliveClass, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -94,35 +82,6 @@ final class KeepAliveClassProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  KeepAliveClass create() => _createCb?.call() ?? KeepAliveClass();
-
-  @$internal
-  @override
-  KeepAliveClassProvider $copyWithCreate(
-    KeepAliveClass Function() create,
-  ) {
-    return KeepAliveClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  KeepAliveClassProvider $copyWithBuild(
-    int Function(
-      Ref,
-      KeepAliveClass,
-    ) build,
-  ) {
-    return KeepAliveClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<KeepAliveClass, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$keepAliveClassHash() => r'e2fffa4d14837dfef71f6a2cc230b826b82541ea';
@@ -145,12 +104,8 @@ const autoDisposeProvider = AutoDisposeProvider._();
 
 final class AutoDisposeProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const AutoDisposeProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AutoDisposeProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -160,12 +115,18 @@ final class AutoDisposeProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$autoDisposeHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return autoDispose(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -173,26 +134,6 @@ final class AutoDisposeProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AutoDisposeProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AutoDisposeProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? autoDispose;
-    return _$cb(ref);
   }
 }
 
@@ -203,10 +144,8 @@ const autoDisposeClassProvider = AutoDisposeClassProvider._();
 
 final class AutoDisposeClassProvider
     extends $NotifierProvider<AutoDisposeClass, int> {
-  const AutoDisposeClassProvider._(
-      {super.runNotifierBuildOverride, AutoDisposeClass Function()? create})
-      : _createCb = create,
-        super(
+  const AutoDisposeClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -216,10 +155,18 @@ final class AutoDisposeClassProvider
           allTransitiveDependencies: null,
         );
 
-  final AutoDisposeClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$autoDisposeClassHash();
+
+  @$internal
+  @override
+  AutoDisposeClass create() => AutoDisposeClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<AutoDisposeClass, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -228,35 +175,6 @@ final class AutoDisposeClassProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  AutoDisposeClass create() => _createCb?.call() ?? AutoDisposeClass();
-
-  @$internal
-  @override
-  AutoDisposeClassProvider $copyWithCreate(
-    AutoDisposeClass Function() create,
-  ) {
-    return AutoDisposeClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  AutoDisposeClassProvider $copyWithBuild(
-    int Function(
-      Ref,
-      AutoDisposeClass,
-    ) build,
-  ) {
-    return AutoDisposeClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<AutoDisposeClass, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$autoDisposeClassHash() => r'5127ab94f7ab4ccf90deb3fca90d7a3c3c4c83f5';
@@ -279,12 +197,8 @@ const fnProvider = FnProvider._();
 
 final class FnProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const FnProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FnProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -294,12 +208,18 @@ final class FnProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$fnHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return fn(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -307,26 +227,6 @@ final class FnProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FnProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FnProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? fn;
-    return _$cb(ref);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
@@ -10,9 +10,8 @@ part of 'protected_notifier_properties.dart';
 const aProvider = AProvider._();
 
 final class AProvider extends $NotifierProvider<A, int> {
-  const AProvider._({super.runNotifierBuildOverride, A Function()? create})
-      : _createCb = create,
-        super(
+  const AProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -22,10 +21,17 @@ final class AProvider extends $NotifierProvider<A, int> {
           allTransitiveDependencies: null,
         );
 
-  final A Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$aHash();
+
+  @$internal
+  @override
+  A create() => A();
+
+  @$internal
+  @override
+  $NotifierProviderElement<A, int> $createElement($ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -34,34 +40,6 @@ final class AProvider extends $NotifierProvider<A, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  A create() => _createCb?.call() ?? A();
-
-  @$internal
-  @override
-  AProvider $copyWithCreate(
-    A Function() create,
-  ) {
-    return AProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  AProvider $copyWithBuild(
-    int Function(
-      Ref,
-      A,
-    ) build,
-  ) {
-    return AProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<A, int> $createElement($ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$aHash() => r'9bf449b010f4dd5800e78f9f5b8a431b1a79c8b7';
@@ -83,9 +61,8 @@ abstract class _$A extends $Notifier<int> {
 const a2Provider = A2Provider._();
 
 final class A2Provider extends $NotifierProvider<A2, int> {
-  const A2Provider._({super.runNotifierBuildOverride, A2 Function()? create})
-      : _createCb = create,
-        super(
+  const A2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -95,10 +72,17 @@ final class A2Provider extends $NotifierProvider<A2, int> {
           allTransitiveDependencies: null,
         );
 
-  final A2 Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$a2Hash();
+
+  @$internal
+  @override
+  A2 create() => A2();
+
+  @$internal
+  @override
+  $NotifierProviderElement<A2, int> $createElement($ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -107,34 +91,6 @@ final class A2Provider extends $NotifierProvider<A2, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  A2 create() => _createCb?.call() ?? A2();
-
-  @$internal
-  @override
-  A2Provider $copyWithCreate(
-    A2 Function() create,
-  ) {
-    return A2Provider._(create: create);
-  }
-
-  @$internal
-  @override
-  A2Provider $copyWithBuild(
-    int Function(
-      Ref,
-      A2,
-    ) build,
-  ) {
-    return A2Provider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<A2, int> $createElement($ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$a2Hash() => r'898d46cbcec03233c7b8b0754810a6903226aa2e';
@@ -157,20 +113,14 @@ const a3Provider = A3Family._();
 
 final class A3Provider extends $NotifierProvider<A3, int> {
   const A3Provider._(
-      {required A3Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      A3 Function()? create})
-      : _createCb = create,
-        super(
+      {required A3Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'a3Provider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final A3 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$a3Hash();
@@ -182,6 +132,15 @@ final class A3Provider extends $NotifierProvider<A3, int> {
         '($argument)';
   }
 
+  @$internal
+  @override
+  A3 create() => A3();
+
+  @$internal
+  @override
+  $NotifierProviderElement<A3, int> $createElement($ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
@@ -189,38 +148,6 @@ final class A3Provider extends $NotifierProvider<A3, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  A3 create() => _createCb?.call() ?? A3();
-
-  @$internal
-  @override
-  A3Provider $copyWithCreate(
-    A3 Function() create,
-  ) {
-    return A3Provider._(
-        argument: argument as int, from: from! as A3Family, create: create);
-  }
-
-  @$internal
-  @override
-  A3Provider $copyWithBuild(
-    int Function(
-      Ref,
-      A3,
-    ) build,
-  ) {
-    return A3Provider._(
-        argument: argument as int,
-        from: from! as A3Family,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<A3, int> $createElement($ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -251,48 +178,37 @@ final class A3Family extends Family {
       A3Provider._(argument: param, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$a3Hash();
-
-  @override
   String toString() => r'a3Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    A3 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A3Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          A3 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A3Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function(Ref ref, A3 notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A3Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(Ref ref, A3 notifier, int argument) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A3Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$A3 extends $Notifier<int> {
@@ -320,20 +236,14 @@ const a4Provider = A4Family._();
 
 final class A4Provider extends $NotifierProvider<A4, int> {
   const A4Provider._(
-      {required A4Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      A4 Function()? create})
-      : _createCb = create,
-        super(
+      {required A4Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'a4Provider',
           isAutoDispose: false,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final A4 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$a4Hash();
@@ -345,6 +255,15 @@ final class A4Provider extends $NotifierProvider<A4, int> {
         '($argument)';
   }
 
+  @$internal
+  @override
+  A4 create() => A4();
+
+  @$internal
+  @override
+  $NotifierProviderElement<A4, int> $createElement($ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
@@ -352,38 +271,6 @@ final class A4Provider extends $NotifierProvider<A4, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  A4 create() => _createCb?.call() ?? A4();
-
-  @$internal
-  @override
-  A4Provider $copyWithCreate(
-    A4 Function() create,
-  ) {
-    return A4Provider._(
-        argument: argument as int, from: from! as A4Family, create: create);
-  }
-
-  @$internal
-  @override
-  A4Provider $copyWithBuild(
-    int Function(
-      Ref,
-      A4,
-    ) build,
-  ) {
-    return A4Provider._(
-        argument: argument as int,
-        from: from! as A4Family,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<A4, int> $createElement($ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -414,48 +301,37 @@ final class A4Family extends Family {
       A4Provider._(argument: param, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$a4Hash();
-
-  @override
   String toString() => r'a4Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    A4 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A4Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          A4 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A4Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    int Function(Ref ref, A4 notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A4Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(Ref ref, A4 notifier, int argument) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A4Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$A4 extends $Notifier<int> {
@@ -483,20 +359,14 @@ const a5Provider = A5Family._();
 
 final class A5Provider extends $AsyncNotifierProvider<A5, int> {
   const A5Provider._(
-      {required A5Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      A5 Function()? create})
-      : _createCb = create,
-        super(
+      {required A5Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'a5Provider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final A5 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$a5Hash();
@@ -510,36 +380,21 @@ final class A5Provider extends $AsyncNotifierProvider<A5, int> {
 
   @$internal
   @override
-  A5 create() => _createCb?.call() ?? A5();
-
-  @$internal
-  @override
-  A5Provider $copyWithCreate(
-    A5 Function() create,
-  ) {
-    return A5Provider._(
-        argument: argument as int, from: from! as A5Family, create: create);
-  }
-
-  @$internal
-  @override
-  A5Provider $copyWithBuild(
-    FutureOr<int> Function(
-      Ref,
-      A5,
-    ) build,
-  ) {
-    return A5Provider._(
-        argument: argument as int,
-        from: from! as A5Family,
-        runNotifierBuildOverride: build);
-  }
+  A5 create() => A5();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<A5, int> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -570,48 +425,37 @@ final class A5Family extends Family {
       A5Provider._(argument: param, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$a5Hash();
-
-  @override
   String toString() => r'a5Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    A5 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A5Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          A5 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A5Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    FutureOr<int> Function(Ref ref, A5 notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A5Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<int> Function(Ref ref, A5 notifier, int argument) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A5Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$A5 extends $AsyncNotifier<int> {
@@ -639,20 +483,14 @@ const a6Provider = A6Family._();
 
 final class A6Provider extends $AsyncNotifierProvider<A6, int> {
   const A6Provider._(
-      {required A6Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      A6 Function()? create})
-      : _createCb = create,
-        super(
+      {required A6Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'a6Provider',
           isAutoDispose: false,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final A6 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$a6Hash();
@@ -666,36 +504,21 @@ final class A6Provider extends $AsyncNotifierProvider<A6, int> {
 
   @$internal
   @override
-  A6 create() => _createCb?.call() ?? A6();
-
-  @$internal
-  @override
-  A6Provider $copyWithCreate(
-    A6 Function() create,
-  ) {
-    return A6Provider._(
-        argument: argument as int, from: from! as A6Family, create: create);
-  }
-
-  @$internal
-  @override
-  A6Provider $copyWithBuild(
-    FutureOr<int> Function(
-      Ref,
-      A6,
-    ) build,
-  ) {
-    return A6Provider._(
-        argument: argument as int,
-        from: from! as A6Family,
-        runNotifierBuildOverride: build);
-  }
+  A6 create() => A6();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<A6, int> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -726,48 +549,37 @@ final class A6Family extends Family {
       A6Provider._(argument: param, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$a6Hash();
-
-  @override
   String toString() => r'a6Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    A6 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A6Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          A6 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A6Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    FutureOr<int> Function(Ref ref, A6 notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A6Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<int> Function(Ref ref, A6 notifier, int argument) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A6Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$A6 extends $AsyncNotifier<int> {
@@ -795,20 +607,14 @@ const a7Provider = A7Family._();
 
 final class A7Provider extends $StreamNotifierProvider<A7, int> {
   const A7Provider._(
-      {required A7Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      A7 Function()? create})
-      : _createCb = create,
-        super(
+      {required A7Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'a7Provider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final A7 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$a7Hash();
@@ -822,36 +628,21 @@ final class A7Provider extends $StreamNotifierProvider<A7, int> {
 
   @$internal
   @override
-  A7 create() => _createCb?.call() ?? A7();
-
-  @$internal
-  @override
-  A7Provider $copyWithCreate(
-    A7 Function() create,
-  ) {
-    return A7Provider._(
-        argument: argument as int, from: from! as A7Family, create: create);
-  }
-
-  @$internal
-  @override
-  A7Provider $copyWithBuild(
-    Stream<int> Function(
-      Ref,
-      A7,
-    ) build,
-  ) {
-    return A7Provider._(
-        argument: argument as int,
-        from: from! as A7Family,
-        runNotifierBuildOverride: build);
-  }
+  A7 create() => A7();
 
   @$internal
   @override
   $StreamNotifierProviderElement<A7, int> $createElement(
           $ProviderPointer pointer) =>
-      $StreamNotifierProviderElement(this, pointer);
+      $StreamNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -882,48 +673,37 @@ final class A7Family extends Family {
       A7Provider._(argument: param, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$a7Hash();
-
-  @override
   String toString() => r'a7Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    A7 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A7Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          A7 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A7Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    Stream<int> Function(Ref ref, A7 notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A7Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Stream<int> Function(Ref ref, A7 notifier, int argument) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A7Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$A7 extends $StreamNotifier<int> {
@@ -951,20 +731,14 @@ const a8Provider = A8Family._();
 
 final class A8Provider extends $StreamNotifierProvider<A8, int> {
   const A8Provider._(
-      {required A8Family super.from,
-      required int super.argument,
-      super.runNotifierBuildOverride,
-      A8 Function()? create})
-      : _createCb = create,
-        super(
+      {required A8Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'a8Provider',
           isAutoDispose: false,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final A8 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$a8Hash();
@@ -978,36 +752,21 @@ final class A8Provider extends $StreamNotifierProvider<A8, int> {
 
   @$internal
   @override
-  A8 create() => _createCb?.call() ?? A8();
-
-  @$internal
-  @override
-  A8Provider $copyWithCreate(
-    A8 Function() create,
-  ) {
-    return A8Provider._(
-        argument: argument as int, from: from! as A8Family, create: create);
-  }
-
-  @$internal
-  @override
-  A8Provider $copyWithBuild(
-    Stream<int> Function(
-      Ref,
-      A8,
-    ) build,
-  ) {
-    return A8Provider._(
-        argument: argument as int,
-        from: from! as A8Family,
-        runNotifierBuildOverride: build);
-  }
+  A8 create() => A8();
 
   @$internal
   @override
   $StreamNotifierProviderElement<A8, int> $createElement(
           $ProviderPointer pointer) =>
-      $StreamNotifierProviderElement(this, pointer);
+      $StreamNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -1038,48 +797,37 @@ final class A8Family extends Family {
       A8Provider._(argument: param, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$a8Hash();
-
-  @override
   String toString() => r'a8Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    A8 Function(
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A8Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          A8 Function(
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A8Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    Stream<int> Function(Ref ref, A8 notifier, int argument) build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as A8Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          Stream<int> Function(Ref ref, A8 notifier, int argument) build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as A8Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$A8 extends $StreamNotifier<int> {
@@ -1106,9 +854,8 @@ abstract class _$A8 extends $StreamNotifier<int> {
 const bProvider = BProvider._();
 
 final class BProvider extends $NotifierProvider<B, int> {
-  const BProvider._({super.runNotifierBuildOverride, B Function()? create})
-      : _createCb = create,
-        super(
+  const BProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1118,10 +865,17 @@ final class BProvider extends $NotifierProvider<B, int> {
           allTransitiveDependencies: null,
         );
 
-  final B Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$bHash();
+
+  @$internal
+  @override
+  B create() => B();
+
+  @$internal
+  @override
+  $NotifierProviderElement<B, int> $createElement($ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1130,34 +884,6 @@ final class BProvider extends $NotifierProvider<B, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  B create() => _createCb?.call() ?? B();
-
-  @$internal
-  @override
-  BProvider $copyWithCreate(
-    B Function() create,
-  ) {
-    return BProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  BProvider $copyWithBuild(
-    int Function(
-      Ref,
-      B,
-    ) build,
-  ) {
-    return BProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<B, int> $createElement($ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$bHash() => r'44288285e9c28f846d609ba892520f577ecf7867';
@@ -1179,9 +905,8 @@ abstract class _$B extends $Notifier<int> {
 const b2Provider = B2Provider._();
 
 final class B2Provider extends $NotifierProvider<B2, int> {
-  const B2Provider._({super.runNotifierBuildOverride, B2 Function()? create})
-      : _createCb = create,
-        super(
+  const B2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1191,10 +916,17 @@ final class B2Provider extends $NotifierProvider<B2, int> {
           allTransitiveDependencies: null,
         );
 
-  final B2 Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$b2Hash();
+
+  @$internal
+  @override
+  B2 create() => B2();
+
+  @$internal
+  @override
+  $NotifierProviderElement<B2, int> $createElement($ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1203,34 +935,6 @@ final class B2Provider extends $NotifierProvider<B2, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  B2 create() => _createCb?.call() ?? B2();
-
-  @$internal
-  @override
-  B2Provider $copyWithCreate(
-    B2 Function() create,
-  ) {
-    return B2Provider._(create: create);
-  }
-
-  @$internal
-  @override
-  B2Provider $copyWithBuild(
-    int Function(
-      Ref,
-      B2,
-    ) build,
-  ) {
-    return B2Provider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<B2, int> $createElement($ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$b2Hash() => r'292925c285c6975ed6585d541c5a9ae18977d73c';

--- a/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
@@ -388,14 +388,6 @@ final class A5Provider extends $AsyncNotifierProvider<A5, int> {
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
-
   @override
   bool operator ==(Object other) {
     return other is A5Provider && other.argument == argument;
@@ -511,14 +503,6 @@ final class A6Provider extends $AsyncNotifierProvider<A6, int> {
   $AsyncNotifierProviderElement<A6, int> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
 
   @override
   bool operator ==(Object other) {
@@ -636,14 +620,6 @@ final class A7Provider extends $StreamNotifierProvider<A7, int> {
           $ProviderPointer pointer) =>
       $StreamNotifierProviderElement(pointer);
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
-
   @override
   bool operator ==(Object other) {
     return other is A7Provider && other.argument == argument;
@@ -759,14 +735,6 @@ final class A8Provider extends $StreamNotifierProvider<A8, int> {
   $StreamNotifierProviderElement<A8, int> $createElement(
           $ProviderPointer pointer) =>
       $StreamNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
 
   @override
   bool operator ==(Object other) {

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/another.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/another.g.dart
@@ -11,12 +11,8 @@ const bProvider = BProvider._();
 
 final class BProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const BProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const BProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class BProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$bHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return b(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class BProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  BProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return BProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? b;
-    return _$cb(ref);
   }
 }
 
@@ -69,12 +51,8 @@ const anotherScopedProvider = AnotherScopedProvider._();
 
 final class AnotherScopedProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const AnotherScopedProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AnotherScopedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -84,12 +62,18 @@ final class AnotherScopedProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$anotherScopedHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return anotherScoped(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -97,26 +81,6 @@ final class AnotherScopedProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AnotherScopedProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AnotherScopedProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? anotherScoped;
-    return _$cb(ref);
   }
 }
 
@@ -127,12 +91,8 @@ const anotherNonEmptyScopedProvider = AnotherNonEmptyScopedProvider._();
 
 final class AnotherNonEmptyScopedProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const AnotherNonEmptyScopedProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AnotherNonEmptyScopedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -146,12 +106,18 @@ final class AnotherNonEmptyScopedProvider extends $FunctionalProvider<int, int>
 
   static const $allTransitiveDependencies0 = anotherScopedProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$anotherNonEmptyScopedHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return anotherNonEmptyScoped(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -159,26 +125,6 @@ final class AnotherNonEmptyScopedProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AnotherNonEmptyScopedProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AnotherNonEmptyScopedProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? anotherNonEmptyScoped;
-    return _$cb(ref);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies.g.dart
@@ -11,12 +11,8 @@ const depProvider = DepProvider._();
 
 final class DepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const DepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class DepProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$depHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return dep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class DepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? dep;
-    return _$cb(ref);
   }
 }
 
@@ -69,12 +51,8 @@ const transitiveDepProvider = TransitiveDepProvider._();
 
 final class TransitiveDepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const TransitiveDepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const TransitiveDepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -88,12 +66,18 @@ final class TransitiveDepProvider extends $FunctionalProvider<int, int>
 
   static const $allTransitiveDependencies0 = depProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$transitiveDepHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return transitiveDep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -101,26 +85,6 @@ final class TransitiveDepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  TransitiveDepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return TransitiveDepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? transitiveDep;
-    return _$cb(ref);
   }
 }
 
@@ -131,12 +95,8 @@ const dep2Provider = Dep2Provider._();
 
 final class Dep2Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const Dep2Provider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Dep2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -146,12 +106,18 @@ final class Dep2Provider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$dep2Hash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return dep2(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -159,26 +125,6 @@ final class Dep2Provider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Dep2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Dep2Provider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? dep2;
-    return _$cb(ref);
   }
 }
 
@@ -190,25 +136,14 @@ const depFamilyProvider = DepFamilyFamily._();
 final class DepFamilyProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   const DepFamilyProvider._(
-      {required DepFamilyFamily super.from,
-      required int super.argument,
-      int Function(
-        Ref ref,
-        int id,
-      )? create})
-      : _createCb = create,
-        super(
+      {required DepFamilyFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'depFamilyProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final int Function(
-    Ref ref,
-    int id,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$depFamilyHash();
@@ -220,42 +155,25 @@ final class DepFamilyProvider extends $FunctionalProvider<int, int>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as int;
+    return depFamily(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DepFamilyProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DepFamilyProvider._(
-        argument: argument as int,
-        from: from! as DepFamilyFamily,
-        create: (
-          ref,
-          int id,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? depFamily;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -288,31 +206,23 @@ final class DepFamilyFamily extends Family {
       DepFamilyProvider._(argument: id, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$depFamilyHash();
-
-  @override
   String toString() => r'depFamilyProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as DepFamilyProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as DepFamilyProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 ////////////
@@ -326,12 +236,8 @@ final class PlainAnnotationProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   ////////////
 // expect_lint: provider_dependencies
-  const PlainAnnotationProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const PlainAnnotationProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -341,12 +247,18 @@ final class PlainAnnotationProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$plainAnnotationHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return plainAnnotation(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -354,26 +266,6 @@ final class PlainAnnotationProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  PlainAnnotationProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return PlainAnnotationProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? plainAnnotation;
-    return _$cb(ref);
   }
 }
 
@@ -384,12 +276,8 @@ const customAnnotationProvider = CustomAnnotationProvider._();
 
 final class CustomAnnotationProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const CustomAnnotationProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CustomAnnotationProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -399,12 +287,18 @@ final class CustomAnnotationProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$customAnnotationHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return customAnnotation(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -412,26 +306,6 @@ final class CustomAnnotationProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CustomAnnotationProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CustomAnnotationProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? customAnnotation;
-    return _$cb(ref);
   }
 }
 
@@ -443,12 +317,8 @@ const customAnnotationWithTrailingCommaProvider =
 
 final class CustomAnnotationWithTrailingCommaProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const CustomAnnotationWithTrailingCommaProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CustomAnnotationWithTrailingCommaProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -458,13 +328,19 @@ final class CustomAnnotationWithTrailingCommaProvider
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$customAnnotationWithTrailingCommaHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return customAnnotationWithTrailingComma(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -472,26 +348,6 @@ final class CustomAnnotationWithTrailingCommaProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CustomAnnotationWithTrailingCommaProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CustomAnnotationWithTrailingCommaProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? customAnnotationWithTrailingComma;
-    return _$cb(ref);
   }
 }
 
@@ -503,12 +359,8 @@ const existingDepProvider = ExistingDepProvider._();
 
 final class ExistingDepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const ExistingDepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExistingDepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -518,12 +370,18 @@ final class ExistingDepProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$existingDepHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return existingDep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -531,26 +389,6 @@ final class ExistingDepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExistingDepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExistingDepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? existingDep;
-    return _$cb(ref);
   }
 }
 
@@ -561,12 +399,8 @@ const multipleDepsProvider = MultipleDepsProvider._();
 
 final class MultipleDepsProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const MultipleDepsProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const MultipleDepsProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -576,12 +410,18 @@ final class MultipleDepsProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$multipleDepsHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return multipleDeps(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -589,26 +429,6 @@ final class MultipleDepsProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  MultipleDepsProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return MultipleDepsProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? multipleDeps;
-    return _$cb(ref);
   }
 }
 
@@ -625,12 +445,8 @@ final class ProviderWithDartDocProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   /// Random doc to test that identifiers in docs don't trigger the lint.
   /// [dep], [DepWidget], [depProvider]
-  const ProviderWithDartDocProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ProviderWithDartDocProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -640,12 +456,18 @@ final class ProviderWithDartDocProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$providerWithDartDocHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return providerWithDartDoc(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -653,26 +475,6 @@ final class ProviderWithDartDocProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ProviderWithDartDocProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ProviderWithDartDocProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? providerWithDartDoc;
-    return _$cb(ref);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.g.dart
@@ -11,12 +11,8 @@ const depProvider = DepProvider._();
 
 final class DepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const DepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class DepProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$depHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return dep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class DepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? dep;
-    return _$cb(ref);
   }
 }
 
@@ -69,12 +51,8 @@ const generatedScopedProvider = GeneratedScopedProvider._();
 
 final class GeneratedScopedProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const GeneratedScopedProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const GeneratedScopedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -84,12 +62,18 @@ final class GeneratedScopedProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$generatedScopedHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return generatedScoped(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -97,26 +81,6 @@ final class GeneratedScopedProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  GeneratedScopedProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return GeneratedScopedProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? generatedScoped;
-    return _$cb(ref);
   }
 }
 
@@ -127,12 +91,8 @@ const generatedRootProvider = GeneratedRootProvider._();
 
 final class GeneratedRootProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const GeneratedRootProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const GeneratedRootProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -142,12 +102,18 @@ final class GeneratedRootProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$generatedRootHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return generatedRoot(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -155,26 +121,6 @@ final class GeneratedRootProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  GeneratedRootProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return GeneratedRootProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? generatedRoot;
-    return _$cb(ref);
   }
 }
 
@@ -186,12 +132,8 @@ const watchScopedButNoDependenciesProvider =
 
 final class WatchScopedButNoDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchScopedButNoDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchScopedButNoDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -201,12 +143,18 @@ final class WatchScopedButNoDependenciesProvider
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$watchScopedButNoDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchScopedButNoDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -214,26 +162,6 @@ final class WatchScopedButNoDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchScopedButNoDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchScopedButNoDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchScopedButNoDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -246,12 +174,8 @@ const watchGeneratedScopedButNoDependenciesProvider =
 
 final class WatchGeneratedScopedButNoDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchGeneratedScopedButNoDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchGeneratedScopedButNoDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -261,13 +185,19 @@ final class WatchGeneratedScopedButNoDependenciesProvider
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$watchGeneratedScopedButNoDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchGeneratedScopedButNoDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -275,26 +205,6 @@ final class WatchGeneratedScopedButNoDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchGeneratedScopedButNoDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchGeneratedScopedButNoDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchGeneratedScopedButNoDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -307,12 +217,8 @@ const watchRootButNoDependenciesProvider =
 
 final class WatchRootButNoDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchRootButNoDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchRootButNoDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -322,12 +228,18 @@ final class WatchRootButNoDependenciesProvider
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$watchRootButNoDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchRootButNoDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -335,26 +247,6 @@ final class WatchRootButNoDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchRootButNoDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchRootButNoDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchRootButNoDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -367,12 +259,8 @@ const watchGeneratedRootButNoDependenciesProvider =
 
 final class WatchGeneratedRootButNoDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchGeneratedRootButNoDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchGeneratedRootButNoDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -382,13 +270,19 @@ final class WatchGeneratedRootButNoDependenciesProvider
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$watchGeneratedRootButNoDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchGeneratedRootButNoDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -396,26 +290,6 @@ final class WatchGeneratedRootButNoDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchGeneratedRootButNoDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchGeneratedRootButNoDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchGeneratedRootButNoDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -428,12 +302,8 @@ const watchScopedButEmptyDependenciesProvider =
 
 final class WatchScopedButEmptyDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchScopedButEmptyDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchScopedButEmptyDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -443,12 +313,18 @@ final class WatchScopedButEmptyDependenciesProvider
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$watchScopedButEmptyDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchScopedButEmptyDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -456,26 +332,6 @@ final class WatchScopedButEmptyDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchScopedButEmptyDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchScopedButEmptyDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchScopedButEmptyDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -488,12 +344,8 @@ const watchGeneratedScopedButEmptyDependenciesProvider =
 
 final class WatchGeneratedScopedButEmptyDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchGeneratedScopedButEmptyDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchGeneratedScopedButEmptyDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -503,13 +355,19 @@ final class WatchGeneratedScopedButEmptyDependenciesProvider
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$watchGeneratedScopedButEmptyDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchGeneratedScopedButEmptyDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -517,26 +375,6 @@ final class WatchGeneratedScopedButEmptyDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchGeneratedScopedButEmptyDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchGeneratedScopedButEmptyDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchGeneratedScopedButEmptyDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -549,12 +387,8 @@ const watchRootButEmptyDependenciesProvider =
 
 final class WatchRootButEmptyDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchRootButEmptyDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchRootButEmptyDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -564,12 +398,18 @@ final class WatchRootButEmptyDependenciesProvider
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$watchRootButEmptyDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchRootButEmptyDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -577,26 +417,6 @@ final class WatchRootButEmptyDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchRootButEmptyDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchRootButEmptyDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchRootButEmptyDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -609,12 +429,8 @@ const watchGeneratedRootButEmptyDependenciesProvider =
 
 final class WatchGeneratedRootButEmptyDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchGeneratedRootButEmptyDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchGeneratedRootButEmptyDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -624,13 +440,19 @@ final class WatchGeneratedRootButEmptyDependenciesProvider
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$watchGeneratedRootButEmptyDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchGeneratedRootButEmptyDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -638,26 +460,6 @@ final class WatchGeneratedRootButEmptyDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchGeneratedRootButEmptyDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchGeneratedRootButEmptyDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchGeneratedRootButEmptyDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -670,12 +472,8 @@ const watchScopedButMissingDependenciesProvider =
 
 final class WatchScopedButMissingDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchScopedButMissingDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchScopedButMissingDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -690,13 +488,19 @@ final class WatchScopedButMissingDependenciesProvider
 
   static const $allTransitiveDependencies0 = depProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$watchScopedButMissingDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchScopedButMissingDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -704,26 +508,6 @@ final class WatchScopedButMissingDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchScopedButMissingDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchScopedButMissingDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchScopedButMissingDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -736,12 +520,8 @@ const watchGeneratedScopedButMissingDependenciesProvider =
 
 final class WatchGeneratedScopedButMissingDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchGeneratedScopedButMissingDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchGeneratedScopedButMissingDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -756,13 +536,19 @@ final class WatchGeneratedScopedButMissingDependenciesProvider
 
   static const $allTransitiveDependencies0 = depProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$watchGeneratedScopedButMissingDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchGeneratedScopedButMissingDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -770,26 +556,6 @@ final class WatchGeneratedScopedButMissingDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchGeneratedScopedButMissingDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchGeneratedScopedButMissingDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchGeneratedScopedButMissingDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -802,12 +568,8 @@ const watchRootButMissingDependenciesProvider =
 
 final class WatchRootButMissingDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchRootButMissingDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchRootButMissingDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -821,12 +583,18 @@ final class WatchRootButMissingDependenciesProvider
 
   static const $allTransitiveDependencies0 = depProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$watchRootButMissingDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchRootButMissingDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -834,26 +602,6 @@ final class WatchRootButMissingDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchRootButMissingDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchRootButMissingDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchRootButMissingDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -866,12 +614,8 @@ const watchGeneratedRootButMissingDependenciesProvider =
 
 final class WatchGeneratedRootButMissingDependenciesProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchGeneratedRootButMissingDependenciesProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchGeneratedRootButMissingDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -886,13 +630,19 @@ final class WatchGeneratedRootButMissingDependenciesProvider
 
   static const $allTransitiveDependencies0 = depProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$watchGeneratedRootButMissingDependenciesHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchGeneratedRootButMissingDependencies(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -900,26 +650,6 @@ final class WatchGeneratedRootButMissingDependenciesProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchGeneratedRootButMissingDependenciesProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchGeneratedRootButMissingDependenciesProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchGeneratedRootButMissingDependencies;
-    return _$cb(ref);
   }
 }
 
@@ -932,12 +662,8 @@ const watchGeneratedScopedAndContainsDependencyProvider =
 
 final class WatchGeneratedScopedAndContainsDependencyProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchGeneratedScopedAndContainsDependencyProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchGeneratedScopedAndContainsDependencyProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -952,13 +678,19 @@ final class WatchGeneratedScopedAndContainsDependencyProvider
 
   static const $allTransitiveDependencies0 = generatedScopedProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$watchGeneratedScopedAndContainsDependencyHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchGeneratedScopedAndContainsDependency(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -966,26 +698,6 @@ final class WatchGeneratedScopedAndContainsDependencyProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchGeneratedScopedAndContainsDependencyProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchGeneratedScopedAndContainsDependencyProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchGeneratedScopedAndContainsDependency;
-    return _$cb(ref);
   }
 }
 
@@ -998,12 +710,8 @@ const watchGeneratedRootAndContainsDependencyProvider =
 
 final class WatchGeneratedRootAndContainsDependencyProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const WatchGeneratedRootAndContainsDependencyProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WatchGeneratedRootAndContainsDependencyProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1018,13 +726,19 @@ final class WatchGeneratedRootAndContainsDependencyProvider
 
   static const $allTransitiveDependencies0 = generatedRootProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$watchGeneratedRootAndContainsDependencyHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return watchGeneratedRootAndContainsDependency(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1032,26 +746,6 @@ final class WatchGeneratedRootAndContainsDependencyProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  WatchGeneratedRootAndContainsDependencyProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WatchGeneratedRootAndContainsDependencyProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? watchGeneratedRootAndContainsDependency;
-    return _$cb(ref);
   }
 }
 
@@ -1064,12 +758,8 @@ const specifiedDependencyButNeverUsedProvider =
 
 final class SpecifiedDependencyButNeverUsedProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const SpecifiedDependencyButNeverUsedProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const SpecifiedDependencyButNeverUsedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1088,12 +778,18 @@ final class SpecifiedDependencyButNeverUsedProvider
   static const $allTransitiveDependencies0 = depProvider;
   static const $allTransitiveDependencies1 = generatedRootProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$specifiedDependencyButNeverUsedHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return specifiedDependencyButNeverUsed(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1101,26 +797,6 @@ final class SpecifiedDependencyButNeverUsedProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  SpecifiedDependencyButNeverUsedProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return SpecifiedDependencyButNeverUsedProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? specifiedDependencyButNeverUsed;
-    return _$cb(ref);
   }
 }
 
@@ -1134,11 +810,8 @@ const classWatchGeneratedRootButMissingDependenciesProvider =
 final class ClassWatchGeneratedRootButMissingDependenciesProvider
     extends $NotifierProvider<ClassWatchGeneratedRootButMissingDependencies,
         int> {
-  const ClassWatchGeneratedRootButMissingDependenciesProvider._(
-      {super.runNotifierBuildOverride,
-      ClassWatchGeneratedRootButMissingDependencies Function()? create})
-      : _createCb = create,
-        super(
+  const ClassWatchGeneratedRootButMissingDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1148,11 +821,20 @@ final class ClassWatchGeneratedRootButMissingDependenciesProvider
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final ClassWatchGeneratedRootButMissingDependencies Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() =>
       _$classWatchGeneratedRootButMissingDependenciesHash();
+
+  @$internal
+  @override
+  ClassWatchGeneratedRootButMissingDependencies create() =>
+      ClassWatchGeneratedRootButMissingDependencies();
+
+  @$internal
+  @override
+  $NotifierProviderElement<ClassWatchGeneratedRootButMissingDependencies, int>
+      $createElement($ProviderPointer pointer) =>
+          $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1161,38 +843,6 @@ final class ClassWatchGeneratedRootButMissingDependenciesProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  ClassWatchGeneratedRootButMissingDependencies create() =>
-      _createCb?.call() ?? ClassWatchGeneratedRootButMissingDependencies();
-
-  @$internal
-  @override
-  ClassWatchGeneratedRootButMissingDependenciesProvider $copyWithCreate(
-    ClassWatchGeneratedRootButMissingDependencies Function() create,
-  ) {
-    return ClassWatchGeneratedRootButMissingDependenciesProvider._(
-        create: create);
-  }
-
-  @$internal
-  @override
-  ClassWatchGeneratedRootButMissingDependenciesProvider $copyWithBuild(
-    int Function(
-      Ref,
-      ClassWatchGeneratedRootButMissingDependencies,
-    ) build,
-  ) {
-    return ClassWatchGeneratedRootButMissingDependenciesProvider._(
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<ClassWatchGeneratedRootButMissingDependencies, int>
-      $createElement($ProviderPointer pointer) =>
-          $NotifierProviderElement(this, pointer);
 }
 
 String _$classWatchGeneratedRootButMissingDependenciesHash() =>
@@ -1217,12 +867,8 @@ const regression2348Provider = Regression2348Provider._();
 
 final class Regression2348Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const Regression2348Provider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Regression2348Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1236,12 +882,18 @@ final class Regression2348Provider extends $FunctionalProvider<int, int>
 
   static const $allTransitiveDependencies0 = generatedScopedProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$regression2348Hash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return regression2348(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1249,26 +901,6 @@ final class Regression2348Provider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Regression2348Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Regression2348Provider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? regression2348;
-    return _$cb(ref);
   }
 }
 
@@ -1279,10 +911,8 @@ const regression2417Provider = Regression2417Provider._();
 
 final class Regression2417Provider
     extends $NotifierProvider<Regression2417, int> {
-  const Regression2417Provider._(
-      {super.runNotifierBuildOverride, Regression2417 Function()? create})
-      : _createCb = create,
-        super(
+  const Regression2417Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1296,10 +926,18 @@ final class Regression2417Provider
 
   static const $allTransitiveDependencies0 = generatedScopedProvider;
 
-  final Regression2417 Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$regression2417Hash();
+
+  @$internal
+  @override
+  Regression2417 create() => Regression2417();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Regression2417, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1308,35 +946,6 @@ final class Regression2417Provider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Regression2417 create() => _createCb?.call() ?? Regression2417();
-
-  @$internal
-  @override
-  Regression2417Provider $copyWithCreate(
-    Regression2417 Function() create,
-  ) {
-    return Regression2417Provider._(create: create);
-  }
-
-  @$internal
-  @override
-  Regression2417Provider $copyWithBuild(
-    int Function(
-      Ref,
-      Regression2417,
-    ) build,
-  ) {
-    return Regression2417Provider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Regression2417, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$regression2417Hash() => r'c9ac0ba44e849ea1460c79c1f676feba1b5400da';
@@ -1360,14 +969,8 @@ const familyDepProvider = FamilyDepFamily._();
 final class FamilyDepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   const FamilyDepProvider._(
-      {required FamilyDepFamily super.from,
-      required int super.argument,
-      int Function(
-        Ref ref,
-        int p,
-      )? create})
-      : _createCb = create,
-        super(
+      {required FamilyDepFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'familyDepProvider',
           isAutoDispose: true,
@@ -1376,11 +979,6 @@ final class FamilyDepProvider extends $FunctionalProvider<int, int>
         );
 
   static const $allTransitiveDependencies0 = depProvider;
-
-  final int Function(
-    Ref ref,
-    int p,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$familyDepHash();
@@ -1392,42 +990,25 @@ final class FamilyDepProvider extends $FunctionalProvider<int, int>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as int;
+    return familyDep(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FamilyDepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyDepProvider._(
-        argument: argument as int,
-        from: from! as FamilyDepFamily,
-        create: (
-          ref,
-          int p,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? familyDep;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -1462,31 +1043,23 @@ final class FamilyDepFamily extends Family {
       FamilyDepProvider._(argument: p, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyDepHash();
-
-  @override
   String toString() => r'familyDepProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyDepProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyDepProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(familyDep2)
@@ -1495,14 +1068,8 @@ const familyDep2Provider = FamilyDep2Family._();
 final class FamilyDep2Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   const FamilyDep2Provider._(
-      {required FamilyDep2Family super.from,
-      required int super.argument,
-      int Function(
-        Ref ref,
-        int p,
-      )? create})
-      : _createCb = create,
-        super(
+      {required FamilyDep2Family super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'familyDep2Provider',
           isAutoDispose: true,
@@ -1514,11 +1081,6 @@ final class FamilyDep2Provider extends $FunctionalProvider<int, int>
   static const $allTransitiveDependencies1 =
       FamilyDepProvider.$allTransitiveDependencies0;
 
-  final int Function(
-    Ref ref,
-    int p,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$familyDep2Hash();
 
@@ -1529,42 +1091,25 @@ final class FamilyDep2Provider extends $FunctionalProvider<int, int>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as int;
+    return familyDep2(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FamilyDep2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FamilyDep2Provider._(
-        argument: argument as int,
-        from: from! as FamilyDep2Family,
-        create: (
-          ref,
-          int p,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? familyDep2;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -1600,31 +1145,23 @@ final class FamilyDep2Family extends Family {
       FamilyDep2Provider._(argument: p, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$familyDep2Hash();
-
-  @override
   String toString() => r'familyDep2Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FamilyDep2Provider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FamilyDep2Provider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(alias)
@@ -1632,12 +1169,8 @@ const aliasProvider = AliasProvider._();
 
 final class AliasProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const AliasProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AliasProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1647,12 +1180,18 @@ final class AliasProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$aliasHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return alias(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1660,26 +1199,6 @@ final class AliasProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AliasProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AliasProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? alias;
-    return _$cb(ref);
   }
 }
 
@@ -1689,10 +1208,8 @@ String _$aliasHash() => r'b410585ad56c66160898a05647e09e1a606aa9d2';
 const aliasClassProvider = AliasClassProvider._();
 
 final class AliasClassProvider extends $NotifierProvider<AliasClass, int> {
-  const AliasClassProvider._(
-      {super.runNotifierBuildOverride, AliasClass Function()? create})
-      : _createCb = create,
-        super(
+  const AliasClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1702,10 +1219,18 @@ final class AliasClassProvider extends $NotifierProvider<AliasClass, int> {
           allTransitiveDependencies: null,
         );
 
-  final AliasClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$aliasClassHash();
+
+  @$internal
+  @override
+  AliasClass create() => AliasClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<AliasClass, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1714,35 +1239,6 @@ final class AliasClassProvider extends $NotifierProvider<AliasClass, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  AliasClass create() => _createCb?.call() ?? AliasClass();
-
-  @$internal
-  @override
-  AliasClassProvider $copyWithCreate(
-    AliasClass Function() create,
-  ) {
-    return AliasClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  AliasClassProvider $copyWithBuild(
-    int Function(
-      Ref,
-      AliasClass,
-    ) build,
-  ) {
-    return AliasClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<AliasClass, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$aliasClassHash() => r'f5c1f43e7541638274ca7dc334a713763c9c8071';
@@ -1765,10 +1261,8 @@ const riverpodDependenciesProvider = RiverpodDependenciesProvider._();
 
 final class RiverpodDependenciesProvider
     extends $NotifierProvider<RiverpodDependencies, int> {
-  const RiverpodDependenciesProvider._(
-      {super.runNotifierBuildOverride, RiverpodDependencies Function()? create})
-      : _createCb = create,
-        super(
+  const RiverpodDependenciesProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1782,10 +1276,18 @@ final class RiverpodDependenciesProvider
 
   static const $allTransitiveDependencies0 = depProvider;
 
-  final RiverpodDependencies Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$riverpodDependenciesHash();
+
+  @$internal
+  @override
+  RiverpodDependencies create() => RiverpodDependencies();
+
+  @$internal
+  @override
+  $NotifierProviderElement<RiverpodDependencies, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1794,35 +1296,6 @@ final class RiverpodDependenciesProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  RiverpodDependencies create() => _createCb?.call() ?? RiverpodDependencies();
-
-  @$internal
-  @override
-  RiverpodDependenciesProvider $copyWithCreate(
-    RiverpodDependencies Function() create,
-  ) {
-    return RiverpodDependenciesProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  RiverpodDependenciesProvider $copyWithBuild(
-    int Function(
-      Ref,
-      RiverpodDependencies,
-    ) build,
-  ) {
-    return RiverpodDependenciesProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<RiverpodDependencies, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$riverpodDependenciesHash() =>
@@ -1846,12 +1319,8 @@ const fooProvider = FooProvider._();
 
 final class FooProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const FooProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FooProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1861,12 +1330,18 @@ final class FooProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$fooHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return foo(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1874,26 +1349,6 @@ final class FooProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FooProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FooProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? foo;
-    return _$cb(ref);
   }
 }
 
@@ -1904,12 +1359,8 @@ const crossFileDependencyProvider = CrossFileDependencyProvider._();
 
 final class CrossFileDependencyProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const CrossFileDependencyProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CrossFileDependencyProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1919,12 +1370,18 @@ final class CrossFileDependencyProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$crossFileDependencyHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return crossFileDependency(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -1932,26 +1389,6 @@ final class CrossFileDependencyProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CrossFileDependencyProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CrossFileDependencyProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? crossFileDependency;
-    return _$cb(ref);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/unused_dependency.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/unused_dependency.g.dart
@@ -11,12 +11,8 @@ const rootProvider = RootProvider._();
 
 final class RootProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const RootProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RootProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class RootProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rootHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return root(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class RootProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RootProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RootProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? root;
-    return _$cb(ref);
   }
 }
 
@@ -69,12 +51,8 @@ const depProvider = DepProvider._();
 
 final class DepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const DepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -84,12 +62,18 @@ final class DepProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$depHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return dep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -97,26 +81,6 @@ final class DepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? dep;
-    return _$cb(ref);
   }
 }
 
@@ -127,12 +91,8 @@ const dep2Provider = Dep2Provider._();
 
 final class Dep2Provider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const Dep2Provider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Dep2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -142,12 +102,18 @@ final class Dep2Provider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$dep2Hash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return dep2(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -155,26 +121,6 @@ final class Dep2Provider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Dep2Provider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Dep2Provider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? dep2;
-    return _$cb(ref);
   }
 }
 
@@ -188,12 +134,8 @@ const extraDepProvider = ExtraDepProvider._();
 final class ExtraDepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   ////////////
-  const ExtraDepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExtraDepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -209,12 +151,18 @@ final class ExtraDepProvider extends $FunctionalProvider<int, int>
   static const $allTransitiveDependencies0 = depProvider;
   static const $allTransitiveDependencies1 = dep2Provider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$extraDepHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return extraDep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -222,26 +170,6 @@ final class ExtraDepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExtraDepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExtraDepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? extraDep;
-    return _$cb(ref);
   }
 }
 
@@ -252,12 +180,8 @@ const noDepProvider = NoDepProvider._();
 
 final class NoDepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const NoDepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const NoDepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -271,12 +195,18 @@ final class NoDepProvider extends $FunctionalProvider<int, int>
 
   static const $allTransitiveDependencies0 = depProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$noDepHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return noDep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -284,26 +214,6 @@ final class NoDepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  NoDepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return NoDepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? noDep;
-    return _$cb(ref);
   }
 }
 
@@ -315,12 +225,8 @@ const dependenciesFirstThenKeepAliveProvider =
 
 final class DependenciesFirstThenKeepAliveProvider
     extends $FunctionalProvider<int, int> with $Provider<int> {
-  const DependenciesFirstThenKeepAliveProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DependenciesFirstThenKeepAliveProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -334,12 +240,18 @@ final class DependenciesFirstThenKeepAliveProvider
 
   static const $allTransitiveDependencies0 = depProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$dependenciesFirstThenKeepAliveHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return dependenciesFirstThenKeepAlive(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -347,26 +259,6 @@ final class DependenciesFirstThenKeepAliveProvider
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DependenciesFirstThenKeepAliveProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DependenciesFirstThenKeepAliveProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? dependenciesFirstThenKeepAlive;
-    return _$cb(ref);
   }
 }
 
@@ -378,12 +270,8 @@ const noDepNoParamProvider = NoDepNoParamProvider._();
 
 final class NoDepNoParamProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const NoDepNoParamProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const NoDepNoParamProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -397,12 +285,18 @@ final class NoDepNoParamProvider extends $FunctionalProvider<int, int>
 
   static const $allTransitiveDependencies0 = depProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$noDepNoParamHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return noDepNoParam(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -410,26 +304,6 @@ final class NoDepNoParamProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  NoDepNoParamProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return NoDepNoParamProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? noDepNoParam;
-    return _$cb(ref);
   }
 }
 
@@ -440,12 +314,8 @@ const noDepWithoutCommaProvider = NoDepWithoutCommaProvider._();
 
 final class NoDepWithoutCommaProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const NoDepWithoutCommaProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const NoDepWithoutCommaProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -459,12 +329,18 @@ final class NoDepWithoutCommaProvider extends $FunctionalProvider<int, int>
 
   static const $allTransitiveDependencies0 = depProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$noDepWithoutCommaHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return noDepWithoutComma(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -472,26 +348,6 @@ final class NoDepWithoutCommaProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  NoDepWithoutCommaProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return NoDepWithoutCommaProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? noDepWithoutComma;
-    return _$cb(ref);
   }
 }
 
@@ -502,12 +358,8 @@ const rootDepProvider = RootDepProvider._();
 
 final class RootDepProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const RootDepProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RootDepProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -521,12 +373,18 @@ final class RootDepProvider extends $FunctionalProvider<int, int>
 
   static const $allTransitiveDependencies0 = rootProvider;
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rootDepHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return rootDep(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -534,26 +392,6 @@ final class RootDepProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RootDepProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RootDepProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? rootDep;
-    return _$cb(ref);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.g.dart
@@ -12,25 +12,14 @@ const generatorProvider = GeneratorFamily._();
 final class GeneratorProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
   const GeneratorProvider._(
-      {required GeneratorFamily super.from,
-      required Object? super.argument,
-      int Function(
-        Ref ref, {
-        Object? value,
-      })? create})
-      : _createCb = create,
-        super(
+      {required GeneratorFamily super.from, required Object? super.argument})
+      : super(
           retry: null,
           name: r'generatorProvider',
           isAutoDispose: false,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final int Function(
-    Ref ref, {
-    Object? value,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$generatorHash();
@@ -42,42 +31,25 @@ final class GeneratorProvider extends $FunctionalProvider<int, int>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument;
+    return generator(
+      ref,
+      value: argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  GeneratorProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return GeneratorProvider._(
-        argument: argument,
-        from: from! as GeneratorFamily,
-        create: (
-          ref, {
-          Object? value,
-        }) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? generator;
-    final argument = this.argument;
-    return _$cb(
-      ref,
-      value: argument,
     );
   }
 
@@ -110,31 +82,23 @@ final class GeneratorFamily extends Family {
       GeneratorProvider._(argument: value, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$generatorHash();
-
-  @override
   String toString() => r'generatorProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      Object? args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as GeneratorProvider;
-
-        final argument = provider.argument;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            Object? args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GeneratorProvider;
+            final argument = provider.argument;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_lint_flutter_test/test/lints/scoped_providers_should_specify_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/scoped_providers_should_specify_dependencies.g.dart
@@ -11,10 +11,8 @@ const unimplementedScopedProvider = UnimplementedScopedProvider._();
 
 final class UnimplementedScopedProvider
     extends $NotifierProvider<UnimplementedScoped, int> {
-  const UnimplementedScopedProvider._(
-      {super.runNotifierBuildOverride, UnimplementedScoped Function()? create})
-      : _createCb = create,
-        super(
+  const UnimplementedScopedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -24,10 +22,18 @@ final class UnimplementedScopedProvider
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final UnimplementedScoped Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$unimplementedScopedHash();
+
+  @$internal
+  @override
+  UnimplementedScoped create() => UnimplementedScoped();
+
+  @$internal
+  @override
+  $NotifierProviderElement<UnimplementedScoped, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -36,35 +42,6 @@ final class UnimplementedScopedProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  UnimplementedScoped create() => _createCb?.call() ?? UnimplementedScoped();
-
-  @$internal
-  @override
-  UnimplementedScopedProvider $copyWithCreate(
-    UnimplementedScoped Function() create,
-  ) {
-    return UnimplementedScopedProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  UnimplementedScopedProvider $copyWithBuild(
-    int Function(
-      Ref,
-      UnimplementedScoped,
-    ) build,
-  ) {
-    return UnimplementedScopedProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<UnimplementedScoped, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$unimplementedScopedHash() =>
@@ -88,12 +65,8 @@ const scopedProvider = ScopedProvider._();
 
 final class ScopedProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const ScopedProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ScopedProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -103,12 +76,18 @@ final class ScopedProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: const <ProviderOrFamily>[],
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$scopedHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return scoped(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -116,26 +95,6 @@ final class ScopedProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ScopedProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ScopedProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? scoped;
-    return _$cb(ref);
   }
 }
 
@@ -146,12 +105,8 @@ const rootProvider = RootProvider._();
 
 final class RootProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const RootProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RootProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -161,12 +116,18 @@ final class RootProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rootHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return root(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -174,26 +135,6 @@ final class RootProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RootProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RootProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? root;
-    return _$cb(ref);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/unsupported_provider_value.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/unsupported_provider_value.g.dart
@@ -11,12 +11,8 @@ const integerProvider = IntegerProvider._();
 
 final class IntegerProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const IntegerProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const IntegerProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,12 +22,18 @@ final class IntegerProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$integerHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return integer(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -39,26 +41,6 @@ final class IntegerProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  IntegerProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return IntegerProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? integer;
-    return _$cb(ref);
   }
 }
 
@@ -70,12 +52,8 @@ const stateNotifierProvider = StateNotifierProvider._();
 final class StateNotifierProvider
     extends $FunctionalProvider<MyStateNotifier, MyStateNotifier>
     with $Provider<MyStateNotifier> {
-  const StateNotifierProvider._(
-      {MyStateNotifier Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const StateNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -85,12 +63,18 @@ final class StateNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final MyStateNotifier Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$stateNotifierHash();
+
+  @$internal
+  @override
+  $ProviderElement<MyStateNotifier> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  MyStateNotifier create(Ref ref) {
+    return stateNotifier(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyStateNotifier value) {
@@ -98,26 +82,6 @@ final class StateNotifierProvider
       origin: this,
       providerOverride: $ValueProvider<MyStateNotifier>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<MyStateNotifier> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  StateNotifierProvider $copyWithCreate(
-    MyStateNotifier Function(
-      Ref ref,
-    ) create,
-  ) {
-    return StateNotifierProvider._(create: create);
-  }
-
-  @override
-  MyStateNotifier create(Ref ref) {
-    final _$cb = _createCb ?? stateNotifier;
-    return _$cb(ref);
   }
 }
 
@@ -129,12 +93,8 @@ const asyncStateNotifierProvider = AsyncStateNotifierProvider._();
 final class AsyncStateNotifierProvider extends $FunctionalProvider<
         AsyncValue<MyStateNotifier>, FutureOr<MyStateNotifier>>
     with $FutureModifier<MyStateNotifier>, $FutureProvider<MyStateNotifier> {
-  const AsyncStateNotifierProvider._(
-      {FutureOr<MyStateNotifier> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AsyncStateNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -144,10 +104,6 @@ final class AsyncStateNotifierProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<MyStateNotifier> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$asyncStateNotifierHash();
 
@@ -155,21 +111,11 @@ final class AsyncStateNotifierProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<MyStateNotifier> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  AsyncStateNotifierProvider $copyWithCreate(
-    FutureOr<MyStateNotifier> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AsyncStateNotifierProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<MyStateNotifier> create(Ref ref) {
-    final _$cb = _createCb ?? asyncStateNotifier;
-    return _$cb(ref);
+    return asyncStateNotifier(ref);
   }
 }
 
@@ -181,10 +127,8 @@ const stateNotifierClassProvider = StateNotifierClassProvider._();
 
 final class StateNotifierClassProvider
     extends $NotifierProvider<StateNotifierClass, MyStateNotifier> {
-  const StateNotifierClassProvider._(
-      {super.runNotifierBuildOverride, StateNotifierClass Function()? create})
-      : _createCb = create,
-        super(
+  const StateNotifierClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -194,10 +138,18 @@ final class StateNotifierClassProvider
           allTransitiveDependencies: null,
         );
 
-  final StateNotifierClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$stateNotifierClassHash();
+
+  @$internal
+  @override
+  StateNotifierClass create() => StateNotifierClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<StateNotifierClass, MyStateNotifier> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyStateNotifier value) {
@@ -206,35 +158,6 @@ final class StateNotifierClassProvider
       providerOverride: $ValueProvider<MyStateNotifier>(value),
     );
   }
-
-  @$internal
-  @override
-  StateNotifierClass create() => _createCb?.call() ?? StateNotifierClass();
-
-  @$internal
-  @override
-  StateNotifierClassProvider $copyWithCreate(
-    StateNotifierClass Function() create,
-  ) {
-    return StateNotifierClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  StateNotifierClassProvider $copyWithBuild(
-    MyStateNotifier Function(
-      Ref,
-      StateNotifierClass,
-    ) build,
-  ) {
-    return StateNotifierClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<StateNotifierClass, MyStateNotifier> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$stateNotifierClassHash() =>
@@ -259,12 +182,8 @@ const stateNotifierAsyncProvider = StateNotifierAsyncProvider._();
 final class StateNotifierAsyncProvider extends $FunctionalProvider<
         AsyncValue<MyStateNotifier>, FutureOr<MyStateNotifier>>
     with $FutureModifier<MyStateNotifier>, $FutureProvider<MyStateNotifier> {
-  const StateNotifierAsyncProvider._(
-      {FutureOr<MyStateNotifier> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const StateNotifierAsyncProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -274,10 +193,6 @@ final class StateNotifierAsyncProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<MyStateNotifier> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$stateNotifierAsyncHash();
 
@@ -285,21 +200,11 @@ final class StateNotifierAsyncProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<MyStateNotifier> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  StateNotifierAsyncProvider $copyWithCreate(
-    FutureOr<MyStateNotifier> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return StateNotifierAsyncProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<MyStateNotifier> create(Ref ref) {
-    final _$cb = _createCb ?? stateNotifierAsync;
-    return _$cb(ref);
+    return stateNotifierAsync(ref);
   }
 }
 
@@ -311,10 +216,8 @@ const selfNotifierProvider = SelfNotifierProvider._();
 
 final class SelfNotifierProvider
     extends $AsyncNotifierProvider<SelfNotifier, SelfNotifier> {
-  const SelfNotifierProvider._(
-      {super.runNotifierBuildOverride, SelfNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const SelfNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -324,39 +227,26 @@ final class SelfNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final SelfNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$selfNotifierHash();
 
   @$internal
   @override
-  SelfNotifier create() => _createCb?.call() ?? SelfNotifier();
-
-  @$internal
-  @override
-  SelfNotifierProvider $copyWithCreate(
-    SelfNotifier Function() create,
-  ) {
-    return SelfNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  SelfNotifierProvider $copyWithBuild(
-    FutureOr<SelfNotifier> Function(
-      Ref,
-      SelfNotifier,
-    ) build,
-  ) {
-    return SelfNotifierProvider._(runNotifierBuildOverride: build);
-  }
+  SelfNotifier create() => SelfNotifier();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<SelfNotifier, SelfNotifier> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<SelfNotifier> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<SelfNotifier>>(value),
+    );
+  }
 }
 
 String _$selfNotifierHash() => r'5a857f5c92a9b7a35daa4e527bd333cf3d8d19ac';
@@ -382,10 +272,8 @@ const syncSelfNotifierProvider = SyncSelfNotifierProvider._();
 
 final class SyncSelfNotifierProvider
     extends $NotifierProvider<SyncSelfNotifier, SyncSelfNotifier> {
-  const SyncSelfNotifierProvider._(
-      {super.runNotifierBuildOverride, SyncSelfNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const SyncSelfNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -395,10 +283,18 @@ final class SyncSelfNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final SyncSelfNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$syncSelfNotifierHash();
+
+  @$internal
+  @override
+  SyncSelfNotifier create() => SyncSelfNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<SyncSelfNotifier, SyncSelfNotifier> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(SyncSelfNotifier value) {
@@ -407,35 +303,6 @@ final class SyncSelfNotifierProvider
       providerOverride: $ValueProvider<SyncSelfNotifier>(value),
     );
   }
-
-  @$internal
-  @override
-  SyncSelfNotifier create() => _createCb?.call() ?? SyncSelfNotifier();
-
-  @$internal
-  @override
-  SyncSelfNotifierProvider $copyWithCreate(
-    SyncSelfNotifier Function() create,
-  ) {
-    return SyncSelfNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  SyncSelfNotifierProvider $copyWithBuild(
-    SyncSelfNotifier Function(
-      Ref,
-      SyncSelfNotifier,
-    ) build,
-  ) {
-    return SyncSelfNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<SyncSelfNotifier, SyncSelfNotifier> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$syncSelfNotifierHash() => r'4f3a2463cb5693a5c8d7e772b4d7c9774b9ba637';
@@ -458,10 +325,8 @@ const streamSelfNotifierProvider = StreamSelfNotifierProvider._();
 
 final class StreamSelfNotifierProvider
     extends $StreamNotifierProvider<StreamSelfNotifier, StreamSelfNotifier> {
-  const StreamSelfNotifierProvider._(
-      {super.runNotifierBuildOverride, StreamSelfNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const StreamSelfNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -471,39 +336,26 @@ final class StreamSelfNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final StreamSelfNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$streamSelfNotifierHash();
 
   @$internal
   @override
-  StreamSelfNotifier create() => _createCb?.call() ?? StreamSelfNotifier();
-
-  @$internal
-  @override
-  StreamSelfNotifierProvider $copyWithCreate(
-    StreamSelfNotifier Function() create,
-  ) {
-    return StreamSelfNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  StreamSelfNotifierProvider $copyWithBuild(
-    Stream<StreamSelfNotifier> Function(
-      Ref,
-      StreamSelfNotifier,
-    ) build,
-  ) {
-    return StreamSelfNotifierProvider._(runNotifierBuildOverride: build);
-  }
+  StreamSelfNotifier create() => StreamSelfNotifier();
 
   @$internal
   @override
   $StreamNotifierProviderElement<StreamSelfNotifier, StreamSelfNotifier>
       $createElement($ProviderPointer pointer) =>
-          $StreamNotifierProviderElement(this, pointer);
+          $StreamNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<StreamSelfNotifier> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<StreamSelfNotifier>>(value),
+    );
+  }
 }
 
 String _$streamSelfNotifierHash() =>
@@ -531,11 +383,8 @@ const stateNotifierClassAsyncProvider = StateNotifierClassAsyncProvider._();
 
 final class StateNotifierClassAsyncProvider
     extends $AsyncNotifierProvider<StateNotifierClassAsync, MyStateNotifier> {
-  const StateNotifierClassAsyncProvider._(
-      {super.runNotifierBuildOverride,
-      StateNotifierClassAsync Function()? create})
-      : _createCb = create,
-        super(
+  const StateNotifierClassAsyncProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -545,40 +394,26 @@ final class StateNotifierClassAsyncProvider
           allTransitiveDependencies: null,
         );
 
-  final StateNotifierClassAsync Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$stateNotifierClassAsyncHash();
 
   @$internal
   @override
-  StateNotifierClassAsync create() =>
-      _createCb?.call() ?? StateNotifierClassAsync();
-
-  @$internal
-  @override
-  StateNotifierClassAsyncProvider $copyWithCreate(
-    StateNotifierClassAsync Function() create,
-  ) {
-    return StateNotifierClassAsyncProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  StateNotifierClassAsyncProvider $copyWithBuild(
-    FutureOr<MyStateNotifier> Function(
-      Ref,
-      StateNotifierClassAsync,
-    ) build,
-  ) {
-    return StateNotifierClassAsyncProvider._(runNotifierBuildOverride: build);
-  }
+  StateNotifierClassAsync create() => StateNotifierClassAsync();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<StateNotifierClassAsync, MyStateNotifier>
       $createElement($ProviderPointer pointer) =>
-          $AsyncNotifierProviderElement(this, pointer);
+          $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<MyStateNotifier> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<MyStateNotifier>>(value),
+    );
+  }
 }
 
 String _$stateNotifierClassAsyncHash() =>
@@ -607,12 +442,8 @@ const changeNotifierProvider = ChangeNotifierProvider._();
 final class ChangeNotifierProvider
     extends $FunctionalProvider<MyChangeNotifier, MyChangeNotifier>
     with $Provider<MyChangeNotifier> {
-  const ChangeNotifierProvider._(
-      {MyChangeNotifier Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ChangeNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -622,12 +453,18 @@ final class ChangeNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final MyChangeNotifier Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$changeNotifierHash();
+
+  @$internal
+  @override
+  $ProviderElement<MyChangeNotifier> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  MyChangeNotifier create(Ref ref) {
+    return changeNotifier(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyChangeNotifier value) {
@@ -635,26 +472,6 @@ final class ChangeNotifierProvider
       origin: this,
       providerOverride: $ValueProvider<MyChangeNotifier>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<MyChangeNotifier> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ChangeNotifierProvider $copyWithCreate(
-    MyChangeNotifier Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ChangeNotifierProvider._(create: create);
-  }
-
-  @override
-  MyChangeNotifier create(Ref ref) {
-    final _$cb = _createCb ?? changeNotifier;
-    return _$cb(ref);
   }
 }
 
@@ -665,10 +482,8 @@ const changeNotifierClassProvider = ChangeNotifierClassProvider._();
 
 final class ChangeNotifierClassProvider
     extends $NotifierProvider<ChangeNotifierClass, MyChangeNotifier> {
-  const ChangeNotifierClassProvider._(
-      {super.runNotifierBuildOverride, ChangeNotifierClass Function()? create})
-      : _createCb = create,
-        super(
+  const ChangeNotifierClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -678,10 +493,18 @@ final class ChangeNotifierClassProvider
           allTransitiveDependencies: null,
         );
 
-  final ChangeNotifierClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$changeNotifierClassHash();
+
+  @$internal
+  @override
+  ChangeNotifierClass create() => ChangeNotifierClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<ChangeNotifierClass, MyChangeNotifier>
+      $createElement($ProviderPointer pointer) =>
+          $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyChangeNotifier value) {
@@ -690,35 +513,6 @@ final class ChangeNotifierClassProvider
       providerOverride: $ValueProvider<MyChangeNotifier>(value),
     );
   }
-
-  @$internal
-  @override
-  ChangeNotifierClass create() => _createCb?.call() ?? ChangeNotifierClass();
-
-  @$internal
-  @override
-  ChangeNotifierClassProvider $copyWithCreate(
-    ChangeNotifierClass Function() create,
-  ) {
-    return ChangeNotifierClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  ChangeNotifierClassProvider $copyWithBuild(
-    MyChangeNotifier Function(
-      Ref,
-      ChangeNotifierClass,
-    ) build,
-  ) {
-    return ChangeNotifierClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<ChangeNotifierClass, MyChangeNotifier>
-      $createElement($ProviderPointer pointer) =>
-          $NotifierProviderElement(this, pointer);
 }
 
 String _$changeNotifierClassHash() =>
@@ -742,12 +536,8 @@ const notifierProvider = NotifierProvider._();
 
 final class NotifierProvider extends $FunctionalProvider<MyNotifier, MyNotifier>
     with $Provider<MyNotifier> {
-  const NotifierProvider._(
-      {MyNotifier Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const NotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -757,12 +547,18 @@ final class NotifierProvider extends $FunctionalProvider<MyNotifier, MyNotifier>
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$notifierHash();
+
+  @$internal
+  @override
+  $ProviderElement<MyNotifier> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  MyNotifier create(Ref ref) {
+    return notifier(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyNotifier value) {
@@ -770,26 +566,6 @@ final class NotifierProvider extends $FunctionalProvider<MyNotifier, MyNotifier>
       origin: this,
       providerOverride: $ValueProvider<MyNotifier>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<MyNotifier> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  NotifierProvider $copyWithCreate(
-    MyNotifier Function(
-      Ref ref,
-    ) create,
-  ) {
-    return NotifierProvider._(create: create);
-  }
-
-  @override
-  MyNotifier create(Ref ref) {
-    final _$cb = _createCb ?? notifier;
-    return _$cb(ref);
   }
 }
 
@@ -801,12 +577,8 @@ const autoDisposeNotifierProvider = AutoDisposeNotifierProvider._();
 final class AutoDisposeNotifierProvider
     extends $FunctionalProvider<MyAutoDisposeNotifier, MyAutoDisposeNotifier>
     with $Provider<MyAutoDisposeNotifier> {
-  const AutoDisposeNotifierProvider._(
-      {MyAutoDisposeNotifier Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AutoDisposeNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -816,12 +588,19 @@ final class AutoDisposeNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final MyAutoDisposeNotifier Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$autoDisposeNotifierHash();
+
+  @$internal
+  @override
+  $ProviderElement<MyAutoDisposeNotifier> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  MyAutoDisposeNotifier create(Ref ref) {
+    return autoDisposeNotifier(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyAutoDisposeNotifier value) {
@@ -829,27 +608,6 @@ final class AutoDisposeNotifierProvider
       origin: this,
       providerOverride: $ValueProvider<MyAutoDisposeNotifier>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<MyAutoDisposeNotifier> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AutoDisposeNotifierProvider $copyWithCreate(
-    MyAutoDisposeNotifier Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AutoDisposeNotifierProvider._(create: create);
-  }
-
-  @override
-  MyAutoDisposeNotifier create(Ref ref) {
-    final _$cb = _createCb ?? autoDisposeNotifier;
-    return _$cb(ref);
   }
 }
 
@@ -861,10 +619,8 @@ const notifierClassProvider = NotifierClassProvider._();
 
 final class NotifierClassProvider
     extends $NotifierProvider<NotifierClass, MyNotifier> {
-  const NotifierClassProvider._(
-      {super.runNotifierBuildOverride, NotifierClass Function()? create})
-      : _createCb = create,
-        super(
+  const NotifierClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -874,10 +630,18 @@ final class NotifierClassProvider
           allTransitiveDependencies: null,
         );
 
-  final NotifierClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$notifierClassHash();
+
+  @$internal
+  @override
+  NotifierClass create() => NotifierClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<NotifierClass, MyNotifier> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyNotifier value) {
@@ -886,35 +650,6 @@ final class NotifierClassProvider
       providerOverride: $ValueProvider<MyNotifier>(value),
     );
   }
-
-  @$internal
-  @override
-  NotifierClass create() => _createCb?.call() ?? NotifierClass();
-
-  @$internal
-  @override
-  NotifierClassProvider $copyWithCreate(
-    NotifierClass Function() create,
-  ) {
-    return NotifierClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  NotifierClassProvider $copyWithBuild(
-    MyNotifier Function(
-      Ref,
-      NotifierClass,
-    ) build,
-  ) {
-    return NotifierClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<NotifierClass, MyNotifier> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$notifierClassHash() => r'e7eefebec2fca4f982582449e7ec14322932b748';
@@ -938,12 +673,8 @@ const asyncNotifierProvider = AsyncNotifierProvider._();
 final class AsyncNotifierProvider
     extends $FunctionalProvider<MyAsyncNotifier, MyAsyncNotifier>
     with $Provider<MyAsyncNotifier> {
-  const AsyncNotifierProvider._(
-      {MyAsyncNotifier Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AsyncNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -953,12 +684,18 @@ final class AsyncNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final MyAsyncNotifier Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$asyncNotifierHash();
+
+  @$internal
+  @override
+  $ProviderElement<MyAsyncNotifier> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  MyAsyncNotifier create(Ref ref) {
+    return asyncNotifier(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyAsyncNotifier value) {
@@ -966,26 +703,6 @@ final class AsyncNotifierProvider
       origin: this,
       providerOverride: $ValueProvider<MyAsyncNotifier>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<MyAsyncNotifier> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AsyncNotifierProvider $copyWithCreate(
-    MyAsyncNotifier Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AsyncNotifierProvider._(create: create);
-  }
-
-  @override
-  MyAsyncNotifier create(Ref ref) {
-    final _$cb = _createCb ?? asyncNotifier;
-    return _$cb(ref);
   }
 }
 
@@ -996,10 +713,8 @@ const asyncNotifierClassProvider = AsyncNotifierClassProvider._();
 
 final class AsyncNotifierClassProvider
     extends $NotifierProvider<AsyncNotifierClass, MyAsyncNotifier> {
-  const AsyncNotifierClassProvider._(
-      {super.runNotifierBuildOverride, AsyncNotifierClass Function()? create})
-      : _createCb = create,
-        super(
+  const AsyncNotifierClassProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1009,10 +724,18 @@ final class AsyncNotifierClassProvider
           allTransitiveDependencies: null,
         );
 
-  final AsyncNotifierClass Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$asyncNotifierClassHash();
+
+  @$internal
+  @override
+  AsyncNotifierClass create() => AsyncNotifierClass();
+
+  @$internal
+  @override
+  $NotifierProviderElement<AsyncNotifierClass, MyAsyncNotifier> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyAsyncNotifier value) {
@@ -1021,35 +744,6 @@ final class AsyncNotifierClassProvider
       providerOverride: $ValueProvider<MyAsyncNotifier>(value),
     );
   }
-
-  @$internal
-  @override
-  AsyncNotifierClass create() => _createCb?.call() ?? AsyncNotifierClass();
-
-  @$internal
-  @override
-  AsyncNotifierClassProvider $copyWithCreate(
-    AsyncNotifierClass Function() create,
-  ) {
-    return AsyncNotifierClassProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  AsyncNotifierClassProvider $copyWithBuild(
-    MyAsyncNotifier Function(
-      Ref,
-      AsyncNotifierClass,
-    ) build,
-  ) {
-    return AsyncNotifierClassProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<AsyncNotifierClass, MyAsyncNotifier> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$asyncNotifierClassHash() =>
@@ -1074,12 +768,8 @@ const rawNotifierProvider = RawNotifierProvider._();
 final class RawNotifierProvider
     extends $FunctionalProvider<Raw<MyChangeNotifier>, Raw<MyChangeNotifier>>
     with $Provider<Raw<MyChangeNotifier>> {
-  const RawNotifierProvider._(
-      {Raw<MyChangeNotifier> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RawNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1089,12 +779,19 @@ final class RawNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final Raw<MyChangeNotifier> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rawNotifierHash();
+
+  @$internal
+  @override
+  $ProviderElement<Raw<MyChangeNotifier>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<MyChangeNotifier> create(Ref ref) {
+    return rawNotifier(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<MyChangeNotifier> value) {
@@ -1102,27 +799,6 @@ final class RawNotifierProvider
       origin: this,
       providerOverride: $ValueProvider<Raw<MyChangeNotifier>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<MyChangeNotifier>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RawNotifierProvider $copyWithCreate(
-    Raw<MyChangeNotifier> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RawNotifierProvider._(create: create);
-  }
-
-  @override
-  Raw<MyChangeNotifier> create(Ref ref) {
-    final _$cb = _createCb ?? rawNotifier;
-    return _$cb(ref);
   }
 }
 
@@ -1134,12 +810,8 @@ const rawFutureNotifierProvider = RawFutureNotifierProvider._();
 final class RawFutureNotifierProvider extends $FunctionalProvider<
         Raw<Future<MyChangeNotifier>>, Raw<Future<MyChangeNotifier>>>
     with $Provider<Raw<Future<MyChangeNotifier>>> {
-  const RawFutureNotifierProvider._(
-      {Raw<Future<MyChangeNotifier>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RawFutureNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1149,12 +821,19 @@ final class RawFutureNotifierProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final Raw<Future<MyChangeNotifier>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rawFutureNotifierHash();
+
+  @$internal
+  @override
+  $ProviderElement<Raw<Future<MyChangeNotifier>>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<Future<MyChangeNotifier>> create(Ref ref) {
+    return rawFutureNotifier(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Future<MyChangeNotifier>> value) {
@@ -1162,27 +841,6 @@ final class RawFutureNotifierProvider extends $FunctionalProvider<
       origin: this,
       providerOverride: $ValueProvider<Raw<Future<MyChangeNotifier>>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<Future<MyChangeNotifier>>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RawFutureNotifierProvider $copyWithCreate(
-    Raw<Future<MyChangeNotifier>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RawFutureNotifierProvider._(create: create);
-  }
-
-  @override
-  Raw<Future<MyChangeNotifier>> create(Ref ref) {
-    final _$cb = _createCb ?? rawFutureNotifier;
-    return _$cb(ref);
   }
 }
 
@@ -1194,12 +852,8 @@ const rawStreamNotifierProvider = RawStreamNotifierProvider._();
 final class RawStreamNotifierProvider extends $FunctionalProvider<
         Raw<Stream<MyChangeNotifier>>, Raw<Stream<MyChangeNotifier>>>
     with $Provider<Raw<Stream<MyChangeNotifier>>> {
-  const RawStreamNotifierProvider._(
-      {Raw<Stream<MyChangeNotifier>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RawStreamNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1209,12 +863,19 @@ final class RawStreamNotifierProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final Raw<Stream<MyChangeNotifier>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rawStreamNotifierHash();
+
+  @$internal
+  @override
+  $ProviderElement<Raw<Stream<MyChangeNotifier>>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<Stream<MyChangeNotifier>> create(Ref ref) {
+    return rawStreamNotifier(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Stream<MyChangeNotifier>> value) {
@@ -1222,27 +883,6 @@ final class RawStreamNotifierProvider extends $FunctionalProvider<
       origin: this,
       providerOverride: $ValueProvider<Raw<Stream<MyChangeNotifier>>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<Stream<MyChangeNotifier>>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RawStreamNotifierProvider $copyWithCreate(
-    Raw<Stream<MyChangeNotifier>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RawStreamNotifierProvider._(create: create);
-  }
-
-  @override
-  Raw<Stream<MyChangeNotifier>> create(Ref ref) {
-    final _$cb = _createCb ?? rawStreamNotifier;
-    return _$cb(ref);
   }
 }
 
@@ -1256,12 +896,8 @@ final class FutureRawNotifierProvider extends $FunctionalProvider<
     with
         $FutureModifier<Raw<MyChangeNotifier>>,
         $FutureProvider<Raw<MyChangeNotifier>> {
-  const FutureRawNotifierProvider._(
-      {FutureOr<Raw<MyChangeNotifier>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FutureRawNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1271,10 +907,6 @@ final class FutureRawNotifierProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Raw<MyChangeNotifier>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$futureRawNotifierHash();
 
@@ -1282,21 +914,11 @@ final class FutureRawNotifierProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<Raw<MyChangeNotifier>> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  FutureRawNotifierProvider $copyWithCreate(
-    FutureOr<Raw<MyChangeNotifier>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FutureRawNotifierProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Raw<MyChangeNotifier>> create(Ref ref) {
-    final _$cb = _createCb ?? futureRawNotifier;
-    return _$cb(ref);
+    return futureRawNotifier(ref);
   }
 }
 
@@ -1310,12 +932,8 @@ final class StreamRawNotifierProvider extends $FunctionalProvider<
     with
         $FutureModifier<Raw<MyChangeNotifier>>,
         $StreamProvider<Raw<MyChangeNotifier>> {
-  const StreamRawNotifierProvider._(
-      {Stream<Raw<MyChangeNotifier>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const StreamRawNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -1325,10 +943,6 @@ final class StreamRawNotifierProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final Stream<Raw<MyChangeNotifier>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$streamRawNotifierHash();
 
@@ -1336,21 +950,11 @@ final class StreamRawNotifierProvider extends $FunctionalProvider<
   @override
   $StreamProviderElement<Raw<MyChangeNotifier>> $createElement(
           $ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  StreamRawNotifierProvider $copyWithCreate(
-    Stream<Raw<MyChangeNotifier>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return StreamRawNotifierProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<Raw<MyChangeNotifier>> create(Ref ref) {
-    final _$cb = _createCb ?? streamRawNotifier;
-    return _$cb(ref);
+    return streamRawNotifier(ref);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/unsupported_provider_value.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/unsupported_provider_value.g.dart
@@ -239,14 +239,6 @@ final class SelfNotifierProvider
   $AsyncNotifierProviderElement<SelfNotifier, SelfNotifier> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<SelfNotifier> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<SelfNotifier>>(value),
-    );
-  }
 }
 
 String _$selfNotifierHash() => r'5a857f5c92a9b7a35daa4e527bd333cf3d8d19ac';
@@ -348,14 +340,6 @@ final class StreamSelfNotifierProvider
   $StreamNotifierProviderElement<StreamSelfNotifier, StreamSelfNotifier>
       $createElement($ProviderPointer pointer) =>
           $StreamNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<StreamSelfNotifier> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<StreamSelfNotifier>>(value),
-    );
-  }
 }
 
 String _$streamSelfNotifierHash() =>
@@ -406,14 +390,6 @@ final class StateNotifierClassAsyncProvider
   $AsyncNotifierProviderElement<StateNotifierClassAsync, MyStateNotifier>
       $createElement($ProviderPointer pointer) =>
           $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<MyStateNotifier> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<MyStateNotifier>>(value),
-    );
-  }
 }
 
 String _$stateNotifierClassAsyncHash() =>

--- a/packages/riverpod_sqflite/example/lib/generated.g.dart
+++ b/packages/riverpod_sqflite/example/lib/generated.g.dart
@@ -87,14 +87,6 @@ final class TodosNotifierProvider
   $AsyncNotifierProviderElement<TodosNotifier, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<Todo>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
-    );
-  }
 }
 
 String _$todosNotifierHash() => r'f7c580875a00ab559ff61cbd0f6986fe1fd515e6';

--- a/packages/riverpod_sqflite/example/lib/generated.g.dart
+++ b/packages/riverpod_sqflite/example/lib/generated.g.dart
@@ -30,12 +30,8 @@ final class StorageProvider extends $FunctionalProvider<
     with
         $FutureModifier<JsonSqFliteStorage>,
         $FutureProvider<JsonSqFliteStorage> {
-  const StorageProvider._(
-      {FutureOr<JsonSqFliteStorage> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const StorageProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -45,10 +41,6 @@ final class StorageProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<JsonSqFliteStorage> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$storageHash();
 
@@ -56,21 +48,11 @@ final class StorageProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<JsonSqFliteStorage> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  StorageProvider $copyWithCreate(
-    FutureOr<JsonSqFliteStorage> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return StorageProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<JsonSqFliteStorage> create(Ref ref) {
-    final _$cb = _createCb ?? storage;
-    return _$cb(ref);
+    return storage(ref);
   }
 }
 
@@ -82,10 +64,8 @@ const todosNotifierProvider = TodosNotifierProvider._();
 
 final class TodosNotifierProvider
     extends $AsyncNotifierProvider<TodosNotifier, List<Todo>> {
-  const TodosNotifierProvider._(
-      {super.runNotifierBuildOverride, TodosNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const TodosNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -95,39 +75,26 @@ final class TodosNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final TodosNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todosNotifierHash();
 
   @$internal
   @override
-  TodosNotifier create() => _createCb?.call() ?? TodosNotifier();
-
-  @$internal
-  @override
-  TodosNotifierProvider $copyWithCreate(
-    TodosNotifier Function() create,
-  ) {
-    return TodosNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  TodosNotifierProvider $copyWithBuild(
-    FutureOr<List<Todo>> Function(
-      Ref,
-      TodosNotifier,
-    ) build,
-  ) {
-    return TodosNotifierProvider._(runNotifierBuildOverride: build);
-  }
+  TodosNotifier create() => TodosNotifier();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<TodosNotifier, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<Todo>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
+    );
+  }
 }
 
 String _$todosNotifierHash() => r'f7c580875a00ab559ff61cbd0f6986fe1fd515e6';

--- a/website/docs/advanced/select/select/codegen.g.dart
+++ b/website/docs/advanced/select/select/codegen.g.dart
@@ -13,12 +13,8 @@ const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $FunctionalProvider<User, User>
     with $Provider<User> {
-  const ExampleProvider._(
-      {User Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class ExampleProvider extends $FunctionalProvider<User, User>
           allTransitiveDependencies: null,
         );
 
-  final User Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  $ProviderElement<User> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  User create(Ref ref) {
+    return example(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(User value) {
@@ -41,26 +43,6 @@ final class ExampleProvider extends $FunctionalProvider<User, User>
       origin: this,
       providerOverride: $ValueProvider<User>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<User> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    User Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @override
-  User create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/advanced/select/select_async/codegen.g.dart
+++ b/website/docs/advanced/select/select_async/codegen.g.dart
@@ -14,12 +14,8 @@ const userProvider = UserProvider._();
 final class UserProvider
     extends $FunctionalProvider<AsyncValue<User>, FutureOr<User>>
     with $FutureModifier<User>, $FutureProvider<User> {
-  const UserProvider._(
-      {FutureOr<User> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const UserProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class UserProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<User> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$userHash();
 
   @$internal
   @override
   $FutureProviderElement<User> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  UserProvider $copyWithCreate(
-    FutureOr<User> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return UserProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<User> create(Ref ref) {
-    final _$cb = _createCb ?? user;
-    return _$cb(ref);
+    return user(ref);
   }
 }
 
@@ -64,12 +46,8 @@ const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $FunctionalProvider<Object?, Object?>
     with $Provider<Object?> {
-  const ExampleProvider._(
-      {Object? Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -79,12 +57,18 @@ final class ExampleProvider extends $FunctionalProvider<Object?, Object?>
           allTransitiveDependencies: null,
         );
 
-  final Object? Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  $ProviderElement<Object?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Object? create(Ref ref) {
+    return example(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Object? value) {
@@ -92,26 +76,6 @@ final class ExampleProvider extends $FunctionalProvider<Object?, Object?>
       origin: this,
       providerOverride: $ValueProvider<Object?>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Object?> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    Object? Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @override
-  Object? create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/case_studies/cancel/detail_screen/codegen.g.dart
+++ b/website/docs/case_studies/cancel/detail_screen/codegen.g.dart
@@ -32,12 +32,8 @@ const activityProvider = ActivityProvider._();
 final class ActivityProvider
     extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
-  const ActivityProvider._(
-      {FutureOr<Activity> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ActivityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -47,31 +43,17 @@ final class ActivityProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Activity> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$activityHash();
 
   @$internal
   @override
   $FutureProviderElement<Activity> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ActivityProvider $copyWithCreate(
-    FutureOr<Activity> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ActivityProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Activity> create(Ref ref) {
-    final _$cb = _createCb ?? activity;
-    return _$cb(ref);
+    return activity(ref);
   }
 }
 

--- a/website/docs/case_studies/cancel/detail_screen_cancel/codegen.g.dart
+++ b/website/docs/case_studies/cancel/detail_screen_cancel/codegen.g.dart
@@ -14,12 +14,8 @@ const activityProvider = ActivityProvider._();
 final class ActivityProvider
     extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
-  const ActivityProvider._(
-      {FutureOr<Activity> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ActivityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ActivityProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Activity> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$activityHash();
 
   @$internal
   @override
   $FutureProviderElement<Activity> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ActivityProvider $copyWithCreate(
-    FutureOr<Activity> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ActivityProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Activity> create(Ref ref) {
-    final _$cb = _createCb ?? activity;
-    return _$cb(ref);
+    return activity(ref);
   }
 }
 

--- a/website/docs/case_studies/cancel/detail_screen_debounce/codegen.g.dart
+++ b/website/docs/case_studies/cancel/detail_screen_debounce/codegen.g.dart
@@ -14,12 +14,8 @@ const activityProvider = ActivityProvider._();
 final class ActivityProvider
     extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
-  const ActivityProvider._(
-      {FutureOr<Activity> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ActivityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ActivityProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Activity> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$activityHash();
 
   @$internal
   @override
   $FutureProviderElement<Activity> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ActivityProvider $copyWithCreate(
-    FutureOr<Activity> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ActivityProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Activity> create(Ref ref) {
-    final _$cb = _createCb ?? activity;
-    return _$cb(ref);
+    return activity(ref);
   }
 }
 

--- a/website/docs/case_studies/cancel/provider_with_extension/codegen.g.dart
+++ b/website/docs/case_studies/cancel/provider_with_extension/codegen.g.dart
@@ -14,12 +14,8 @@ const activityProvider = ActivityProvider._();
 final class ActivityProvider
     extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
-  const ActivityProvider._(
-      {FutureOr<Activity> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ActivityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ActivityProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Activity> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$activityHash();
 
   @$internal
   @override
   $FutureProviderElement<Activity> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ActivityProvider $copyWithCreate(
-    FutureOr<Activity> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ActivityProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Activity> create(Ref ref) {
-    final _$cb = _createCb ?? activity;
-    return _$cb(ref);
+    return activity(ref);
   }
 }
 

--- a/website/docs/case_studies/pull_to_refresh/fetch_activity/codegen.g.dart
+++ b/website/docs/case_studies/pull_to_refresh/fetch_activity/codegen.g.dart
@@ -14,12 +14,8 @@ const activityProvider = ActivityProvider._();
 final class ActivityProvider
     extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
-  const ActivityProvider._(
-      {FutureOr<Activity> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ActivityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ActivityProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Activity> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$activityHash();
 
   @$internal
   @override
   $FutureProviderElement<Activity> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ActivityProvider $copyWithCreate(
-    FutureOr<Activity> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ActivityProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Activity> create(Ref ref) {
-    final _$cb = _createCb ?? activity;
-    return _$cb(ref);
+    return activity(ref);
   }
 }
 

--- a/website/docs/case_studies/pull_to_refresh/full_app/codegen.g.dart
+++ b/website/docs/case_studies/pull_to_refresh/full_app/codegen.g.dart
@@ -32,12 +32,8 @@ const activityProvider = ActivityProvider._();
 final class ActivityProvider
     extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
-  const ActivityProvider._(
-      {FutureOr<Activity> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ActivityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -47,31 +43,17 @@ final class ActivityProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Activity> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$activityHash();
 
   @$internal
   @override
   $FutureProviderElement<Activity> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ActivityProvider $copyWithCreate(
-    FutureOr<Activity> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ActivityProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Activity> create(Ref ref) {
-    final _$cb = _createCb ?? activity;
-    return _$cb(ref);
+    return activity(ref);
   }
 }
 

--- a/website/docs/concepts/about_codegen/main.g.dart
+++ b/website/docs/concepts/about_codegen/main.g.dart
@@ -15,25 +15,14 @@ final class FetchUserProvider
     extends $FunctionalProvider<AsyncValue<User>, FutureOr<User>>
     with $FutureModifier<User>, $FutureProvider<User> {
   const FetchUserProvider._(
-      {required FetchUserFamily super.from,
-      required int super.argument,
-      FutureOr<User> Function(
-        Ref ref, {
-        required int userId,
-      })? create})
-      : _createCb = create,
-        super(
+      {required FetchUserFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'fetchUserProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FutureOr<User> Function(
-    Ref ref, {
-    required int userId,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$fetchUserHash();
@@ -48,29 +37,12 @@ final class FetchUserProvider
   @$internal
   @override
   $FutureProviderElement<User> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  FetchUserProvider $copyWithCreate(
-    FutureOr<User> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FetchUserProvider._(
-        argument: argument as int,
-        from: from! as FetchUserFamily,
-        create: (
-          ref, {
-          required int userId,
-        }) =>
-            create(ref));
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<User> create(Ref ref) {
-    final _$cb = _createCb ?? fetchUser;
     final argument = this.argument as int;
-    return _$cb(
+    return fetchUser(
       ref,
       userId: argument,
     );
@@ -105,31 +77,23 @@ final class FetchUserFamily extends Family {
       FetchUserProvider._(argument: userId, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$fetchUserHash();
-
-  @override
   String toString() => r'fetchUserProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FutureOr<User> Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FetchUserProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<User> Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FetchUserProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/concepts/about_codegen/provider_type/async_class_future.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_class_future.g.dart
@@ -35,14 +35,6 @@ final class ExampleProvider extends $AsyncNotifierProvider<Example, String> {
   $AsyncNotifierProviderElement<Example, String> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<String> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<String>>(value),
-    );
-  }
 }
 
 String _$exampleHash() => r'8a906741b8ea4b9b0d3f0b924779704b3e1773a1';

--- a/website/docs/concepts/about_codegen/provider_type/async_class_future.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_class_future.g.dart
@@ -12,10 +12,8 @@ part of 'async_class_future.dart';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $AsyncNotifierProvider<Example, String> {
-  const ExampleProvider._(
-      {super.runNotifierBuildOverride, Example Function()? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,39 +23,26 @@ final class ExampleProvider extends $AsyncNotifierProvider<Example, String> {
           allTransitiveDependencies: null,
         );
 
-  final Example Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
 
   @$internal
   @override
-  Example create() => _createCb?.call() ?? Example();
-
-  @$internal
-  @override
-  ExampleProvider $copyWithCreate(
-    Example Function() create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  ExampleProvider $copyWithBuild(
-    FutureOr<String> Function(
-      Ref,
-      Example,
-    ) build,
-  ) {
-    return ExampleProvider._(runNotifierBuildOverride: build);
-  }
+  Example create() => Example();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<Example, String> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<String>>(value),
+    );
+  }
 }
 
 String _$exampleHash() => r'8a906741b8ea4b9b0d3f0b924779704b3e1773a1';

--- a/website/docs/concepts/about_codegen/provider_type/async_class_stream.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_class_stream.g.dart
@@ -35,14 +35,6 @@ final class ExampleProvider extends $StreamNotifierProvider<Example, String> {
   $StreamNotifierProviderElement<Example, String> $createElement(
           $ProviderPointer pointer) =>
       $StreamNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<String> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<String>>(value),
-    );
-  }
 }
 
 String _$exampleHash() => r'4bca936132b77a9a804549f086f33571724b4804';

--- a/website/docs/concepts/about_codegen/provider_type/async_class_stream.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_class_stream.g.dart
@@ -12,10 +12,8 @@ part of 'async_class_stream.dart';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $StreamNotifierProvider<Example, String> {
-  const ExampleProvider._(
-      {super.runNotifierBuildOverride, Example Function()? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,39 +23,26 @@ final class ExampleProvider extends $StreamNotifierProvider<Example, String> {
           allTransitiveDependencies: null,
         );
 
-  final Example Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
 
   @$internal
   @override
-  Example create() => _createCb?.call() ?? Example();
-
-  @$internal
-  @override
-  ExampleProvider $copyWithCreate(
-    Example Function() create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  ExampleProvider $copyWithBuild(
-    Stream<String> Function(
-      Ref,
-      Example,
-    ) build,
-  ) {
-    return ExampleProvider._(runNotifierBuildOverride: build);
-  }
+  Example create() => Example();
 
   @$internal
   @override
   $StreamNotifierProviderElement<Example, String> $createElement(
           $ProviderPointer pointer) =>
-      $StreamNotifierProviderElement(this, pointer);
+      $StreamNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<String> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<String>>(value),
+    );
+  }
 }
 
 String _$exampleHash() => r'4bca936132b77a9a804549f086f33571724b4804';

--- a/website/docs/concepts/about_codegen/provider_type/async_fn_future.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_fn_future.g.dart
@@ -14,12 +14,8 @@ const exampleProvider = ExampleProvider._();
 final class ExampleProvider
     extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
-  const ExampleProvider._(
-      {FutureOr<String> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ExampleProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<String> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
 
   @$internal
   @override
   $FutureProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    FutureOr<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<String> create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
+    return example(ref);
   }
 }
 

--- a/website/docs/concepts/about_codegen/provider_type/async_fn_stream.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_fn_stream.g.dart
@@ -14,12 +14,8 @@ const exampleProvider = ExampleProvider._();
 final class ExampleProvider
     extends $FunctionalProvider<AsyncValue<String>, Stream<String>>
     with $FutureModifier<String>, $StreamProvider<String> {
-  const ExampleProvider._(
-      {Stream<String> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ExampleProvider
           allTransitiveDependencies: null,
         );
 
-  final Stream<String> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
 
   @$internal
   @override
   $StreamProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    Stream<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<String> create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
+    return example(ref);
   }
 }
 

--- a/website/docs/concepts/about_codegen/provider_type/auto_dispose.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/auto_dispose.g.dart
@@ -13,12 +13,8 @@ const example1Provider = Example1Provider._();
 
 final class Example1Provider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const Example1Provider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Example1Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class Example1Provider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$example1Hash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return example1(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -41,26 +43,6 @@ final class Example1Provider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Example1Provider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Example1Provider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? example1;
-    return _$cb(ref);
   }
 }
 
@@ -71,12 +53,8 @@ const example2Provider = Example2Provider._();
 
 final class Example2Provider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const Example2Provider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const Example2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -86,12 +64,18 @@ final class Example2Provider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$example2Hash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return example2(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -99,26 +83,6 @@ final class Example2Provider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  Example2Provider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return Example2Provider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? example2;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/about_codegen/provider_type/family.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family.g.dart
@@ -14,25 +14,14 @@ const exampleProvider = ExampleFamily._();
 final class ExampleProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
   const ExampleProvider._(
-      {required ExampleFamily super.from,
-      required int super.argument,
-      String Function(
-        Ref ref,
-        int param,
-      )? create})
-      : _createCb = create,
-        super(
+      {required ExampleFamily super.from, required int super.argument})
+      : super(
           retry: null,
           name: r'exampleProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    int param,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
@@ -44,42 +33,25 @@ final class ExampleProvider extends $FunctionalProvider<String, String>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    final argument = this.argument as int;
+    return example(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(
-        argument: argument as int,
-        from: from! as ExampleFamily,
-        create: (
-          ref,
-          int param,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    final argument = this.argument as int;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -112,31 +84,23 @@ final class ExampleFamily extends Family {
       ExampleProvider._(argument: param, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$exampleHash();
-
-  @override
   String toString() => r'exampleProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      int args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ExampleProvider;
-
-        final argument = provider.argument as int;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            int args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ExampleProvider;
+            final argument = provider.argument as int;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/concepts/about_codegen/provider_type/family_class.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_class.g.dart
@@ -18,19 +18,14 @@ final class ExampleProvider extends $NotifierProvider<Example, String> {
         int, {
         String param2,
       })
-          super.argument,
-      super.runNotifierBuildOverride,
-      Example Function()? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'exampleProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final Example Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
@@ -42,6 +37,16 @@ final class ExampleProvider extends $NotifierProvider<Example, String> {
         '$argument';
   }
 
+  @$internal
+  @override
+  Example create() => Example();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Example, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
@@ -49,47 +54,6 @@ final class ExampleProvider extends $NotifierProvider<Example, String> {
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  Example create() => _createCb?.call() ?? Example();
-
-  @$internal
-  @override
-  ExampleProvider $copyWithCreate(
-    Example Function() create,
-  ) {
-    return ExampleProvider._(
-        argument: argument as (
-          int, {
-          String param2,
-        }),
-        from: from! as ExampleFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  ExampleProvider $copyWithBuild(
-    String Function(
-      Ref,
-      Example,
-    ) build,
-  ) {
-    return ExampleProvider._(
-        argument: argument as (
-          int, {
-          String param2,
-        }),
-        from: from! as ExampleFamily,
-        runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Example, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 
   @override
   bool operator ==(Object other) {
@@ -124,64 +88,53 @@ final class ExampleFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$exampleHash();
-
-  @override
   String toString() => r'exampleProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    Example Function(
-      (
-        int, {
-        String param2,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ExampleProvider;
-
-        final argument = provider.argument as (
-          int, {
-          String param2,
-        });
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-    String Function(
-            Ref ref,
-            Example notifier,
+          Example Function(
             (
               int, {
               String param2,
-            }) argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ExampleProvider;
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ExampleProvider;
+            final argument = provider.argument as (
+              int, {
+              String param2,
+            });
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
-        final argument = provider.argument as (
-          int, {
-          String param2,
-        });
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+  /// {@macro riverpod.override_with_build}
+  Override overrideWithBuild(
+          String Function(
+                  Ref ref,
+                  Example notifier,
+                  (
+                    int, {
+                    String param2,
+                  }) argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ExampleProvider;
+            final argument = provider.argument as (
+              int, {
+              String param2,
+            });
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$Example extends $Notifier<String> {

--- a/website/docs/concepts/about_codegen/provider_type/family_fn.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_fn.g.dart
@@ -19,26 +19,14 @@ final class ExampleProvider extends $FunctionalProvider<String, String>
         int, {
         String param2,
       })
-          super.argument,
-      String Function(
-        Ref ref,
-        int param1, {
-        String param2,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'exampleProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    int param1, {
-    String param2,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
@@ -50,50 +38,29 @@ final class ExampleProvider extends $FunctionalProvider<String, String>
         '$argument';
   }
 
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    final argument = this.argument as (
+      int, {
+      String param2,
+    });
+    return example(
+      ref,
+      argument.$1,
+      param2: argument.param2,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(
-        argument: argument as (
-          int, {
-          String param2,
-        }),
-        from: from! as ExampleFamily,
-        create: (
-          ref,
-          int param1, {
-          String param2 = 'foo',
-        }) =>
-            create(ref));
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    final argument = this.argument as (
-      int, {
-      String param2,
-    });
-    return _$cb(
-      ref,
-      argument.$1,
-      param2: argument.param2,
     );
   }
 
@@ -130,37 +97,29 @@ final class ExampleFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$exampleHash();
-
-  @override
   String toString() => r'exampleProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      (
-        int, {
-        String param2,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ExampleProvider;
-
-        final argument = provider.argument as (
-          int, {
-          String param2,
-        });
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            (
+              int, {
+              String param2,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ExampleProvider;
+            final argument = provider.argument as (
+              int, {
+              String param2,
+            });
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/concepts/about_codegen/provider_type/sync_class.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/sync_class.g.dart
@@ -12,10 +12,8 @@ part of 'sync_class.dart';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $NotifierProvider<Example, String> {
-  const ExampleProvider._(
-      {super.runNotifierBuildOverride, Example Function()? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class ExampleProvider extends $NotifierProvider<Example, String> {
           allTransitiveDependencies: null,
         );
 
-  final Example Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  Example create() => Example();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Example, String> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -37,35 +43,6 @@ final class ExampleProvider extends $NotifierProvider<Example, String> {
       providerOverride: $ValueProvider<String>(value),
     );
   }
-
-  @$internal
-  @override
-  Example create() => _createCb?.call() ?? Example();
-
-  @$internal
-  @override
-  ExampleProvider $copyWithCreate(
-    Example Function() create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  ExampleProvider $copyWithBuild(
-    String Function(
-      Ref,
-      Example,
-    ) build,
-  ) {
-    return ExampleProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Example, String> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$exampleHash() => r'c237193ab6d57674973aaa02eb73db6f6822eb26';

--- a/website/docs/concepts/about_codegen/provider_type/sync_fn.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/sync_fn.g.dart
@@ -13,12 +13,8 @@ const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const ExampleProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class ExampleProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return example(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -41,26 +43,6 @@ final class ExampleProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/combining_provider_states/characters_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/characters_provider/codegen.g.dart
@@ -13,12 +13,8 @@ const searchProvider = SearchProvider._();
 
 final class SearchProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const SearchProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const SearchProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class SearchProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$searchHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return search(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -41,26 +43,6 @@ final class SearchProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  SearchProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return SearchProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? search;
-    return _$cb(ref);
   }
 }
 
@@ -72,12 +54,8 @@ const configsProvider = ConfigsProvider._();
 final class ConfigsProvider extends $FunctionalProvider<
         AsyncValue<Configuration>, Stream<Configuration>>
     with $FutureModifier<Configuration>, $StreamProvider<Configuration> {
-  const ConfigsProvider._(
-      {Stream<Configuration> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ConfigsProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -87,10 +65,6 @@ final class ConfigsProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final Stream<Configuration> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$configsHash();
 
@@ -98,21 +72,11 @@ final class ConfigsProvider extends $FunctionalProvider<
   @override
   $StreamProviderElement<Configuration> $createElement(
           $ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  ConfigsProvider $copyWithCreate(
-    Stream<Configuration> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ConfigsProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<Configuration> create(Ref ref) {
-    final _$cb = _createCb ?? configs;
-    return _$cb(ref);
+    return configs(ref);
   }
 }
 
@@ -124,12 +88,8 @@ const charactersProvider = CharactersProvider._();
 final class CharactersProvider extends $FunctionalProvider<
         AsyncValue<List<Character>>, FutureOr<List<Character>>>
     with $FutureModifier<List<Character>>, $FutureProvider<List<Character>> {
-  const CharactersProvider._(
-      {FutureOr<List<Character>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CharactersProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -139,10 +99,6 @@ final class CharactersProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<List<Character>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$charactersHash();
 
@@ -150,21 +106,11 @@ final class CharactersProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<List<Character>> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  CharactersProvider $copyWithCreate(
-    FutureOr<List<Character>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CharactersProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Character>> create(Ref ref) {
-    final _$cb = _createCb ?? characters;
-    return _$cb(ref);
+    return characters(ref);
   }
 }
 

--- a/website/docs/concepts/combining_provider_states/city_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/city_provider/codegen.g.dart
@@ -13,12 +13,8 @@ const cityProvider = CityProvider._();
 
 final class CityProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const CityProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class CityProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$cityHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return city(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -41,26 +43,6 @@ final class CityProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CityProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CityProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? city;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/codegen.g.dart
@@ -13,12 +13,8 @@ const filterProvider = FilterProvider._();
 
 final class FilterProvider extends $FunctionalProvider<Filter, Filter>
     with $Provider<Filter> {
-  const FilterProvider._(
-      {Filter Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FilterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class FilterProvider extends $FunctionalProvider<Filter, Filter>
           allTransitiveDependencies: null,
         );
 
-  final Filter Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$filterHash();
+
+  @$internal
+  @override
+  $ProviderElement<Filter> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Filter create(Ref ref) {
+    return filter(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Filter value) {
@@ -41,26 +43,6 @@ final class FilterProvider extends $FunctionalProvider<Filter, Filter>
       origin: this,
       providerOverride: $ValueProvider<Filter>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Filter> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FilterProvider $copyWithCreate(
-    Filter Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FilterProvider._(create: create);
-  }
-
-  @override
-  Filter create(Ref ref) {
-    final _$cb = _createCb ?? filter;
-    return _$cb(ref);
   }
 }
 
@@ -72,12 +54,8 @@ const filteredTodoListProvider = FilteredTodoListProvider._();
 final class FilteredTodoListProvider
     extends $FunctionalProvider<List<Todo>, List<Todo>>
     with $Provider<List<Todo>> {
-  const FilteredTodoListProvider._(
-      {List<Todo> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FilteredTodoListProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -87,12 +65,18 @@ final class FilteredTodoListProvider
           allTransitiveDependencies: null,
         );
 
-  final List<Todo> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$filteredTodoListHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<Todo> create(Ref ref) {
+    return filteredTodoList(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -100,26 +84,6 @@ final class FilteredTodoListProvider
       origin: this,
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FilteredTodoListProvider $copyWithCreate(
-    List<Todo> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FilteredTodoListProvider._(create: create);
-  }
-
-  @override
-  List<Todo> create(Ref ref) {
-    final _$cb = _createCb ?? filteredTodoList;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/combining_provider_states/read_in_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/read_in_provider/codegen.g.dart
@@ -13,12 +13,8 @@ const anotherProvider = AnotherProvider._();
 
 final class AnotherProvider extends $FunctionalProvider<MyValue, MyValue>
     with $Provider<MyValue> {
-  const AnotherProvider._(
-      {MyValue Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AnotherProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class AnotherProvider extends $FunctionalProvider<MyValue, MyValue>
           allTransitiveDependencies: null,
         );
 
-  final MyValue Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$anotherHash();
+
+  @$internal
+  @override
+  $ProviderElement<MyValue> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  MyValue create(Ref ref) {
+    return another(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyValue value) {
@@ -41,26 +43,6 @@ final class AnotherProvider extends $FunctionalProvider<MyValue, MyValue>
       origin: this,
       providerOverride: $ValueProvider<MyValue>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<MyValue> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AnotherProvider $copyWithCreate(
-    MyValue Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AnotherProvider._(create: create);
-  }
-
-  @override
-  MyValue create(Ref ref) {
-    final _$cb = _createCb ?? another;
-    return _$cb(ref);
   }
 }
 
@@ -71,12 +53,8 @@ const myProvider = MyProvider._();
 
 final class MyProvider extends $FunctionalProvider<MyValue, MyValue>
     with $Provider<MyValue> {
-  const MyProvider._(
-      {MyValue Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const MyProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -86,12 +64,18 @@ final class MyProvider extends $FunctionalProvider<MyValue, MyValue>
           allTransitiveDependencies: null,
         );
 
-  final MyValue Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myHash();
+
+  @$internal
+  @override
+  $ProviderElement<MyValue> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  MyValue create(Ref ref) {
+    return my(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyValue value) {
@@ -99,26 +83,6 @@ final class MyProvider extends $FunctionalProvider<MyValue, MyValue>
       origin: this,
       providerOverride: $ValueProvider<MyValue>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<MyValue> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  MyProvider $copyWithCreate(
-    MyValue Function(
-      Ref ref,
-    ) create,
-  ) {
-    return MyProvider._(create: create);
-  }
-
-  @override
-  MyValue create(Ref ref) {
-    final _$cb = _createCb ?? my;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/combining_provider_states/select_async_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/select_async_provider/codegen.g.dart
@@ -14,12 +14,8 @@ const configProvider = ConfigProvider._();
 final class ConfigProvider extends $FunctionalProvider<
         AsyncValue<Configuration>, Stream<Configuration>>
     with $FutureModifier<Configuration>, $StreamProvider<Configuration> {
-  const ConfigProvider._(
-      {Stream<Configuration> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ConfigProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,10 +25,6 @@ final class ConfigProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final Stream<Configuration> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$configHash();
 
@@ -40,21 +32,11 @@ final class ConfigProvider extends $FunctionalProvider<
   @override
   $StreamProviderElement<Configuration> $createElement(
           $ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  ConfigProvider $copyWithCreate(
-    Stream<Configuration> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ConfigProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<Configuration> create(Ref ref) {
-    final _$cb = _createCb ?? config;
-    return _$cb(ref);
+    return config(ref);
   }
 }
 
@@ -66,12 +48,8 @@ const productsProvider = ProductsProvider._();
 final class ProductsProvider extends $FunctionalProvider<
         AsyncValue<List<Product>>, FutureOr<List<Product>>>
     with $FutureModifier<List<Product>>, $FutureProvider<List<Product>> {
-  const ProductsProvider._(
-      {FutureOr<List<Product>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ProductsProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -81,10 +59,6 @@ final class ProductsProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<List<Product>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$productsHash();
 
@@ -92,21 +66,11 @@ final class ProductsProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<List<Product>> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ProductsProvider $copyWithCreate(
-    FutureOr<List<Product>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ProductsProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Product>> create(Ref ref) {
-    final _$cb = _createCb ?? products;
-    return _$cb(ref);
+    return products(ref);
   }
 }
 

--- a/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.g.dart
@@ -12,10 +12,8 @@ part of 'codegen.dart';
 const todoListProvider = TodoListProvider._();
 
 final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
-  const TodoListProvider._(
-      {super.runNotifierBuildOverride, TodoList Function()? create})
-      : _createCb = create,
-        super(
+  const TodoListProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
           allTransitiveDependencies: null,
         );
 
-  final TodoList Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todoListHash();
+
+  @$internal
+  @override
+  TodoList create() => TodoList();
+
+  @$internal
+  @override
+  $NotifierProviderElement<TodoList, List<Todo>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -37,35 +43,6 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
   }
-
-  @$internal
-  @override
-  TodoList create() => _createCb?.call() ?? TodoList();
-
-  @$internal
-  @override
-  TodoListProvider $copyWithCreate(
-    TodoList Function() create,
-  ) {
-    return TodoListProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  TodoListProvider $copyWithBuild(
-    List<Todo> Function(
-      Ref,
-      TodoList,
-    ) build,
-  ) {
-    return TodoListProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<TodoList, List<Todo>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$todoListHash() => r'6c965beb867ffeee119133f0ae2e6ebeb68e6f7e';

--- a/website/docs/concepts/combining_provider_states/weather_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/weather_provider/codegen.g.dart
@@ -13,12 +13,8 @@ const cityProvider = CityProvider._();
 
 final class CityProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const CityProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class CityProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$cityHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return city(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -41,26 +43,6 @@ final class CityProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CityProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CityProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? city;
-    return _$cb(ref);
   }
 }
 
@@ -72,12 +54,8 @@ const weatherProvider = WeatherProvider._();
 final class WeatherProvider
     extends $FunctionalProvider<AsyncValue<Weather>, FutureOr<Weather>>
     with $FutureModifier<Weather>, $FutureProvider<Weather> {
-  const WeatherProvider._(
-      {FutureOr<Weather> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const WeatherProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -87,31 +65,17 @@ final class WeatherProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Weather> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$weatherHash();
 
   @$internal
   @override
   $FutureProviderElement<Weather> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  WeatherProvider $copyWithCreate(
-    FutureOr<Weather> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return WeatherProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Weather> create(Ref ref) {
-    final _$cb = _createCb ?? weather;
-    return _$cb(ref);
+    return weather(ref);
   }
 }
 

--- a/website/docs/concepts/combining_provider_states/whole_object_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/whole_object_provider/codegen.g.dart
@@ -14,12 +14,8 @@ const configProvider = ConfigProvider._();
 final class ConfigProvider extends $FunctionalProvider<
         AsyncValue<Configuration>, Stream<Configuration>>
     with $FutureModifier<Configuration>, $StreamProvider<Configuration> {
-  const ConfigProvider._(
-      {Stream<Configuration> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ConfigProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,10 +25,6 @@ final class ConfigProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final Stream<Configuration> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$configHash();
 
@@ -40,21 +32,11 @@ final class ConfigProvider extends $FunctionalProvider<
   @override
   $StreamProviderElement<Configuration> $createElement(
           $ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  ConfigProvider $copyWithCreate(
-    Stream<Configuration> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ConfigProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<Configuration> create(Ref ref) {
-    final _$cb = _createCb ?? config;
-    return _$cb(ref);
+    return config(ref);
   }
 }
 
@@ -66,12 +48,8 @@ const productsProvider = ProductsProvider._();
 final class ProductsProvider extends $FunctionalProvider<
         AsyncValue<List<Product>>, FutureOr<List<Product>>>
     with $FutureModifier<List<Product>>, $FutureProvider<List<Product>> {
-  const ProductsProvider._(
-      {FutureOr<List<Product>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ProductsProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -81,10 +59,6 @@ final class ProductsProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<List<Product>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$productsHash();
 
@@ -92,21 +66,11 @@ final class ProductsProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<List<Product>> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ProductsProvider $copyWithCreate(
-    FutureOr<List<Product>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ProductsProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Product>> create(Ref ref) {
-    final _$cb = _createCb ?? products;
-    return _$cb(ref);
+    return products(ref);
   }
 }
 

--- a/website/docs/concepts/lifecycle_on_dispose/codegen.g.dart
+++ b/website/docs/concepts/lifecycle_on_dispose/codegen.g.dart
@@ -14,12 +14,8 @@ const exampleProvider = ExampleProvider._();
 final class ExampleProvider
     extends $FunctionalProvider<AsyncValue<int>, Stream<int>>
     with $FutureModifier<int>, $StreamProvider<int> {
-  const ExampleProvider._(
-      {Stream<int> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ExampleProvider
           allTransitiveDependencies: null,
         );
 
-  final Stream<int> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
 
   @$internal
   @override
   $StreamProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    Stream<int> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<int> create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
+    return example(ref);
   }
 }
 

--- a/website/docs/concepts/providers/creating_a_provider/codegen.g.dart
+++ b/website/docs/concepts/providers/creating_a_provider/codegen.g.dart
@@ -13,12 +13,8 @@ const myProvider = MyProvider._();
 
 final class MyProvider extends $FunctionalProvider<MyValue, MyValue>
     with $Provider<MyValue> {
-  const MyProvider._(
-      {MyValue Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const MyProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class MyProvider extends $FunctionalProvider<MyValue, MyValue>
           allTransitiveDependencies: null,
         );
 
-  final MyValue Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myHash();
+
+  @$internal
+  @override
+  $ProviderElement<MyValue> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  MyValue create(Ref ref) {
+    return my(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(MyValue value) {
@@ -41,26 +43,6 @@ final class MyProvider extends $FunctionalProvider<MyValue, MyValue>
       origin: this,
       providerOverride: $ValueProvider<MyValue>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<MyValue> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  MyProvider $copyWithCreate(
-    MyValue Function(
-      Ref ref,
-    ) create,
-  ) {
-    return MyProvider._(create: create);
-  }
-
-  @override
-  MyValue create(Ref ref) {
-    final _$cb = _createCb ?? my;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/providers/declaring_many_providers/codegen.g.dart
+++ b/website/docs/concepts/providers/declaring_many_providers/codegen.g.dart
@@ -13,12 +13,8 @@ const cityProvider = CityProvider._();
 
 final class CityProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const CityProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class CityProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$cityHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return city(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -41,26 +43,6 @@ final class CityProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CityProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CityProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? city;
-    return _$cb(ref);
   }
 }
 
@@ -71,12 +53,8 @@ const countryProvider = CountryProvider._();
 
 final class CountryProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const CountryProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CountryProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -86,12 +64,18 @@ final class CountryProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$countryHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return country(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -99,26 +83,6 @@ final class CountryProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CountryProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CountryProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? country;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/reading/counter/codegen.g.dart
+++ b/website/docs/concepts/reading/counter/codegen.g.dart
@@ -14,12 +14,8 @@ const repositoryProvider = RepositoryProvider._();
 final class RepositoryProvider
     extends $FunctionalProvider<Repository, Repository>
     with $Provider<Repository> {
-  const RepositoryProvider._(
-      {Repository Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RepositoryProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,12 +25,18 @@ final class RepositoryProvider
           allTransitiveDependencies: null,
         );
 
-  final Repository Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$repositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<Repository> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Repository create(Ref ref) {
+    return repository(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Repository value) {
@@ -42,26 +44,6 @@ final class RepositoryProvider
       origin: this,
       providerOverride: $ValueProvider<Repository>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Repository> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RepositoryProvider $copyWithCreate(
-    Repository Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RepositoryProvider._(create: create);
-  }
-
-  @override
-  Repository create(Ref ref) {
-    final _$cb = _createCb ?? repository;
-    return _$cb(ref);
   }
 }
 
@@ -71,10 +53,8 @@ String _$repositoryHash() => r'6f859a9d70c3112139aaf826ee2bd541a4c001cb';
 const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $NotifierProvider<Counter, int> {
-  const CounterProvider._(
-      {super.runNotifierBuildOverride, Counter Function()? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -84,10 +64,18 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
           allTransitiveDependencies: null,
         );
 
-  final Counter Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  Counter create() => Counter();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Counter, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -96,35 +84,6 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Counter create() => _createCb?.call() ?? Counter();
-
-  @$internal
-  @override
-  CounterProvider $copyWithCreate(
-    Counter Function() create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Counter,
-    ) build,
-  ) {
-    return CounterProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Counter, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterHash() => r'6bd7806869af024b3288645da03c077af9478083';

--- a/website/docs/concepts/reading/listen/codegen.g.dart
+++ b/website/docs/concepts/reading/listen/codegen.g.dart
@@ -13,12 +13,8 @@ const anotherProvider = AnotherProvider._();
 
 final class AnotherProvider extends $FunctionalProvider<void, void>
     with $Provider<void> {
-  const AnotherProvider._(
-      {void Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AnotherProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class AnotherProvider extends $FunctionalProvider<void, void>
           allTransitiveDependencies: null,
         );
 
-  final void Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$anotherHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return another(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(void value) {
@@ -41,26 +43,6 @@ final class AnotherProvider extends $FunctionalProvider<void, void>
       origin: this,
       providerOverride: $ValueProvider<void>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AnotherProvider $copyWithCreate(
-    void Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AnotherProvider._(create: create);
-  }
-
-  @override
-  void create(Ref ref) {
-    final _$cb = _createCb ?? another;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/reading/listen_build/codegen.g.dart
+++ b/website/docs/concepts/reading/listen_build/codegen.g.dart
@@ -12,10 +12,8 @@ part of 'codegen.dart';
 const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $NotifierProvider<Counter, int> {
-  const CounterProvider._(
-      {super.runNotifierBuildOverride, Counter Function()? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
           allTransitiveDependencies: null,
         );
 
-  final Counter Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  Counter create() => Counter();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Counter, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Counter create() => _createCb?.call() ?? Counter();
-
-  @$internal
-  @override
-  CounterProvider $copyWithCreate(
-    Counter Function() create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Counter,
-    ) build,
-  ) {
-    return CounterProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Counter, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterHash() => r'4320f811608c7a6e7342b83e3031965a34f7cb8e';

--- a/website/docs/concepts/reading/listen_build/codegen_hooks.g.dart
+++ b/website/docs/concepts/reading/listen_build/codegen_hooks.g.dart
@@ -12,10 +12,8 @@ part of 'codegen_hooks.dart';
 const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $NotifierProvider<Counter, int> {
-  const CounterProvider._(
-      {super.runNotifierBuildOverride, Counter Function()? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
           allTransitiveDependencies: null,
         );
 
-  final Counter Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  Counter create() => Counter();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Counter, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Counter create() => _createCb?.call() ?? Counter();
-
-  @$internal
-  @override
-  CounterProvider $copyWithCreate(
-    Counter Function() create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Counter,
-    ) build,
-  ) {
-    return CounterProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Counter, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterHash() => r'4320f811608c7a6e7342b83e3031965a34f7cb8e';

--- a/website/docs/concepts/reading/provider/codegen.g.dart
+++ b/website/docs/concepts/reading/provider/codegen.g.dart
@@ -14,12 +14,8 @@ const repositoryProvider = RepositoryProvider._();
 final class RepositoryProvider
     extends $FunctionalProvider<Repository, Repository>
     with $Provider<Repository> {
-  const RepositoryProvider._(
-      {Repository Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RepositoryProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,12 +25,18 @@ final class RepositoryProvider
           allTransitiveDependencies: null,
         );
 
-  final Repository Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$repositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<Repository> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Repository create(Ref ref) {
+    return repository(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Repository value) {
@@ -42,26 +44,6 @@ final class RepositoryProvider
       origin: this,
       providerOverride: $ValueProvider<Repository>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Repository> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RepositoryProvider $copyWithCreate(
-    Repository Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RepositoryProvider._(create: create);
-  }
-
-  @override
-  Repository create(Ref ref) {
-    final _$cb = _createCb ?? repository;
-    return _$cb(ref);
   }
 }
 
@@ -72,12 +54,8 @@ const valueProvider = ValueProvider._();
 
 final class ValueProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const ValueProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ValueProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -87,12 +65,18 @@ final class ValueProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$valueHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return value(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -100,26 +84,6 @@ final class ValueProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ValueProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ValueProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? value;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/reading/read/codegen.g.dart
+++ b/website/docs/concepts/reading/read/codegen.g.dart
@@ -12,10 +12,8 @@ part of 'codegen.dart';
 const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $NotifierProvider<Counter, int> {
-  const CounterProvider._(
-      {super.runNotifierBuildOverride, Counter Function()? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
           allTransitiveDependencies: null,
         );
 
-  final Counter Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  Counter create() => Counter();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Counter, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Counter create() => _createCb?.call() ?? Counter();
-
-  @$internal
-  @override
-  CounterProvider $copyWithCreate(
-    Counter Function() create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Counter,
-    ) build,
-  ) {
-    return CounterProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Counter, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterHash() => r'600c6beb47b3732049b6955a9e49d7eef30c741a';

--- a/website/docs/concepts/reading/read/codegen_hooks.g.dart
+++ b/website/docs/concepts/reading/read/codegen_hooks.g.dart
@@ -12,10 +12,8 @@ part of 'codegen_hooks.dart';
 const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $NotifierProvider<Counter, int> {
-  const CounterProvider._(
-      {super.runNotifierBuildOverride, Counter Function()? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
           allTransitiveDependencies: null,
         );
 
-  final Counter Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  Counter create() => Counter();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Counter, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Counter create() => _createCb?.call() ?? Counter();
-
-  @$internal
-  @override
-  CounterProvider $copyWithCreate(
-    Counter Function() create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Counter,
-    ) build,
-  ) {
-    return CounterProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Counter, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterHash() => r'600c6beb47b3732049b6955a9e49d7eef30c741a';

--- a/website/docs/concepts/reading/read_build/codegen.g.dart
+++ b/website/docs/concepts/reading/read_build/codegen.g.dart
@@ -12,10 +12,8 @@ part of 'codegen.dart';
 const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $NotifierProvider<Counter, int> {
-  const CounterProvider._(
-      {super.runNotifierBuildOverride, Counter Function()? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
           allTransitiveDependencies: null,
         );
 
-  final Counter Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  Counter create() => Counter();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Counter, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Counter create() => _createCb?.call() ?? Counter();
-
-  @$internal
-  @override
-  CounterProvider $copyWithCreate(
-    Counter Function() create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Counter,
-    ) build,
-  ) {
-    return CounterProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Counter, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterHash() => r'600c6beb47b3732049b6955a9e49d7eef30c741a';

--- a/website/docs/concepts/reading/read_notifier_build/codegen.g.dart
+++ b/website/docs/concepts/reading/read_notifier_build/codegen.g.dart
@@ -12,10 +12,8 @@ part of 'codegen.dart';
 const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $NotifierProvider<Counter, int> {
-  const CounterProvider._(
-      {super.runNotifierBuildOverride, Counter Function()? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
           allTransitiveDependencies: null,
         );
 
-  final Counter Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  Counter create() => Counter();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Counter, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Counter create() => _createCb?.call() ?? Counter();
-
-  @$internal
-  @override
-  CounterProvider $copyWithCreate(
-    Counter Function() create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Counter,
-    ) build,
-  ) {
-    return CounterProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Counter, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterHash() => r'600c6beb47b3732049b6955a9e49d7eef30c741a';

--- a/website/docs/concepts/reading/watch/codegen.g.dart
+++ b/website/docs/concepts/reading/watch/codegen.g.dart
@@ -14,12 +14,8 @@ const filterTypeProvider = FilterTypeProvider._();
 final class FilterTypeProvider
     extends $FunctionalProvider<FilterType, FilterType>
     with $Provider<FilterType> {
-  const FilterTypeProvider._(
-      {FilterType Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FilterTypeProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,12 +25,18 @@ final class FilterTypeProvider
           allTransitiveDependencies: null,
         );
 
-  final FilterType Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$filterTypeHash();
+
+  @$internal
+  @override
+  $ProviderElement<FilterType> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  FilterType create(Ref ref) {
+    return filterType(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(FilterType value) {
@@ -42,26 +44,6 @@ final class FilterTypeProvider
       origin: this,
       providerOverride: $ValueProvider<FilterType>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<FilterType> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FilterTypeProvider $copyWithCreate(
-    FilterType Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FilterTypeProvider._(create: create);
-  }
-
-  @override
-  FilterType create(Ref ref) {
-    final _$cb = _createCb ?? filterType;
-    return _$cb(ref);
   }
 }
 
@@ -71,10 +53,8 @@ String _$filterTypeHash() => r'68d61a593d49306927c26fbcc66ea9fffa7c52f5';
 const todosProvider = TodosProvider._();
 
 final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
-  const TodosProvider._(
-      {super.runNotifierBuildOverride, Todos Function()? create})
-      : _createCb = create,
-        super(
+  const TodosProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -84,10 +64,18 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
           allTransitiveDependencies: null,
         );
 
-  final Todos Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todosHash();
+
+  @$internal
+  @override
+  Todos create() => Todos();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Todos, List<Todo>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -96,35 +84,6 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
   }
-
-  @$internal
-  @override
-  Todos create() => _createCb?.call() ?? Todos();
-
-  @$internal
-  @override
-  TodosProvider $copyWithCreate(
-    Todos Function() create,
-  ) {
-    return TodosProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  TodosProvider $copyWithBuild(
-    List<Todo> Function(
-      Ref,
-      Todos,
-    ) build,
-  ) {
-    return TodosProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Todos, List<Todo>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$todosHash() => r'b66ac2b1e5cf7ac7957d25864cfdffad1af233a6';
@@ -148,12 +107,8 @@ const filteredTodoListProvider = FilteredTodoListProvider._();
 final class FilteredTodoListProvider
     extends $FunctionalProvider<List<Todo>, List<Todo>>
     with $Provider<List<Todo>> {
-  const FilteredTodoListProvider._(
-      {List<Todo> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FilteredTodoListProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -163,12 +118,18 @@ final class FilteredTodoListProvider
           allTransitiveDependencies: null,
         );
 
-  final List<Todo> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$filteredTodoListHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<Todo> create(Ref ref) {
+    return filteredTodoList(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -176,26 +137,6 @@ final class FilteredTodoListProvider
       origin: this,
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FilteredTodoListProvider $copyWithCreate(
-    List<Todo> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FilteredTodoListProvider._(create: create);
-  }
-
-  @override
-  List<Todo> create(Ref ref) {
-    final _$cb = _createCb ?? filteredTodoList;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/reading/watch_build/codegen.g.dart
+++ b/website/docs/concepts/reading/watch_build/codegen.g.dart
@@ -12,10 +12,8 @@ part of 'codegen.dart';
 const todoListProvider = TodoListProvider._();
 
 final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
-  const TodoListProvider._(
-      {super.runNotifierBuildOverride, TodoList Function()? create})
-      : _createCb = create,
-        super(
+  const TodoListProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
           allTransitiveDependencies: null,
         );
 
-  final TodoList Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todoListHash();
+
+  @$internal
+  @override
+  TodoList create() => TodoList();
+
+  @$internal
+  @override
+  $NotifierProviderElement<TodoList, List<Todo>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -37,35 +43,6 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
   }
-
-  @$internal
-  @override
-  TodoList create() => _createCb?.call() ?? TodoList();
-
-  @$internal
-  @override
-  TodoListProvider $copyWithCreate(
-    TodoList Function() create,
-  ) {
-    return TodoListProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  TodoListProvider $copyWithBuild(
-    List<Todo> Function(
-      Ref,
-      TodoList,
-    ) build,
-  ) {
-    return TodoListProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<TodoList, List<Todo>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$todoListHash() => r'77f007cd4f5105330a4c2ab8555ea0d1716945c1';
@@ -88,12 +65,8 @@ const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const CounterProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -103,12 +76,18 @@ final class CounterProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return counter(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -116,26 +95,6 @@ final class CounterProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CounterProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? counter;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/reading/watch_build/codegen_hooks.g.dart
+++ b/website/docs/concepts/reading/watch_build/codegen_hooks.g.dart
@@ -12,10 +12,8 @@ part of 'codegen_hooks.dart';
 const todoListProvider = TodoListProvider._();
 
 final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
-  const TodoListProvider._(
-      {super.runNotifierBuildOverride, TodoList Function()? create})
-      : _createCb = create,
-        super(
+  const TodoListProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
           allTransitiveDependencies: null,
         );
 
-  final TodoList Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todoListHash();
+
+  @$internal
+  @override
+  TodoList create() => TodoList();
+
+  @$internal
+  @override
+  $NotifierProviderElement<TodoList, List<Todo>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -37,35 +43,6 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
   }
-
-  @$internal
-  @override
-  TodoList create() => _createCb?.call() ?? TodoList();
-
-  @$internal
-  @override
-  TodoListProvider $copyWithCreate(
-    TodoList Function() create,
-  ) {
-    return TodoListProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  TodoListProvider $copyWithBuild(
-    List<Todo> Function(
-      Ref,
-      TodoList,
-    ) build,
-  ) {
-    return TodoListProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<TodoList, List<Todo>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$todoListHash() => r'77f007cd4f5105330a4c2ab8555ea0d1716945c1';
@@ -88,12 +65,8 @@ const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const CounterProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -103,12 +76,18 @@ final class CounterProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return counter(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -116,26 +95,6 @@ final class CounterProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CounterProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? counter;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/concepts/reading/watch_notifier_build/codegen.g.dart
+++ b/website/docs/concepts/reading/watch_notifier_build/codegen.g.dart
@@ -12,10 +12,8 @@ part of 'codegen.dart';
 const counterProvider = CounterProvider._();
 
 final class CounterProvider extends $NotifierProvider<Counter, int> {
-  const CounterProvider._(
-      {super.runNotifierBuildOverride, Counter Function()? create})
-      : _createCb = create,
-        super(
+  const CounterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
           allTransitiveDependencies: null,
         );
 
-  final Counter Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterHash();
+
+  @$internal
+  @override
+  Counter create() => Counter();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Counter, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Counter create() => _createCb?.call() ?? Counter();
-
-  @$internal
-  @override
-  CounterProvider $copyWithCreate(
-    Counter Function() create,
-  ) {
-    return CounterProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Counter,
-    ) build,
-  ) {
-    return CounterProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Counter, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterHash() => r'600c6beb47b3732049b6955a9e49d7eef30c741a';

--- a/website/docs/concepts/why_immutability/codegen.g.dart
+++ b/website/docs/concepts/why_immutability/codegen.g.dart
@@ -13,10 +13,8 @@ const themeNotifierProvider = ThemeNotifierProvider._();
 
 final class ThemeNotifierProvider
     extends $NotifierProvider<ThemeNotifier, ThemeSettings> {
-  const ThemeNotifierProvider._(
-      {super.runNotifierBuildOverride, ThemeNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const ThemeNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,10 +24,18 @@ final class ThemeNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final ThemeNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$themeNotifierHash();
+
+  @$internal
+  @override
+  ThemeNotifier create() => ThemeNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<ThemeNotifier, ThemeSettings> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(ThemeSettings value) {
@@ -38,35 +44,6 @@ final class ThemeNotifierProvider
       providerOverride: $ValueProvider<ThemeSettings>(value),
     );
   }
-
-  @$internal
-  @override
-  ThemeNotifier create() => _createCb?.call() ?? ThemeNotifier();
-
-  @$internal
-  @override
-  ThemeNotifierProvider $copyWithCreate(
-    ThemeNotifier Function() create,
-  ) {
-    return ThemeNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  ThemeNotifierProvider $copyWithBuild(
-    ThemeSettings Function(
-      Ref,
-      ThemeNotifier,
-    ) build,
-  ) {
-    return ThemeNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<ThemeNotifier, ThemeSettings> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$themeNotifierHash() => r'e119d56d9bf8b8d7c19624997f99d116098b45e9';

--- a/website/docs/essentials/auto_dispose/cache_for_usage/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/cache_for_usage/codegen.g.dart
@@ -14,12 +14,8 @@ const exampleProvider = ExampleProvider._();
 final class ExampleProvider
     extends $FunctionalProvider<AsyncValue<Object>, FutureOr<Object>>
     with $FutureModifier<Object>, $FutureProvider<Object> {
-  const ExampleProvider._(
-      {FutureOr<Object> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ExampleProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Object> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
 
   @$internal
   @override
   $FutureProviderElement<Object> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    FutureOr<Object> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Object> create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
+    return example(ref);
   }
 }
 

--- a/website/docs/essentials/auto_dispose/codegen_keep_alive.g.dart
+++ b/website/docs/essentials/auto_dispose/codegen_keep_alive.g.dart
@@ -13,12 +13,8 @@ const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const ExampleProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return example(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -41,26 +43,6 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/essentials/auto_dispose/invalidate_family_example/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/invalidate_family_example/codegen.g.dart
@@ -14,25 +14,14 @@ const labelProvider = LabelFamily._();
 final class LabelProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
   const LabelProvider._(
-      {required LabelFamily super.from,
-      required String super.argument,
-      String Function(
-        Ref ref,
-        String userName,
-      )? create})
-      : _createCb = create,
-        super(
+      {required LabelFamily super.from, required String super.argument})
+      : super(
           retry: null,
           name: r'labelProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final String Function(
-    Ref ref,
-    String userName,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$labelHash();
@@ -44,42 +33,25 @@ final class LabelProvider extends $FunctionalProvider<String, String>
         '($argument)';
   }
 
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    final argument = this.argument as String;
+    return label(
+      ref,
+      argument,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<String>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  LabelProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return LabelProvider._(
-        argument: argument as String,
-        from: from! as LabelFamily,
-        create: (
-          ref,
-          String userName,
-        ) =>
-            create(ref));
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? label;
-    final argument = this.argument as String;
-    return _$cb(
-      ref,
-      argument,
     );
   }
 
@@ -112,31 +84,23 @@ final class LabelFamily extends Family {
       LabelProvider._(argument: userName, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$labelHash();
-
-  @override
   String toString() => r'labelProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    String Function(
-      Ref ref,
-      String args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as LabelProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          String Function(
+            Ref ref,
+            String args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as LabelProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/essentials/auto_dispose/keep_alive/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/keep_alive/codegen.g.dart
@@ -14,12 +14,8 @@ const exampleProvider = ExampleProvider._();
 final class ExampleProvider
     extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
-  const ExampleProvider._(
-      {FutureOr<String> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ExampleProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<String> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
 
   @$internal
   @override
   $FutureProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    FutureOr<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<String> create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
+    return example(ref);
   }
 }
 

--- a/website/docs/essentials/auto_dispose/on_dispose_example/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/on_dispose_example/codegen.g.dart
@@ -13,12 +13,8 @@ const otherProvider = OtherProvider._();
 
 final class OtherProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const OtherProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const OtherProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class OtherProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$otherHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return other(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -41,26 +43,6 @@ final class OtherProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  OtherProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return OtherProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? other;
-    return _$cb(ref);
   }
 }
 
@@ -72,12 +54,8 @@ const exampleProvider = ExampleProvider._();
 final class ExampleProvider
     extends $FunctionalProvider<AsyncValue<int>, Stream<int>>
     with $FutureModifier<int>, $StreamProvider<int> {
-  const ExampleProvider._(
-      {Stream<int> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -87,31 +65,17 @@ final class ExampleProvider
           allTransitiveDependencies: null,
         );
 
-  final Stream<int> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
 
   @$internal
   @override
   $StreamProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    Stream<int> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<int> create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
+    return example(ref);
   }
 }
 

--- a/website/docs/essentials/combining_requests/functional_ref/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/functional_ref/codegen.g.dart
@@ -13,12 +13,8 @@ const otherProvider = OtherProvider._();
 
 final class OtherProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const OtherProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const OtherProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class OtherProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$otherHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return other(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -41,26 +43,6 @@ final class OtherProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  OtherProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return OtherProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? other;
-    return _$cb(ref);
   }
 }
 
@@ -71,12 +53,8 @@ const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const ExampleProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -86,12 +64,18 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return example(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -99,26 +83,6 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/essentials/combining_requests/listen_example/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/listen_example/codegen.g.dart
@@ -13,12 +13,8 @@ const otherProvider = OtherProvider._();
 
 final class OtherProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const OtherProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const OtherProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class OtherProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$otherHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return other(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -41,26 +43,6 @@ final class OtherProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  OtherProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return OtherProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? other;
-    return _$cb(ref);
   }
 }
 
@@ -71,12 +53,8 @@ const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const ExampleProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -86,12 +64,18 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return example(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -99,26 +83,6 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/essentials/combining_requests/notifier_ref/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/notifier_ref/codegen.g.dart
@@ -13,12 +13,8 @@ const otherProvider = OtherProvider._();
 
 final class OtherProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const OtherProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const OtherProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class OtherProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$otherHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return other(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -41,26 +43,6 @@ final class OtherProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  OtherProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return OtherProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? other;
-    return _$cb(ref);
   }
 }
 
@@ -70,10 +52,8 @@ String _$otherHash() => r'5d27b2b1b1c6bd17ba0844f74ade2088611be371';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $NotifierProvider<Example, int> {
-  const ExampleProvider._(
-      {super.runNotifierBuildOverride, Example Function()? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -83,10 +63,18 @@ final class ExampleProvider extends $NotifierProvider<Example, int> {
           allTransitiveDependencies: null,
         );
 
-  final Example Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  Example create() => Example();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Example, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -95,35 +83,6 @@ final class ExampleProvider extends $NotifierProvider<Example, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Example create() => _createCb?.call() ?? Example();
-
-  @$internal
-  @override
-  ExampleProvider $copyWithCreate(
-    Example Function() create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  ExampleProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Example,
-    ) build,
-  ) {
-    return ExampleProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Example, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$exampleHash() => r'893db991b377b8e314e60c429043e5e81f1fd526';

--- a/website/docs/essentials/combining_requests/read_example/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/read_example/codegen.g.dart
@@ -13,12 +13,8 @@ const otherProvider = OtherProvider._();
 
 final class OtherProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const OtherProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const OtherProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class OtherProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$otherHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return other(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -41,26 +43,6 @@ final class OtherProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  OtherProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return OtherProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? other;
-    return _$cb(ref);
   }
 }
 
@@ -70,10 +52,8 @@ String _$otherHash() => r'5d27b2b1b1c6bd17ba0844f74ade2088611be371';
 const myNotifierProvider = MyNotifierProvider._();
 
 final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
-  const MyNotifierProvider._(
-      {super.runNotifierBuildOverride, MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const MyNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -83,10 +63,18 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
+
+  @$internal
+  @override
+  MyNotifier create() => MyNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<MyNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -95,35 +83,6 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<MyNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$myNotifierHash() => r'353efe22dd5a91b2d036286211ac9e60c9de5f6d';

--- a/website/docs/essentials/combining_requests/watch_example/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/watch_example/codegen.g.dart
@@ -17,12 +17,8 @@ final class LocationProvider extends $FunctionalProvider<
     with
         $FutureModifier<({double longitude, double latitude})>,
         $StreamProvider<({double longitude, double latitude})> {
-  const LocationProvider._(
-      {Stream<({double longitude, double latitude})> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const LocationProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -32,10 +28,6 @@ final class LocationProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final Stream<({double longitude, double latitude})> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$locationHash();
 
@@ -43,21 +35,11 @@ final class LocationProvider extends $FunctionalProvider<
   @override
   $StreamProviderElement<({double longitude, double latitude})> $createElement(
           $ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  LocationProvider $copyWithCreate(
-    Stream<({double longitude, double latitude})> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return LocationProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<({double longitude, double latitude})> create(Ref ref) {
-    final _$cb = _createCb ?? location;
-    return _$cb(ref);
+    return location(ref);
   }
 }
 
@@ -69,12 +51,8 @@ const restaurantsNearMeProvider = RestaurantsNearMeProvider._();
 final class RestaurantsNearMeProvider extends $FunctionalProvider<
         AsyncValue<List<String>>, FutureOr<List<String>>>
     with $FutureModifier<List<String>>, $FutureProvider<List<String>> {
-  const RestaurantsNearMeProvider._(
-      {FutureOr<List<String>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RestaurantsNearMeProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -84,10 +62,6 @@ final class RestaurantsNearMeProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<List<String>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$restaurantsNearMeHash();
 
@@ -95,21 +69,11 @@ final class RestaurantsNearMeProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<List<String>> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  RestaurantsNearMeProvider $copyWithCreate(
-    FutureOr<List<String>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RestaurantsNearMeProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<String>> create(Ref ref) {
-    final _$cb = _createCb ?? restaurantsNearMe;
-    return _$cb(ref);
+    return restaurantsNearMe(ref);
   }
 }
 

--- a/website/docs/essentials/combining_requests/watch_placement/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/watch_placement/codegen.g.dart
@@ -13,12 +13,8 @@ const otherProvider = OtherProvider._();
 
 final class OtherProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const OtherProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const OtherProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class OtherProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$otherHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return other(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -41,26 +43,6 @@ final class OtherProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  OtherProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return OtherProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? other;
-    return _$cb(ref);
   }
 }
 
@@ -71,12 +53,8 @@ const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const ExampleProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -86,12 +64,18 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return example(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -99,26 +83,6 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
   }
 }
 
@@ -128,10 +92,8 @@ String _$exampleHash() => r'fed2d2be4787bc4a715efa198a89a297967b54a1';
 const myNotifierProvider = MyNotifierProvider._();
 
 final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
-  const MyNotifierProvider._(
-      {super.runNotifierBuildOverride, MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const MyNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -141,10 +103,18 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
+
+  @$internal
+  @override
+  MyNotifier create() => MyNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<MyNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -153,35 +123,6 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<MyNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$myNotifierHash() => r'ad79fdb5b0e72a800fa03efc1e7157f0d1524844';

--- a/website/docs/essentials/eager_initialization/require_value/codegen.g.dart
+++ b/website/docs/essentials/eager_initialization/require_value/codegen.g.dart
@@ -14,12 +14,8 @@ const exampleProvider = ExampleProvider._();
 final class ExampleProvider
     extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
-  const ExampleProvider._(
-      {FutureOr<String> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ExampleProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<String> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
 
   @$internal
   @override
   $FutureProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    FutureOr<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<String> create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
+    return example(ref);
   }
 }
 

--- a/website/docs/essentials/first_request/codegen/provider.g.dart
+++ b/website/docs/essentials/first_request/codegen/provider.g.dart
@@ -23,12 +23,8 @@ final class ActivityProvider
   /// This will create a provider named `activityProvider`
   /// which will cache the result of this function.
 // {@endtemplate}
-  const ActivityProvider._(
-      {FutureOr<Activity> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ActivityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -38,31 +34,17 @@ final class ActivityProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Activity> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$activityHash();
 
   @$internal
   @override
   $FutureProviderElement<Activity> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ActivityProvider $copyWithCreate(
-    FutureOr<Activity> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ActivityProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Activity> create(Ref ref) {
-    final _$cb = _createCb ?? activity;
-    return _$cb(ref);
+    return activity(ref);
   }
 }
 

--- a/website/docs/essentials/passing_args/family/codegen.g.dart
+++ b/website/docs/essentials/passing_args/family/codegen.g.dart
@@ -132,14 +132,6 @@ final class ActivityNotifier2Provider
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<Activity> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<Activity>>(value),
-    );
-  }
-
   @override
   bool operator ==(Object other) {
     return other is ActivityNotifier2Provider && other.argument == argument;

--- a/website/docs/essentials/passing_args/family/codegen.g.dart
+++ b/website/docs/essentials/passing_args/family/codegen.g.dart
@@ -15,25 +15,14 @@ final class ActivityProvider
     extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
   const ActivityProvider._(
-      {required ActivityFamily super.from,
-      required String super.argument,
-      FutureOr<Activity> Function(
-        Ref ref,
-        String activityType,
-      )? create})
-      : _createCb = create,
-        super(
+      {required ActivityFamily super.from, required String super.argument})
+      : super(
           retry: null,
           name: r'activityProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FutureOr<Activity> Function(
-    Ref ref,
-    String activityType,
-  )? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$activityHash();
@@ -48,29 +37,12 @@ final class ActivityProvider
   @$internal
   @override
   $FutureProviderElement<Activity> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ActivityProvider $copyWithCreate(
-    FutureOr<Activity> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ActivityProvider._(
-        argument: argument as String,
-        from: from! as ActivityFamily,
-        create: (
-          ref,
-          String activityType,
-        ) =>
-            create(ref));
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Activity> create(Ref ref) {
-    final _$cb = _createCb ?? activity;
     final argument = this.argument as String;
-    return _$cb(
+    return activity(
       ref,
       argument,
     );
@@ -105,31 +77,23 @@ final class ActivityFamily extends Family {
       ActivityProvider._(argument: activityType, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$activityHash();
-
-  @override
   String toString() => r'activityProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FutureOr<Activity> Function(
-      Ref ref,
-      String args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ActivityProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<Activity> Function(
+            Ref ref,
+            String args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ActivityProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 
 @ProviderFor(ActivityNotifier2)
@@ -139,19 +103,14 @@ final class ActivityNotifier2Provider
     extends $AsyncNotifierProvider<ActivityNotifier2, Activity> {
   const ActivityNotifier2Provider._(
       {required ActivityNotifier2Family super.from,
-      required String super.argument,
-      super.runNotifierBuildOverride,
-      ActivityNotifier2 Function()? create})
-      : _createCb = create,
-        super(
+      required String super.argument})
+      : super(
           retry: null,
           name: r'activityNotifier2Provider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final ActivityNotifier2 Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$activityNotifier2Hash();
@@ -165,38 +124,21 @@ final class ActivityNotifier2Provider
 
   @$internal
   @override
-  ActivityNotifier2 create() => _createCb?.call() ?? ActivityNotifier2();
-
-  @$internal
-  @override
-  ActivityNotifier2Provider $copyWithCreate(
-    ActivityNotifier2 Function() create,
-  ) {
-    return ActivityNotifier2Provider._(
-        argument: argument as String,
-        from: from! as ActivityNotifier2Family,
-        create: create);
-  }
-
-  @$internal
-  @override
-  ActivityNotifier2Provider $copyWithBuild(
-    FutureOr<Activity> Function(
-      Ref,
-      ActivityNotifier2,
-    ) build,
-  ) {
-    return ActivityNotifier2Provider._(
-        argument: argument as String,
-        from: from! as ActivityNotifier2Family,
-        runNotifierBuildOverride: build);
-  }
+  ActivityNotifier2 create() => ActivityNotifier2();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<ActivityNotifier2, Activity> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<Activity> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<Activity>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -227,50 +169,39 @@ final class ActivityNotifier2Family extends Family {
       ActivityNotifier2Provider._(argument: activityType, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$activityNotifier2Hash();
-
-  @override
   String toString() => r'activityNotifier2Provider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    ActivityNotifier2 Function(
-      String args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ActivityNotifier2Provider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          ActivityNotifier2 Function(
+            String args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ActivityNotifier2Provider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    FutureOr<Activity> Function(
-            Ref ref, ActivityNotifier2 notifier, String argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as ActivityNotifier2Provider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<Activity> Function(
+                  Ref ref, ActivityNotifier2 notifier, String argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as ActivityNotifier2Provider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$ActivityNotifier2 extends $AsyncNotifier<Activity> {

--- a/website/docs/essentials/passing_args/no_arg_provider/codegen.g.dart
+++ b/website/docs/essentials/passing_args/no_arg_provider/codegen.g.dart
@@ -69,14 +69,6 @@ final class ActivityNotifier2Provider
   $AsyncNotifierProviderElement<ActivityNotifier2, Activity> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<Activity> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<Activity>>(value),
-    );
-  }
 }
 
 String _$activityNotifier2Hash() => r'280f4d82a186cfb62827f4d7c74f5349bb0a9e4a';

--- a/website/docs/essentials/passing_args/no_arg_provider/codegen.g.dart
+++ b/website/docs/essentials/passing_args/no_arg_provider/codegen.g.dart
@@ -14,12 +14,8 @@ const activityProvider = ActivityProvider._();
 final class ActivityProvider
     extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
-  const ActivityProvider._(
-      {FutureOr<Activity> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ActivityProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ActivityProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Activity> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$activityHash();
 
   @$internal
   @override
   $FutureProviderElement<Activity> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ActivityProvider $copyWithCreate(
-    FutureOr<Activity> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ActivityProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Activity> create(Ref ref) {
-    final _$cb = _createCb ?? activity;
-    return _$cb(ref);
+    return activity(ref);
   }
 }
 
@@ -64,10 +46,8 @@ const activityNotifier2Provider = ActivityNotifier2Provider._();
 
 final class ActivityNotifier2Provider
     extends $AsyncNotifierProvider<ActivityNotifier2, Activity> {
-  const ActivityNotifier2Provider._(
-      {super.runNotifierBuildOverride, ActivityNotifier2 Function()? create})
-      : _createCb = create,
-        super(
+  const ActivityNotifier2Provider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -77,39 +57,26 @@ final class ActivityNotifier2Provider
           allTransitiveDependencies: null,
         );
 
-  final ActivityNotifier2 Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$activityNotifier2Hash();
 
   @$internal
   @override
-  ActivityNotifier2 create() => _createCb?.call() ?? ActivityNotifier2();
-
-  @$internal
-  @override
-  ActivityNotifier2Provider $copyWithCreate(
-    ActivityNotifier2 Function() create,
-  ) {
-    return ActivityNotifier2Provider._(create: create);
-  }
-
-  @$internal
-  @override
-  ActivityNotifier2Provider $copyWithBuild(
-    FutureOr<Activity> Function(
-      Ref,
-      ActivityNotifier2,
-    ) build,
-  ) {
-    return ActivityNotifier2Provider._(runNotifierBuildOverride: build);
-  }
+  ActivityNotifier2 create() => ActivityNotifier2();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<ActivityNotifier2, Activity> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<Activity> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<Activity>>(value),
+    );
+  }
 }
 
 String _$activityNotifier2Hash() => r'280f4d82a186cfb62827f4d7c74f5349bb0a9e4a';

--- a/website/docs/essentials/side_effects/codegen/todo_list_notifier.g.dart
+++ b/website/docs/essentials/side_effects/codegen/todo_list_notifier.g.dart
@@ -27,10 +27,8 @@ const todoListProvider = TodoListProvider._();
 
 final class TodoListProvider
     extends $AsyncNotifierProvider<TodoList, List<Todo>> {
-  const TodoListProvider._(
-      {super.runNotifierBuildOverride, TodoList Function()? create})
-      : _createCb = create,
-        super(
+  const TodoListProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -40,39 +38,26 @@ final class TodoListProvider
           allTransitiveDependencies: null,
         );
 
-  final TodoList Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todoListHash();
 
   @$internal
   @override
-  TodoList create() => _createCb?.call() ?? TodoList();
-
-  @$internal
-  @override
-  TodoListProvider $copyWithCreate(
-    TodoList Function() create,
-  ) {
-    return TodoListProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  TodoListProvider $copyWithBuild(
-    FutureOr<List<Todo>> Function(
-      Ref,
-      TodoList,
-    ) build,
-  ) {
-    return TodoListProvider._(runNotifierBuildOverride: build);
-  }
+  TodoList create() => TodoList();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<TodoList, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<Todo>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
+    );
+  }
 }
 
 String _$todoListHash() => r'c939d438b07da6065dbbcfab86c27ef363bdb76c';

--- a/website/docs/essentials/side_effects/codegen/todo_list_notifier.g.dart
+++ b/website/docs/essentials/side_effects/codegen/todo_list_notifier.g.dart
@@ -50,14 +50,6 @@ final class TodoListProvider
   $AsyncNotifierProviderElement<TodoList, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<Todo>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
-    );
-  }
 }
 
 String _$todoListHash() => r'c939d438b07da6065dbbcfab86c27ef363bdb76c';

--- a/website/docs/essentials/side_effects/codegen/todo_list_notifier_add_todo.g.dart
+++ b/website/docs/essentials/side_effects/codegen/todo_list_notifier_add_todo.g.dart
@@ -36,14 +36,6 @@ final class TodoListProvider
   $AsyncNotifierProviderElement<TodoList, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<Todo>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
-    );
-  }
 }
 
 String _$todoListHash() => r'4008395aaca8f55312f668c0b2a32e7599f82349';

--- a/website/docs/essentials/side_effects/codegen/todo_list_notifier_add_todo.g.dart
+++ b/website/docs/essentials/side_effects/codegen/todo_list_notifier_add_todo.g.dart
@@ -13,10 +13,8 @@ const todoListProvider = TodoListProvider._();
 
 final class TodoListProvider
     extends $AsyncNotifierProvider<TodoList, List<Todo>> {
-  const TodoListProvider._(
-      {super.runNotifierBuildOverride, TodoList Function()? create})
-      : _createCb = create,
-        super(
+  const TodoListProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,39 +24,26 @@ final class TodoListProvider
           allTransitiveDependencies: null,
         );
 
-  final TodoList Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todoListHash();
 
   @$internal
   @override
-  TodoList create() => _createCb?.call() ?? TodoList();
-
-  @$internal
-  @override
-  TodoListProvider $copyWithCreate(
-    TodoList Function() create,
-  ) {
-    return TodoListProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  TodoListProvider $copyWithBuild(
-    FutureOr<List<Todo>> Function(
-      Ref,
-      TodoList,
-    ) build,
-  ) {
-    return TodoListProvider._(runNotifierBuildOverride: build);
-  }
+  TodoList create() => TodoList();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<TodoList, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<Todo>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
+    );
+  }
 }
 
 String _$todoListHash() => r'4008395aaca8f55312f668c0b2a32e7599f82349';

--- a/website/docs/essentials/side_effects/codegen/todo_list_provider.g.dart
+++ b/website/docs/essentials/side_effects/codegen/todo_list_provider.g.dart
@@ -14,12 +14,8 @@ const todoListProvider = TodoListProvider._();
 final class TodoListProvider
     extends $FunctionalProvider<AsyncValue<List<Todo>>, FutureOr<List<Todo>>>
     with $FutureModifier<List<Todo>>, $FutureProvider<List<Todo>> {
-  const TodoListProvider._(
-      {FutureOr<List<Todo>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const TodoListProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class TodoListProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<List<Todo>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todoListHash();
 
   @$internal
   @override
   $FutureProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  TodoListProvider $copyWithCreate(
-    FutureOr<List<Todo>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return TodoListProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Todo>> create(Ref ref) {
-    final _$cb = _createCb ?? todoList;
-    return _$cb(ref);
+    return todoList(ref);
   }
 }
 

--- a/website/docs/essentials/testing/notifier_mock/codegen.g.dart
+++ b/website/docs/essentials/testing/notifier_mock/codegen.g.dart
@@ -12,10 +12,8 @@ part of 'codegen.dart';
 const myNotifierProvider = MyNotifierProvider._();
 
 final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
-  const MyNotifierProvider._(
-      {super.runNotifierBuildOverride, MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const MyNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
+
+  @$internal
+  @override
+  MyNotifier create() => MyNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<MyNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<MyNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$myNotifierHash() => r'912fa35c2296626fc0825bcbcfc6b6c85958be02';

--- a/website/docs/essentials/testing/provider_to_mock/codegen.g.dart
+++ b/website/docs/essentials/testing/provider_to_mock/codegen.g.dart
@@ -14,12 +14,8 @@ const exampleProvider = ExampleProvider._();
 final class ExampleProvider
     extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
-  const ExampleProvider._(
-      {FutureOr<String> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ExampleProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<String> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$exampleHash();
 
   @$internal
   @override
   $FutureProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ExampleProvider $copyWithCreate(
-    FutureOr<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ExampleProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<String> create(Ref ref) {
-    final _$cb = _createCb ?? example;
-    return _$cb(ref);
+    return example(ref);
   }
 }
 

--- a/website/docs/essentials/websockets_sync/pipe_change_notifier.g.dart
+++ b/website/docs/essentials/websockets_sync/pipe_change_notifier.g.dart
@@ -23,12 +23,8 @@ final class MyListenableProvider extends $FunctionalProvider<
   /// A provider which creates a ValueNotifier and update its listeners
   /// whenever the value changes.
 // {@endtemplate}
-  const MyListenableProvider._(
-      {Raw<ValueNotifier<int>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const MyListenableProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -38,12 +34,19 @@ final class MyListenableProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final Raw<ValueNotifier<int>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myListenableHash();
+
+  @$internal
+  @override
+  $ProviderElement<Raw<ValueNotifier<int>>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<ValueNotifier<int>> create(Ref ref) {
+    return myListenable(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<ValueNotifier<int>> value) {
@@ -51,27 +54,6 @@ final class MyListenableProvider extends $FunctionalProvider<
       origin: this,
       providerOverride: $ValueProvider<Raw<ValueNotifier<int>>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<ValueNotifier<int>>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  MyListenableProvider $copyWithCreate(
-    Raw<ValueNotifier<int>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return MyListenableProvider._(create: create);
-  }
-
-  @override
-  Raw<ValueNotifier<int>> create(Ref ref) {
-    final _$cb = _createCb ?? myListenable;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/essentials/websockets_sync/raw_usage.g.dart
+++ b/website/docs/essentials/websockets_sync/raw_usage.g.dart
@@ -14,12 +14,8 @@ const rawStreamProvider = RawStreamProvider._();
 final class RawStreamProvider
     extends $FunctionalProvider<Raw<Stream<int>>, Raw<Stream<int>>>
     with $Provider<Raw<Stream<int>>> {
-  const RawStreamProvider._(
-      {Raw<Stream<int>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RawStreamProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,12 +25,18 @@ final class RawStreamProvider
           allTransitiveDependencies: null,
         );
 
-  final Raw<Stream<int>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$rawStreamHash();
+
+  @$internal
+  @override
+  $ProviderElement<Raw<Stream<int>>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<Stream<int>> create(Ref ref) {
+    return rawStream(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<Stream<int>> value) {
@@ -42,26 +44,6 @@ final class RawStreamProvider
       origin: this,
       providerOverride: $ValueProvider<Raw<Stream<int>>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<Stream<int>>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RawStreamProvider $copyWithCreate(
-    Raw<Stream<int>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RawStreamProvider._(create: create);
-  }
-
-  @override
-  Raw<Stream<int>> create(Ref ref) {
-    final _$cb = _createCb ?? rawStream;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/essentials/websockets_sync/shared_pipe_change_notifier.g.dart
+++ b/website/docs/essentials/websockets_sync/shared_pipe_change_notifier.g.dart
@@ -14,12 +14,8 @@ const myListenableProvider = MyListenableProvider._();
 final class MyListenableProvider extends $FunctionalProvider<
     Raw<ValueNotifier<int>>,
     Raw<ValueNotifier<int>>> with $Provider<Raw<ValueNotifier<int>>> {
-  const MyListenableProvider._(
-      {Raw<ValueNotifier<int>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const MyListenableProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,12 +25,19 @@ final class MyListenableProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final Raw<ValueNotifier<int>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myListenableHash();
+
+  @$internal
+  @override
+  $ProviderElement<Raw<ValueNotifier<int>>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<ValueNotifier<int>> create(Ref ref) {
+    return myListenable(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<ValueNotifier<int>> value) {
@@ -42,27 +45,6 @@ final class MyListenableProvider extends $FunctionalProvider<
       origin: this,
       providerOverride: $ValueProvider<Raw<ValueNotifier<int>>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<ValueNotifier<int>>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  MyListenableProvider $copyWithCreate(
-    Raw<ValueNotifier<int>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return MyListenableProvider._(create: create);
-  }
-
-  @override
-  Raw<ValueNotifier<int>> create(Ref ref) {
-    final _$cb = _createCb ?? myListenable;
-    return _$cb(ref);
   }
 }
 
@@ -74,12 +56,8 @@ const anotherListenableProvider = AnotherListenableProvider._();
 final class AnotherListenableProvider extends $FunctionalProvider<
     Raw<ValueNotifier<int>>,
     Raw<ValueNotifier<int>>> with $Provider<Raw<ValueNotifier<int>>> {
-  const AnotherListenableProvider._(
-      {Raw<ValueNotifier<int>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const AnotherListenableProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -89,12 +67,19 @@ final class AnotherListenableProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final Raw<ValueNotifier<int>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$anotherListenableHash();
+
+  @$internal
+  @override
+  $ProviderElement<Raw<ValueNotifier<int>>> $createElement(
+          $ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Raw<ValueNotifier<int>> create(Ref ref) {
+    return anotherListenable(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Raw<ValueNotifier<int>> value) {
@@ -102,27 +87,6 @@ final class AnotherListenableProvider extends $FunctionalProvider<
       origin: this,
       providerOverride: $ValueProvider<Raw<ValueNotifier<int>>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Raw<ValueNotifier<int>>> $createElement(
-          $ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  AnotherListenableProvider $copyWithCreate(
-    Raw<ValueNotifier<int>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return AnotherListenableProvider._(create: create);
-  }
-
-  @override
-  Raw<ValueNotifier<int>> create(Ref ref) {
-    final _$cb = _createCb ?? anotherListenable;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/essentials/websockets_sync/stream_provider/codegen.g.dart
+++ b/website/docs/essentials/websockets_sync/stream_provider/codegen.g.dart
@@ -14,12 +14,8 @@ const streamExampleProvider = StreamExampleProvider._();
 final class StreamExampleProvider
     extends $FunctionalProvider<AsyncValue<int>, Stream<int>>
     with $FutureModifier<int>, $StreamProvider<int> {
-  const StreamExampleProvider._(
-      {Stream<int> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const StreamExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class StreamExampleProvider
           allTransitiveDependencies: null,
         );
 
-  final Stream<int> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$streamExampleHash();
 
   @$internal
   @override
   $StreamProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  StreamExampleProvider $copyWithCreate(
-    Stream<int> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return StreamExampleProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<int> create(Ref ref) {
-    final _$cb = _createCb ?? streamExample;
-    return _$cb(ref);
+    return streamExample(ref);
   }
 }
 

--- a/website/docs/essentials/websockets_sync/sync_definition/codegen.g.dart
+++ b/website/docs/essentials/websockets_sync/sync_definition/codegen.g.dart
@@ -13,12 +13,8 @@ const synchronousExampleProvider = SynchronousExampleProvider._();
 
 final class SynchronousExampleProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const SynchronousExampleProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const SynchronousExampleProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class SynchronousExampleProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$synchronousExampleHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return synchronousExample(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -41,26 +43,6 @@ final class SynchronousExampleProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  SynchronousExampleProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return SynchronousExampleProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? synchronousExample;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/from_provider/family/family.g.dart
+++ b/website/docs/from_provider/family/family.g.dart
@@ -19,26 +19,14 @@ final class RandomProvider extends $FunctionalProvider<int, int>
         int seed,
         int max,
       })
-          super.argument,
-      int Function(
-        Ref ref, {
-        required int seed,
-        required int max,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'randomProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final int Function(
-    Ref ref, {
-    required int seed,
-    required int max,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$randomHash();
@@ -50,50 +38,29 @@ final class RandomProvider extends $FunctionalProvider<int, int>
         '$argument';
   }
 
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    final argument = this.argument as ({
+      int seed,
+      int max,
+    });
+    return random(
+      ref,
+      seed: argument.seed,
+      max: argument.max,
+    );
+  }
+
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
       providerOverride: $ValueProvider<int>(value),
-    );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RandomProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RandomProvider._(
-        argument: argument as ({
-          int seed,
-          int max,
-        }),
-        from: from! as RandomFamily,
-        create: (
-          ref, {
-          required int seed,
-          required int max,
-        }) =>
-            create(ref));
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? random;
-    final argument = this.argument as ({
-      int seed,
-      int max,
-    });
-    return _$cb(
-      ref,
-      seed: argument.seed,
-      max: argument.max,
     );
   }
 
@@ -130,37 +97,29 @@ final class RandomFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$randomHash();
-
-  @override
   String toString() => r'randomProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    int Function(
-      Ref ref,
-      ({
-        int seed,
-        int max,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as RandomProvider;
-
-        final argument = provider.argument as ({
-          int seed,
-          int max,
-        });
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          int Function(
+            Ref ref,
+            ({
+              int seed,
+              int max,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as RandomProvider;
+            final argument = provider.argument as ({
+              int seed,
+              int max,
+            });
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/from_provider/motivation/async_values/async_values.g.dart
+++ b/website/docs/from_provider/motivation/async_values/async_values.g.dart
@@ -14,12 +14,8 @@ const itemsApiProvider = ItemsApiProvider._();
 final class ItemsApiProvider
     extends $FunctionalProvider<AsyncValue<List<Item>>, FutureOr<List<Item>>>
     with $FutureModifier<List<Item>>, $FutureProvider<List<Item>> {
-  const ItemsApiProvider._(
-      {FutureOr<List<Item>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ItemsApiProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class ItemsApiProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<List<Item>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$itemsApiHash();
 
   @$internal
   @override
   $FutureProviderElement<List<Item>> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ItemsApiProvider $copyWithCreate(
-    FutureOr<List<Item>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ItemsApiProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Item>> create(Ref ref) {
-    final _$cb = _createCb ?? itemsApi;
-    return _$cb(ref);
+    return itemsApi(ref);
   }
 }
 
@@ -65,12 +47,8 @@ const evenItemsProvider = EvenItemsProvider._();
 final class EvenItemsProvider
     extends $FunctionalProvider<List<Item>, List<Item>>
     with $Provider<List<Item>> {
-  const EvenItemsProvider._(
-      {List<Item> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const EvenItemsProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -80,12 +58,18 @@ final class EvenItemsProvider
           allTransitiveDependencies: null,
         );
 
-  final List<Item> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$evenItemsHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<Item>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<Item> create(Ref ref) {
+    return evenItems(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Item> value) {
@@ -93,26 +77,6 @@ final class EvenItemsProvider
       origin: this,
       providerOverride: $ValueProvider<List<Item>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<List<Item>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  EvenItemsProvider $copyWithCreate(
-    List<Item> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return EvenItemsProvider._(create: create);
-  }
-
-  @override
-  List<Item> create(Ref ref) {
-    final _$cb = _createCb ?? evenItems;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/from_provider/motivation/auto_dispose/auto_dispose.g.dart
+++ b/website/docs/from_provider/motivation/auto_dispose/auto_dispose.g.dart
@@ -13,12 +13,8 @@ const diceRollProvider = DiceRollProvider._();
 
 final class DiceRollProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const DiceRollProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DiceRollProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class DiceRollProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$diceRollHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return diceRoll(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -41,26 +43,6 @@ final class DiceRollProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DiceRollProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DiceRollProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? diceRoll;
-    return _$cb(ref);
   }
 }
 
@@ -71,12 +53,8 @@ const cachedDiceRollProvider = CachedDiceRollProvider._();
 
 final class CachedDiceRollProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const CachedDiceRollProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CachedDiceRollProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -86,12 +64,18 @@ final class CachedDiceRollProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$cachedDiceRollHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return cachedDiceRoll(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -99,26 +83,6 @@ final class CachedDiceRollProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CachedDiceRollProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CachedDiceRollProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? cachedDiceRoll;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/from_provider/motivation/combine/combine.g.dart
+++ b/website/docs/from_provider/motivation/combine/combine.g.dart
@@ -13,12 +13,8 @@ const numberProvider = NumberProvider._();
 
 final class NumberProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const NumberProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const NumberProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class NumberProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$numberHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return number(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -41,26 +43,6 @@ final class NumberProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  NumberProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return NumberProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? number;
-    return _$cb(ref);
   }
 }
 
@@ -71,12 +53,8 @@ const doubledProvider = DoubledProvider._();
 
 final class DoubledProvider extends $FunctionalProvider<int, int>
     with $Provider<int> {
-  const DoubledProvider._(
-      {int Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DoubledProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -86,12 +64,18 @@ final class DoubledProvider extends $FunctionalProvider<int, int>
           allTransitiveDependencies: null,
         );
 
-  final int Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$doubledHash();
+
+  @$internal
+  @override
+  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  int create(Ref ref) {
+    return doubled(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -99,26 +83,6 @@ final class DoubledProvider extends $FunctionalProvider<int, int>
       origin: this,
       providerOverride: $ValueProvider<int>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<int> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DoubledProvider $copyWithCreate(
-    int Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DoubledProvider._(create: create);
-  }
-
-  @override
-  int create(Ref ref) {
-    final _$cb = _createCb ?? doubled;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/from_provider/motivation/same_type/same_type.g.dart
+++ b/website/docs/from_provider/motivation/same_type/same_type.g.dart
@@ -13,12 +13,8 @@ const itemsProvider = ItemsProvider._();
 
 final class ItemsProvider extends $FunctionalProvider<List<Item>, List<Item>>
     with $Provider<List<Item>> {
-  const ItemsProvider._(
-      {List<Item> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ItemsProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class ItemsProvider extends $FunctionalProvider<List<Item>, List<Item>>
           allTransitiveDependencies: null,
         );
 
-  final List<Item> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$itemsHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<Item>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<Item> create(Ref ref) {
+    return items(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Item> value) {
@@ -41,26 +43,6 @@ final class ItemsProvider extends $FunctionalProvider<List<Item>, List<Item>>
       origin: this,
       providerOverride: $ValueProvider<List<Item>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<List<Item>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  ItemsProvider $copyWithCreate(
-    List<Item> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ItemsProvider._(create: create);
-  }
-
-  @override
-  List<Item> create(Ref ref) {
-    final _$cb = _createCb ?? items;
-    return _$cb(ref);
   }
 }
 
@@ -72,12 +54,8 @@ const evenItemsProvider = EvenItemsProvider._();
 final class EvenItemsProvider
     extends $FunctionalProvider<List<Item>, List<Item>>
     with $Provider<List<Item>> {
-  const EvenItemsProvider._(
-      {List<Item> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const EvenItemsProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -87,12 +65,18 @@ final class EvenItemsProvider
           allTransitiveDependencies: null,
         );
 
-  final List<Item> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$evenItemsHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<Item>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<Item> create(Ref ref) {
+    return evenItems(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Item> value) {
@@ -100,26 +84,6 @@ final class EvenItemsProvider
       origin: this,
       providerOverride: $ValueProvider<List<Item>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<List<Item>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  EvenItemsProvider $copyWithCreate(
-    List<Item> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return EvenItemsProvider._(create: create);
-  }
-
-  @override
-  List<Item> create(Ref ref) {
-    final _$cb = _createCb ?? evenItems;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/introduction/getting_started/dart_hello_world/main.g.dart
+++ b/website/docs/introduction/getting_started/dart_hello_world/main.g.dart
@@ -13,12 +13,8 @@ const helloWorldProvider = HelloWorldProvider._();
 
 final class HelloWorldProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const HelloWorldProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const HelloWorldProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class HelloWorldProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$helloWorldHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return helloWorld(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -41,26 +43,6 @@ final class HelloWorldProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  HelloWorldProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return HelloWorldProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? helloWorld;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/introduction/getting_started/hello_world/hooks_codegen/main.g.dart
+++ b/website/docs/introduction/getting_started/hello_world/hooks_codegen/main.g.dart
@@ -13,12 +13,8 @@ const helloWorldProvider = HelloWorldProvider._();
 
 final class HelloWorldProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const HelloWorldProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const HelloWorldProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class HelloWorldProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$helloWorldHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return helloWorld(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -41,26 +43,6 @@ final class HelloWorldProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  HelloWorldProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return HelloWorldProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? helloWorld;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/introduction/getting_started/hello_world/main.g.dart
+++ b/website/docs/introduction/getting_started/hello_world/main.g.dart
@@ -13,12 +13,8 @@ const helloWorldProvider = HelloWorldProvider._();
 
 final class HelloWorldProvider extends $FunctionalProvider<String, String>
     with $Provider<String> {
-  const HelloWorldProvider._(
-      {String Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const HelloWorldProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class HelloWorldProvider extends $FunctionalProvider<String, String>
           allTransitiveDependencies: null,
         );
 
-  final String Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$helloWorldHash();
+
+  @$internal
+  @override
+  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  String create(Ref ref) {
+    return helloWorld(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String value) {
@@ -41,26 +43,6 @@ final class HelloWorldProvider extends $FunctionalProvider<String, String>
       origin: this,
       providerOverride: $ValueProvider<String>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  HelloWorldProvider $copyWithCreate(
-    String Function(
-      Ref ref,
-    ) create,
-  ) {
-    return HelloWorldProvider._(create: create);
-  }
-
-  @override
-  String create(Ref ref) {
-    final _$cb = _createCb ?? helloWorld;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/introduction/why_riverpod/codegen.g.dart
+++ b/website/docs/introduction/why_riverpod/codegen.g.dart
@@ -20,26 +20,14 @@ final class FetchPackagesProvider extends $FunctionalProvider<
         int page,
         String search,
       })
-          super.argument,
-      FutureOr<List<Package>> Function(
-        Ref ref, {
-        required int page,
-        String search,
-      })? create})
-      : _createCb = create,
-        super(
+          super.argument})
+      : super(
           retry: null,
           name: r'fetchPackagesProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final FutureOr<List<Package>> Function(
-    Ref ref, {
-    required int page,
-    String search,
-  })? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$fetchPackagesHash();
@@ -55,36 +43,15 @@ final class FetchPackagesProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<List<Package>> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  FetchPackagesProvider $copyWithCreate(
-    FutureOr<List<Package>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FetchPackagesProvider._(
-        argument: argument as ({
-          int page,
-          String search,
-        }),
-        from: from! as FetchPackagesFamily,
-        create: (
-          ref, {
-          required int page,
-          String search = '',
-        }) =>
-            create(ref));
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Package>> create(Ref ref) {
-    final _$cb = _createCb ?? fetchPackages;
     final argument = this.argument as ({
       int page,
       String search,
     });
-    return _$cb(
+    return fetchPackages(
       ref,
       page: argument.page,
       search: argument.search,
@@ -124,37 +91,29 @@ final class FetchPackagesFamily extends Family {
       ), from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$fetchPackagesHash();
-
-  @override
   String toString() => r'fetchPackagesProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    FutureOr<List<Package>> Function(
-      Ref ref,
-      ({
-        int page,
-        String search,
-      }) args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as FetchPackagesProvider;
-
-        final argument = provider.argument as ({
-          int page,
-          String search,
-        });
-
-        return provider
-            .$copyWithCreate((ref) => create(ref, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<List<Package>> Function(
+            Ref ref,
+            ({
+              int page,
+              String search,
+            }) args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as FetchPackagesProvider;
+            final argument = provider.argument as ({
+              int page,
+              String search,
+            });
+            return provider
+                .$view(create: (ref) => create(ref, argument))
+                .$createElement(pointer);
+          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/migration/from_change_notifier/declaration/declaration.g.dart
+++ b/website/docs/migration/from_change_notifier/declaration/declaration.g.dart
@@ -36,14 +36,6 @@ final class MyNotifierProvider
   $AsyncNotifierProviderElement<MyNotifier, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<Todo>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
-    );
-  }
 }
 
 String _$myNotifierHash() => r'fc9a07f8ef9f792da2ac660d76ea0a809335ba18';

--- a/website/docs/migration/from_change_notifier/declaration/declaration.g.dart
+++ b/website/docs/migration/from_change_notifier/declaration/declaration.g.dart
@@ -13,10 +13,8 @@ const myNotifierProvider = MyNotifierProvider._();
 
 final class MyNotifierProvider
     extends $AsyncNotifierProvider<MyNotifier, List<Todo>> {
-  const MyNotifierProvider._(
-      {super.runNotifierBuildOverride, MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const MyNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,39 +24,26 @@ final class MyNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
 
   @$internal
   @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    FutureOr<List<Todo>> Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(runNotifierBuildOverride: build);
-  }
+  MyNotifier create() => MyNotifier();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<MyNotifier, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<Todo>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
+    );
+  }
 }
 
 String _$myNotifierHash() => r'fc9a07f8ef9f792da2ac660d76ea0a809335ba18';

--- a/website/docs/migration/from_change_notifier/initialization/initialization.g.dart
+++ b/website/docs/migration/from_change_notifier/initialization/initialization.g.dart
@@ -36,14 +36,6 @@ final class MyNotifierProvider
   $AsyncNotifierProviderElement<MyNotifier, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<Todo>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
-    );
-  }
 }
 
 String _$myNotifierHash() => r'1c67c12443102cf8c43efbf6c630d3028d9847c3';

--- a/website/docs/migration/from_change_notifier/initialization/initialization.g.dart
+++ b/website/docs/migration/from_change_notifier/initialization/initialization.g.dart
@@ -13,10 +13,8 @@ const myNotifierProvider = MyNotifierProvider._();
 
 final class MyNotifierProvider
     extends $AsyncNotifierProvider<MyNotifier, List<Todo>> {
-  const MyNotifierProvider._(
-      {super.runNotifierBuildOverride, MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const MyNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,39 +24,26 @@ final class MyNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
 
   @$internal
   @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    FutureOr<List<Todo>> Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(runNotifierBuildOverride: build);
-  }
+  MyNotifier create() => MyNotifier();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<MyNotifier, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<Todo>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
+    );
+  }
 }
 
 String _$myNotifierHash() => r'1c67c12443102cf8c43efbf6c630d3028d9847c3';

--- a/website/docs/migration/from_change_notifier/migrated/migrated.g.dart
+++ b/website/docs/migration/from_change_notifier/migrated/migrated.g.dart
@@ -13,10 +13,8 @@ const myNotifierProvider = MyNotifierProvider._();
 
 final class MyNotifierProvider
     extends $AsyncNotifierProvider<MyNotifier, List<Todo>> {
-  const MyNotifierProvider._(
-      {super.runNotifierBuildOverride, MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const MyNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,39 +24,26 @@ final class MyNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
 
   @$internal
   @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    FutureOr<List<Todo>> Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(runNotifierBuildOverride: build);
-  }
+  MyNotifier create() => MyNotifier();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<MyNotifier, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<Todo>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
+    );
+  }
 }
 
 String _$myNotifierHash() => r'bde95c56aa12eff7c8c01ede57ae4ad2b616c225';

--- a/website/docs/migration/from_change_notifier/migrated/migrated.g.dart
+++ b/website/docs/migration/from_change_notifier/migrated/migrated.g.dart
@@ -36,14 +36,6 @@ final class MyNotifierProvider
   $AsyncNotifierProviderElement<MyNotifier, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<Todo>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
-    );
-  }
 }
 
 String _$myNotifierHash() => r'bde95c56aa12eff7c8c01ede57ae4ad2b616c225';

--- a/website/docs/migration/from_state_notifier/add_listener/add_listener.g.dart
+++ b/website/docs/migration/from_state_notifier/add_listener/add_listener.g.dart
@@ -12,10 +12,8 @@ part of 'add_listener.dart';
 const myNotifierProvider = MyNotifierProvider._();
 
 final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
-  const MyNotifierProvider._(
-      {super.runNotifierBuildOverride, MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const MyNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
+
+  @$internal
+  @override
+  MyNotifier create() => MyNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<MyNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<MyNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$myNotifierHash() => r'7ff4b7b8f822ca720b55e2d29ed07d7f0b3485e8';

--- a/website/docs/migration/from_state_notifier/async_notifier/async_notifier.g.dart
+++ b/website/docs/migration/from_state_notifier/async_notifier/async_notifier.g.dart
@@ -13,10 +13,8 @@ const asyncTodosNotifierProvider = AsyncTodosNotifierProvider._();
 
 final class AsyncTodosNotifierProvider
     extends $AsyncNotifierProvider<AsyncTodosNotifier, List<Todo>> {
-  const AsyncTodosNotifierProvider._(
-      {super.runNotifierBuildOverride, AsyncTodosNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const AsyncTodosNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,39 +24,26 @@ final class AsyncTodosNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final AsyncTodosNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$asyncTodosNotifierHash();
 
   @$internal
   @override
-  AsyncTodosNotifier create() => _createCb?.call() ?? AsyncTodosNotifier();
-
-  @$internal
-  @override
-  AsyncTodosNotifierProvider $copyWithCreate(
-    AsyncTodosNotifier Function() create,
-  ) {
-    return AsyncTodosNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  AsyncTodosNotifierProvider $copyWithBuild(
-    FutureOr<List<Todo>> Function(
-      Ref,
-      AsyncTodosNotifier,
-    ) build,
-  ) {
-    return AsyncTodosNotifierProvider._(runNotifierBuildOverride: build);
-  }
+  AsyncTodosNotifier create() => AsyncTodosNotifier();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<AsyncTodosNotifier, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<Todo>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
+    );
+  }
 }
 
 String _$asyncTodosNotifierHash() =>

--- a/website/docs/migration/from_state_notifier/async_notifier/async_notifier.g.dart
+++ b/website/docs/migration/from_state_notifier/async_notifier/async_notifier.g.dart
@@ -36,14 +36,6 @@ final class AsyncTodosNotifierProvider
   $AsyncNotifierProviderElement<AsyncTodosNotifier, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<Todo>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
-    );
-  }
 }
 
 String _$asyncTodosNotifierHash() =>

--- a/website/docs/migration/from_state_notifier/build_init/build_init.g.dart
+++ b/website/docs/migration/from_state_notifier/build_init/build_init.g.dart
@@ -13,10 +13,8 @@ const counterNotifierProvider = CounterNotifierProvider._();
 
 final class CounterNotifierProvider
     extends $NotifierProvider<CounterNotifier, int> {
-  const CounterNotifierProvider._(
-      {super.runNotifierBuildOverride, CounterNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const CounterNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,10 +24,18 @@ final class CounterNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final CounterNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterNotifierHash();
+
+  @$internal
+  @override
+  CounterNotifier create() => CounterNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<CounterNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -38,35 +44,6 @@ final class CounterNotifierProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  CounterNotifier create() => _createCb?.call() ?? CounterNotifier();
-
-  @$internal
-  @override
-  CounterNotifierProvider $copyWithCreate(
-    CounterNotifier Function() create,
-  ) {
-    return CounterNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      CounterNotifier,
-    ) build,
-  ) {
-    return CounterNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<CounterNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterNotifierHash() => r'4a971b45b66819f429f205806499527353d1a78e';

--- a/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
+++ b/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
@@ -85,14 +85,6 @@ final class BugsEncounteredNotifierProvider
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
 
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
-    );
-  }
-
   @override
   bool operator ==(Object other) {
     return other is BugsEncounteredNotifierProvider &&

--- a/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
+++ b/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
@@ -14,12 +14,8 @@ const taskTrackerProvider = TaskTrackerProvider._();
 final class TaskTrackerProvider
     extends $FunctionalProvider<TaskTrackerRepo, TaskTrackerRepo>
     with $Provider<TaskTrackerRepo> {
-  const TaskTrackerProvider._(
-      {TaskTrackerRepo Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const TaskTrackerProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,12 +25,18 @@ final class TaskTrackerProvider
           allTransitiveDependencies: null,
         );
 
-  final TaskTrackerRepo Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$taskTrackerHash();
+
+  @$internal
+  @override
+  $ProviderElement<TaskTrackerRepo> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  TaskTrackerRepo create(Ref ref) {
+    return taskTracker(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(TaskTrackerRepo value) {
@@ -42,26 +44,6 @@ final class TaskTrackerProvider
       origin: this,
       providerOverride: $ValueProvider<TaskTrackerRepo>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<TaskTrackerRepo> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  TaskTrackerProvider $copyWithCreate(
-    TaskTrackerRepo Function(
-      Ref ref,
-    ) create,
-  ) {
-    return TaskTrackerProvider._(create: create);
-  }
-
-  @override
-  TaskTrackerRepo create(Ref ref) {
-    final _$cb = _createCb ?? taskTracker;
-    return _$cb(ref);
   }
 }
 
@@ -74,19 +56,14 @@ final class BugsEncounteredNotifierProvider
     extends $AsyncNotifierProvider<BugsEncounteredNotifier, int> {
   const BugsEncounteredNotifierProvider._(
       {required BugsEncounteredNotifierFamily super.from,
-      required String super.argument,
-      super.runNotifierBuildOverride,
-      BugsEncounteredNotifier Function()? create})
-      : _createCb = create,
-        super(
+      required String super.argument})
+      : super(
           retry: null,
           name: r'bugsEncounteredNotifierProvider',
           isAutoDispose: true,
           dependencies: null,
           allTransitiveDependencies: null,
         );
-
-  final BugsEncounteredNotifier Function()? _createCb;
 
   @override
   String debugGetCreateSourceHash() => _$bugsEncounteredNotifierHash();
@@ -100,39 +77,21 @@ final class BugsEncounteredNotifierProvider
 
   @$internal
   @override
-  BugsEncounteredNotifier create() =>
-      _createCb?.call() ?? BugsEncounteredNotifier();
-
-  @$internal
-  @override
-  BugsEncounteredNotifierProvider $copyWithCreate(
-    BugsEncounteredNotifier Function() create,
-  ) {
-    return BugsEncounteredNotifierProvider._(
-        argument: argument as String,
-        from: from! as BugsEncounteredNotifierFamily,
-        create: create);
-  }
-
-  @$internal
-  @override
-  BugsEncounteredNotifierProvider $copyWithBuild(
-    FutureOr<int> Function(
-      Ref,
-      BugsEncounteredNotifier,
-    ) build,
-  ) {
-    return BugsEncounteredNotifierProvider._(
-        argument: argument as String,
-        from: from! as BugsEncounteredNotifierFamily,
-        runNotifierBuildOverride: build);
-  }
+  BugsEncounteredNotifier create() => BugsEncounteredNotifier();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<BugsEncounteredNotifier, int> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<int> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -165,50 +124,39 @@ final class BugsEncounteredNotifierFamily extends Family {
       BugsEncounteredNotifierProvider._(argument: featureId, from: this);
 
   @override
-  String debugGetCreateSourceHash() => _$bugsEncounteredNotifierHash();
-
-  @override
   String toString() => r'bugsEncounteredNotifierProvider';
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-    BugsEncounteredNotifier Function(
-      String args,
-    ) create,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as BugsEncounteredNotifierProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithCreate(() => create(argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          BugsEncounteredNotifier Function(
+            String args,
+          ) create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as BugsEncounteredNotifierProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(create: () => create(argument))
+                .$createElement(pointer);
+          });
 
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
-    FutureOr<int> Function(
-            Ref ref, BugsEncounteredNotifier notifier, String argument)
-        build,
-  ) {
-    return $FamilyOverride(
-      from: this,
-      createElement: (pointer) {
-        final provider = pointer.origin as BugsEncounteredNotifierProvider;
-
-        final argument = provider.argument as String;
-
-        return provider
-            .$copyWithBuild((ref, notifier) => build(ref, notifier, argument))
-            .$createElement(pointer);
-      },
-    );
-  }
+          FutureOr<int> Function(
+                  Ref ref, BugsEncounteredNotifier notifier, String argument)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as BugsEncounteredNotifierProvider;
+            final argument = provider.argument as String;
+            return provider
+                .$view(
+                    runNotifierBuildOverride: (ref, notifier) =>
+                        build(ref, notifier, argument))
+                .$createElement(pointer);
+          });
 }
 
 abstract class _$BugsEncounteredNotifier extends $AsyncNotifier<int> {

--- a/website/docs/migration/from_state_notifier/from_state_provider/from_state_provider.g.dart
+++ b/website/docs/migration/from_state_notifier/from_state_provider/from_state_provider.g.dart
@@ -13,10 +13,8 @@ const counterNotifierProvider = CounterNotifierProvider._();
 
 final class CounterNotifierProvider
     extends $NotifierProvider<CounterNotifier, int> {
-  const CounterNotifierProvider._(
-      {super.runNotifierBuildOverride, CounterNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const CounterNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -26,10 +24,18 @@ final class CounterNotifierProvider
           allTransitiveDependencies: null,
         );
 
-  final CounterNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$counterNotifierHash();
+
+  @$internal
+  @override
+  CounterNotifier create() => CounterNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<CounterNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -38,35 +44,6 @@ final class CounterNotifierProvider
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  CounterNotifier create() => _createCb?.call() ?? CounterNotifier();
-
-  @$internal
-  @override
-  CounterNotifierProvider $copyWithCreate(
-    CounterNotifier Function() create,
-  ) {
-    return CounterNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CounterNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      CounterNotifier,
-    ) build,
-  ) {
-    return CounterNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<CounterNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$counterNotifierHash() => r'b32033040f0fff627f1a6dfd9cfb4e93a842390b';

--- a/website/docs/migration/from_state_notifier/old_lifecycles/old_lifecycles.g.dart
+++ b/website/docs/migration/from_state_notifier/old_lifecycles/old_lifecycles.g.dart
@@ -12,10 +12,8 @@ part of 'old_lifecycles.dart';
 const myNotifierProvider = MyNotifierProvider._();
 
 final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
-  const MyNotifierProvider._(
-      {super.runNotifierBuildOverride, MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const MyNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
+
+  @$internal
+  @override
+  MyNotifier create() => MyNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<MyNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<MyNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$myNotifierHash() => r'0495c52ce893ee0304d4d5ac5648c634ed4a241e';

--- a/website/docs/migration/from_state_notifier/old_lifecycles_final/old_lifecycles_final.g.dart
+++ b/website/docs/migration/from_state_notifier/old_lifecycles_final/old_lifecycles_final.g.dart
@@ -13,12 +13,8 @@ const durationProvider = DurationProvider._();
 
 final class DurationProvider extends $FunctionalProvider<Duration, Duration>
     with $Provider<Duration> {
-  const DurationProvider._(
-      {Duration Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const DurationProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class DurationProvider extends $FunctionalProvider<Duration, Duration>
           allTransitiveDependencies: null,
         );
 
-  final Duration Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$durationHash();
+
+  @$internal
+  @override
+  $ProviderElement<Duration> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Duration create(Ref ref) {
+    return duration(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Duration value) {
@@ -41,26 +43,6 @@ final class DurationProvider extends $FunctionalProvider<Duration, Duration>
       origin: this,
       providerOverride: $ValueProvider<Duration>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Duration> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  DurationProvider $copyWithCreate(
-    Duration Function(
-      Ref ref,
-    ) create,
-  ) {
-    return DurationProvider._(create: create);
-  }
-
-  @override
-  Duration create(Ref ref) {
-    final _$cb = _createCb ?? duration;
-    return _$cb(ref);
   }
 }
 
@@ -71,12 +53,8 @@ const repositoryProvider = RepositoryProvider._();
 
 final class RepositoryProvider extends $FunctionalProvider<_MyRepo, _MyRepo>
     with $Provider<_MyRepo> {
-  const RepositoryProvider._(
-      {_MyRepo Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const RepositoryProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -86,12 +64,18 @@ final class RepositoryProvider extends $FunctionalProvider<_MyRepo, _MyRepo>
           allTransitiveDependencies: null,
         );
 
-  final _MyRepo Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$repositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<_MyRepo> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  _MyRepo create(Ref ref) {
+    return repository(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(_MyRepo value) {
@@ -99,26 +83,6 @@ final class RepositoryProvider extends $FunctionalProvider<_MyRepo, _MyRepo>
       origin: this,
       providerOverride: $ValueProvider<_MyRepo>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<_MyRepo> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  RepositoryProvider $copyWithCreate(
-    _MyRepo Function(
-      Ref ref,
-    ) create,
-  ) {
-    return RepositoryProvider._(create: create);
-  }
-
-  @override
-  _MyRepo create(Ref ref) {
-    final _$cb = _createCb ?? repository;
-    return _$cb(ref);
   }
 }
 
@@ -128,10 +92,8 @@ String _$repositoryHash() => r'8c1b035ba722660550674e92444db7b6f25ac2a3';
 const myNotifierProvider = MyNotifierProvider._();
 
 final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
-  const MyNotifierProvider._(
-      {super.runNotifierBuildOverride, MyNotifier Function()? create})
-      : _createCb = create,
-        super(
+  const MyNotifierProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -141,10 +103,18 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
           allTransitiveDependencies: null,
         );
 
-  final MyNotifier Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$myNotifierHash();
+
+  @$internal
+  @override
+  MyNotifier create() => MyNotifier();
+
+  @$internal
+  @override
+  $NotifierProviderElement<MyNotifier, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -153,35 +123,6 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  MyNotifier create() => _createCb?.call() ?? MyNotifier();
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithCreate(
-    MyNotifier Function() create,
-  ) {
-    return MyNotifierProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  MyNotifierProvider $copyWithBuild(
-    int Function(
-      Ref,
-      MyNotifier,
-    ) build,
-  ) {
-    return MyNotifierProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<MyNotifier, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$myNotifierHash() => r'8ea2586ea29d12306efd4b8b847142136dd20338';

--- a/website/docs/providers/future_provider/config_provider/codegen.g.dart
+++ b/website/docs/providers/future_provider/config_provider/codegen.g.dart
@@ -14,12 +14,8 @@ const fetchConfigurationProvider = FetchConfigurationProvider._();
 final class FetchConfigurationProvider extends $FunctionalProvider<
         AsyncValue<Configuration>, FutureOr<Configuration>>
     with $FutureModifier<Configuration>, $FutureProvider<Configuration> {
-  const FetchConfigurationProvider._(
-      {FutureOr<Configuration> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FetchConfigurationProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,10 +25,6 @@ final class FetchConfigurationProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Configuration> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$fetchConfigurationHash();
 
@@ -40,21 +32,11 @@ final class FetchConfigurationProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<Configuration> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  FetchConfigurationProvider $copyWithCreate(
-    FutureOr<Configuration> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FetchConfigurationProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Configuration> create(Ref ref) {
-    final _$cb = _createCb ?? fetchConfiguration;
-    return _$cb(ref);
+    return fetchConfiguration(ref);
   }
 }
 

--- a/website/docs/providers/notifier_provider/remote_todos/codegen.g.dart
+++ b/website/docs/providers/notifier_provider/remote_todos/codegen.g.dart
@@ -29,10 +29,8 @@ const asyncTodosProvider = AsyncTodosProvider._();
 
 final class AsyncTodosProvider
     extends $AsyncNotifierProvider<AsyncTodos, List<Todo>> {
-  const AsyncTodosProvider._(
-      {super.runNotifierBuildOverride, AsyncTodos Function()? create})
-      : _createCb = create,
-        super(
+  const AsyncTodosProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -42,39 +40,26 @@ final class AsyncTodosProvider
           allTransitiveDependencies: null,
         );
 
-  final AsyncTodos Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$asyncTodosHash();
 
   @$internal
   @override
-  AsyncTodos create() => _createCb?.call() ?? AsyncTodos();
-
-  @$internal
-  @override
-  AsyncTodosProvider $copyWithCreate(
-    AsyncTodos Function() create,
-  ) {
-    return AsyncTodosProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  AsyncTodosProvider $copyWithBuild(
-    FutureOr<List<Todo>> Function(
-      Ref,
-      AsyncTodos,
-    ) build,
-  ) {
-    return AsyncTodosProvider._(runNotifierBuildOverride: build);
-  }
+  AsyncTodos create() => AsyncTodos();
 
   @$internal
   @override
   $AsyncNotifierProviderElement<AsyncTodos, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
-      $AsyncNotifierProviderElement(this, pointer);
+      $AsyncNotifierProviderElement(pointer);
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<List<Todo>> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
+    );
+  }
 }
 
 String _$asyncTodosHash() => r'fd0d7502a1c17b7cedd2350519649dd680fc48cd';

--- a/website/docs/providers/notifier_provider/remote_todos/codegen.g.dart
+++ b/website/docs/providers/notifier_provider/remote_todos/codegen.g.dart
@@ -52,14 +52,6 @@ final class AsyncTodosProvider
   $AsyncNotifierProviderElement<AsyncTodos, List<Todo>> $createElement(
           $ProviderPointer pointer) =>
       $AsyncNotifierProviderElement(pointer);
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<List<Todo>> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $ValueProvider<AsyncValue<List<Todo>>>(value),
-    );
-  }
 }
 
 String _$asyncTodosHash() => r'fd0d7502a1c17b7cedd2350519649dd680fc48cd';

--- a/website/docs/providers/notifier_provider/todos/codegen.g.dart
+++ b/website/docs/providers/notifier_provider/todos/codegen.g.dart
@@ -12,10 +12,8 @@ part of 'codegen.dart';
 const todosProvider = TodosProvider._();
 
 final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
-  const TodosProvider._(
-      {super.runNotifierBuildOverride, Todos Function()? create})
-      : _createCb = create,
-        super(
+  const TodosProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
           allTransitiveDependencies: null,
         );
 
-  final Todos Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todosHash();
+
+  @$internal
+  @override
+  Todos create() => Todos();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Todos, List<Todo>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -37,35 +43,6 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
   }
-
-  @$internal
-  @override
-  Todos create() => _createCb?.call() ?? Todos();
-
-  @$internal
-  @override
-  TodosProvider $copyWithCreate(
-    Todos Function() create,
-  ) {
-    return TodosProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  TodosProvider $copyWithBuild(
-    List<Todo> Function(
-      Ref,
-      Todos,
-    ) build,
-  ) {
-    return TodosProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Todos, List<Todo>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$todosHash() => r'3485c14ec4db07efe5fe52243258a66e6f99b2b4';

--- a/website/docs/providers/provider/completed_todos/completed_todos.g.dart
+++ b/website/docs/providers/provider/completed_todos/completed_todos.g.dart
@@ -14,12 +14,8 @@ const completedTodosProvider = CompletedTodosProvider._();
 final class CompletedTodosProvider
     extends $FunctionalProvider<List<Todo>, List<Todo>>
     with $Provider<List<Todo>> {
-  const CompletedTodosProvider._(
-      {List<Todo> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CompletedTodosProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,12 +25,18 @@ final class CompletedTodosProvider
           allTransitiveDependencies: null,
         );
 
-  final List<Todo> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$completedTodosHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<Todo> create(Ref ref) {
+    return completedTodos(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -42,26 +44,6 @@ final class CompletedTodosProvider
       origin: this,
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CompletedTodosProvider $copyWithCreate(
-    List<Todo> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CompletedTodosProvider._(create: create);
-  }
-
-  @override
-  List<Todo> create(Ref ref) {
-    final _$cb = _createCb ?? completedTodos;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/providers/provider/optimized_previous_button/optimized_previous_button.g.dart
+++ b/website/docs/providers/provider/optimized_previous_button/optimized_previous_button.g.dart
@@ -12,10 +12,8 @@ part of 'optimized_previous_button.dart';
 const pageIndexProvider = PageIndexProvider._();
 
 final class PageIndexProvider extends $NotifierProvider<PageIndex, int> {
-  const PageIndexProvider._(
-      {super.runNotifierBuildOverride, PageIndex Function()? create})
-      : _createCb = create,
-        super(
+  const PageIndexProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class PageIndexProvider extends $NotifierProvider<PageIndex, int> {
           allTransitiveDependencies: null,
         );
 
-  final PageIndex Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$pageIndexHash();
+
+  @$internal
+  @override
+  PageIndex create() => PageIndex();
+
+  @$internal
+  @override
+  $NotifierProviderElement<PageIndex, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class PageIndexProvider extends $NotifierProvider<PageIndex, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  PageIndex create() => _createCb?.call() ?? PageIndex();
-
-  @$internal
-  @override
-  PageIndexProvider $copyWithCreate(
-    PageIndex Function() create,
-  ) {
-    return PageIndexProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  PageIndexProvider $copyWithBuild(
-    int Function(
-      Ref,
-      PageIndex,
-    ) build,
-  ) {
-    return PageIndexProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<PageIndex, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$pageIndexHash() => r'59307ecf23b5b2432833da5ad6b312bf36435d0e';
@@ -88,12 +65,8 @@ const canGoToPreviousPageProvider = CanGoToPreviousPageProvider._();
 
 final class CanGoToPreviousPageProvider extends $FunctionalProvider<bool, bool>
     with $Provider<bool> {
-  const CanGoToPreviousPageProvider._(
-      {bool Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const CanGoToPreviousPageProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -103,12 +76,18 @@ final class CanGoToPreviousPageProvider extends $FunctionalProvider<bool, bool>
           allTransitiveDependencies: null,
         );
 
-  final bool Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$canGoToPreviousPageHash();
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    return canGoToPreviousPage(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(bool value) {
@@ -116,26 +95,6 @@ final class CanGoToPreviousPageProvider extends $FunctionalProvider<bool, bool>
       origin: this,
       providerOverride: $ValueProvider<bool>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  CanGoToPreviousPageProvider $copyWithCreate(
-    bool Function(
-      Ref ref,
-    ) create,
-  ) {
-    return CanGoToPreviousPageProvider._(create: create);
-  }
-
-  @override
-  bool create(Ref ref) {
-    final _$cb = _createCb ?? canGoToPreviousPage;
-    return _$cb(ref);
   }
 }
 

--- a/website/docs/providers/provider/todo/todo.g.dart
+++ b/website/docs/providers/provider/todo/todo.g.dart
@@ -12,10 +12,8 @@ part of 'todo.dart';
 const todosProvider = TodosProvider._();
 
 final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
-  const TodosProvider._(
-      {super.runNotifierBuildOverride, Todos Function()? create})
-      : _createCb = create,
-        super(
+  const TodosProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
           allTransitiveDependencies: null,
         );
 
-  final Todos Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todosHash();
+
+  @$internal
+  @override
+  Todos create() => Todos();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Todos, List<Todo>> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -37,35 +43,6 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
   }
-
-  @$internal
-  @override
-  Todos create() => _createCb?.call() ?? Todos();
-
-  @$internal
-  @override
-  TodosProvider $copyWithCreate(
-    Todos Function() create,
-  ) {
-    return TodosProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  TodosProvider $copyWithBuild(
-    List<Todo> Function(
-      Ref,
-      Todos,
-    ) build,
-  ) {
-    return TodosProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Todos, List<Todo>> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$todosHash() => r'4bd25c3c15bfff56ad6e733bd17ecb7284c4ceb2';

--- a/website/docs/providers/provider/unoptimized_previous_button/unoptimized_previous_button.g.dart
+++ b/website/docs/providers/provider/unoptimized_previous_button/unoptimized_previous_button.g.dart
@@ -12,10 +12,8 @@ part of 'unoptimized_previous_button.dart';
 const pageIndexProvider = PageIndexProvider._();
 
 final class PageIndexProvider extends $NotifierProvider<PageIndex, int> {
-  const PageIndexProvider._(
-      {super.runNotifierBuildOverride, PageIndex Function()? create})
-      : _createCb = create,
-        super(
+  const PageIndexProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class PageIndexProvider extends $NotifierProvider<PageIndex, int> {
           allTransitiveDependencies: null,
         );
 
-  final PageIndex Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$pageIndexHash();
+
+  @$internal
+  @override
+  PageIndex create() => PageIndex();
+
+  @$internal
+  @override
+  $NotifierProviderElement<PageIndex, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class PageIndexProvider extends $NotifierProvider<PageIndex, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  PageIndex create() => _createCb?.call() ?? PageIndex();
-
-  @$internal
-  @override
-  PageIndexProvider $copyWithCreate(
-    PageIndex Function() create,
-  ) {
-    return PageIndexProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  PageIndexProvider $copyWithBuild(
-    int Function(
-      Ref,
-      PageIndex,
-    ) build,
-  ) {
-    return PageIndexProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<PageIndex, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$pageIndexHash() => r'59307ecf23b5b2432833da5ad6b312bf36435d0e';

--- a/website/docs/providers/stream_provider/live_stream_chat_provider/codegen.g.dart
+++ b/website/docs/providers/stream_provider/live_stream_chat_provider/codegen.g.dart
@@ -14,12 +14,8 @@ const chatProvider = ChatProvider._();
 final class ChatProvider
     extends $FunctionalProvider<AsyncValue<List<String>>, Stream<List<String>>>
     with $FutureModifier<List<String>>, $StreamProvider<List<String>> {
-  const ChatProvider._(
-      {Stream<List<String>> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ChatProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,10 +25,6 @@ final class ChatProvider
           allTransitiveDependencies: null,
         );
 
-  final Stream<List<String>> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$chatHash();
 
@@ -40,21 +32,11 @@ final class ChatProvider
   @override
   $StreamProviderElement<List<String>> $createElement(
           $ProviderPointer pointer) =>
-      $StreamProviderElement(this, pointer);
-
-  @override
-  ChatProvider $copyWithCreate(
-    Stream<List<String>> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ChatProvider._(create: create);
-  }
+      $StreamProviderElement(pointer);
 
   @override
   Stream<List<String>> create(Ref ref) {
-    final _$cb = _createCb ?? chat;
-    return _$cb(ref);
+    return chat(ref);
   }
 }
 

--- a/website/static/snippets/async.g.dart
+++ b/website/static/snippets/async.g.dart
@@ -14,12 +14,8 @@ const configurationsProvider = ConfigurationsProvider._();
 final class ConfigurationsProvider extends $FunctionalProvider<
         AsyncValue<Configuration>, FutureOr<Configuration>>
     with $FutureModifier<Configuration>, $FutureProvider<Configuration> {
-  const ConfigurationsProvider._(
-      {FutureOr<Configuration> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const ConfigurationsProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,10 +25,6 @@ final class ConfigurationsProvider extends $FunctionalProvider<
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<Configuration> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$configurationsHash();
 
@@ -40,21 +32,11 @@ final class ConfigurationsProvider extends $FunctionalProvider<
   @override
   $FutureProviderElement<Configuration> $createElement(
           $ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  ConfigurationsProvider $copyWithCreate(
-    FutureOr<Configuration> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return ConfigurationsProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<Configuration> create(Ref ref) {
-    final _$cb = _createCb ?? configurations;
-    return _$cb(ref);
+    return configurations(ref);
   }
 }
 

--- a/website/static/snippets/combine.g.dart
+++ b/website/static/snippets/combine.g.dart
@@ -13,12 +13,8 @@ const todosProvider = TodosProvider._();
 
 final class TodosProvider extends $FunctionalProvider<List<Todo>, List<Todo>>
     with $Provider<List<Todo>> {
-  const TodosProvider._(
-      {List<Todo> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const TodosProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -28,12 +24,18 @@ final class TodosProvider extends $FunctionalProvider<List<Todo>, List<Todo>>
           allTransitiveDependencies: null,
         );
 
-  final List<Todo> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$todosHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<Todo> create(Ref ref) {
+    return todos(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -41,26 +43,6 @@ final class TodosProvider extends $FunctionalProvider<List<Todo>, List<Todo>>
       origin: this,
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  TodosProvider $copyWithCreate(
-    List<Todo> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return TodosProvider._(create: create);
-  }
-
-  @override
-  List<Todo> create(Ref ref) {
-    final _$cb = _createCb ?? todos;
-    return _$cb(ref);
   }
 }
 
@@ -71,12 +53,8 @@ const filterProvider = FilterProvider._();
 
 final class FilterProvider extends $FunctionalProvider<Filter, Filter>
     with $Provider<Filter> {
-  const FilterProvider._(
-      {Filter Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FilterProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -86,12 +64,18 @@ final class FilterProvider extends $FunctionalProvider<Filter, Filter>
           allTransitiveDependencies: null,
         );
 
-  final Filter Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$filterHash();
+
+  @$internal
+  @override
+  $ProviderElement<Filter> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Filter create(Ref ref) {
+    return filter(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Filter value) {
@@ -99,26 +83,6 @@ final class FilterProvider extends $FunctionalProvider<Filter, Filter>
       origin: this,
       providerOverride: $ValueProvider<Filter>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<Filter> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FilterProvider $copyWithCreate(
-    Filter Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FilterProvider._(create: create);
-  }
-
-  @override
-  Filter create(Ref ref) {
-    final _$cb = _createCb ?? filter;
-    return _$cb(ref);
   }
 }
 
@@ -130,12 +94,8 @@ const filteredTodosProvider = FilteredTodosProvider._();
 final class FilteredTodosProvider
     extends $FunctionalProvider<List<Todo>, List<Todo>>
     with $Provider<List<Todo>> {
-  const FilteredTodosProvider._(
-      {List<Todo> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const FilteredTodosProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -145,12 +105,18 @@ final class FilteredTodosProvider
           allTransitiveDependencies: null,
         );
 
-  final List<Todo> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$filteredTodosHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  List<Todo> create(Ref ref) {
+    return filteredTodos(ref);
+  }
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(List<Todo> value) {
@@ -158,26 +124,6 @@ final class FilteredTodosProvider
       origin: this,
       providerOverride: $ValueProvider<List<Todo>>(value),
     );
-  }
-
-  @$internal
-  @override
-  $ProviderElement<List<Todo>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(this, pointer);
-
-  @override
-  FilteredTodosProvider $copyWithCreate(
-    List<Todo> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return FilteredTodosProvider._(create: create);
-  }
-
-  @override
-  List<Todo> create(Ref ref) {
-    final _$cb = _createCb ?? filteredTodos;
-    return _$cb(ref);
   }
 }
 

--- a/website/static/snippets/create.g.dart
+++ b/website/static/snippets/create.g.dart
@@ -14,12 +14,8 @@ const boredSuggestionProvider = BoredSuggestionProvider._();
 final class BoredSuggestionProvider
     extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
-  const BoredSuggestionProvider._(
-      {FutureOr<String> Function(
-        Ref ref,
-      )? create})
-      : _createCb = create,
-        super(
+  const BoredSuggestionProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -29,31 +25,17 @@ final class BoredSuggestionProvider
           allTransitiveDependencies: null,
         );
 
-  final FutureOr<String> Function(
-    Ref ref,
-  )? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$boredSuggestionHash();
 
   @$internal
   @override
   $FutureProviderElement<String> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(this, pointer);
-
-  @override
-  BoredSuggestionProvider $copyWithCreate(
-    FutureOr<String> Function(
-      Ref ref,
-    ) create,
-  ) {
-    return BoredSuggestionProvider._(create: create);
-  }
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<String> create(Ref ref) {
-    final _$cb = _createCb ?? boredSuggestion;
-    return _$cb(ref);
+    return boredSuggestion(ref);
   }
 }
 

--- a/website/static/snippets/declare.g.dart
+++ b/website/static/snippets/declare.g.dart
@@ -12,10 +12,8 @@ part of 'declare.dart';
 const countProvider = CountProvider._();
 
 final class CountProvider extends $NotifierProvider<Count, int> {
-  const CountProvider._(
-      {super.runNotifierBuildOverride, Count Function()? create})
-      : _createCb = create,
-        super(
+  const CountProvider._()
+      : super(
           from: null,
           argument: null,
           retry: null,
@@ -25,10 +23,18 @@ final class CountProvider extends $NotifierProvider<Count, int> {
           allTransitiveDependencies: null,
         );
 
-  final Count Function()? _createCb;
-
   @override
   String debugGetCreateSourceHash() => _$countHash();
+
+  @$internal
+  @override
+  Count create() => Count();
+
+  @$internal
+  @override
+  $NotifierProviderElement<Count, int> $createElement(
+          $ProviderPointer pointer) =>
+      $NotifierProviderElement(pointer);
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(int value) {
@@ -37,35 +43,6 @@ final class CountProvider extends $NotifierProvider<Count, int> {
       providerOverride: $ValueProvider<int>(value),
     );
   }
-
-  @$internal
-  @override
-  Count create() => _createCb?.call() ?? Count();
-
-  @$internal
-  @override
-  CountProvider $copyWithCreate(
-    Count Function() create,
-  ) {
-    return CountProvider._(create: create);
-  }
-
-  @$internal
-  @override
-  CountProvider $copyWithBuild(
-    int Function(
-      Ref,
-      Count,
-    ) build,
-  ) {
-    return CountProvider._(runNotifierBuildOverride: build);
-  }
-
-  @$internal
-  @override
-  $NotifierProviderElement<Count, int> $createElement(
-          $ProviderPointer pointer) =>
-      $NotifierProviderElement(this, pointer);
 }
 
 String _$countHash() => r'6fc5f8ad4bbd390899dd0d14c7b902407d4413bd';


### PR DESCRIPTION
Nice

<img width="383" alt="Screenshot 2025-04-21 at 10 02 44" src="https://github.com/user-attachments/assets/82168da1-0063-41fb-a260-3335fea89c8c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Provider classes have been simplified to always use the original creation logic, removing support for custom creation callbacks and related copy methods.
  - The ability to override provider creation via constructor parameters or copy methods has been removed; providers now directly call their original functions or constructors.
  - Element creation methods have been streamlined, now only requiring a pointer argument.
  - Override methods have been unified and simplified across families and individual providers using a new `$view` mechanism.
  - Generic provider families now use a generic capture helper to handle type parameters during overrides.
  - Debug-only source hash methods have been removed from family classes.
- **Style**
  - Placement of override methods and internal logic has been standardized for consistency across all providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->