### PR TITLE
docs(ko): Fix typo 'provice' → 'provider' in websockets_sync.mdx

### DIFF
--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/essentials/websockets_sync.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/essentials/websockets_sync.mdx
@@ -30,7 +30,7 @@ _하지만_ Riverpod는 필요한 경우 다른 형식도 지원합니다.
 
 ## 동기적으로 객체 반환하기
 
-객체를 동기적으로 생성하려면 provice가 Future를 반환하지 않는지 확인하세요:
+객체를 동기적으로 생성하려면 provider가 Future를 반환하지 않는지 확인하세요:
 
 <AutoSnippet 
   {...syncDefinition} 


### PR DESCRIPTION
## Related Issues

fixes #4077

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
      
  **This is a documentation-only PR that corrects a translation error in the Korean version of the docs.
There are no code changes or feature additions, and therefore no CHANGELOG.md update is required.**

Let me know if you'd like me to revise anything further.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in the Korean documentation for WebSockets synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->