### PR TITLE
docs(ko): Fix remaining typo in Korean docs: 'provice' → 'provider'

### DIFF
--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/essentials/websockets_sync.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/essentials/websockets_sync.mdx
@@ -30,7 +30,7 @@ _하지만_ Riverpod는 필요한 경우 다른 형식도 지원합니다.
 
 ## 동기적으로 객체 반환하기
 
-객체를 동기적으로 생성하려면 provice가 Future를 반환하지 않는지 확인하세요:
+객체를 동기적으로 생성하려면 provider가 Future를 반환하지 않는지 확인하세요:
 
 <AutoSnippet 
   {...syncDefinition} 

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/essentials/websockets_sync.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/essentials/websockets_sync.mdx
@@ -48,7 +48,7 @@ provider가 객체를 동기적으로 생성하면 객체가 소비되는 방식
   }}
 />
 
-이 차이로 인해 provice가 에러를 발생시키면 값을 읽으려고(read) 하면 에러가 다시 발생(rethrow)합니다.
+이 차이로 인해 provider 에러를 발생시키면 값을 읽으려고(read) 하면 에러가 다시 발생(rethrow)합니다.
 또는 `ref.listen`을 사용할 경우 "onError" 콜백이 호출됩니다.
 
 ### 수신 가능(Listenable) 객체 고려 사항


### PR DESCRIPTION
## Related Issues

fixes #4077 

The issue #4077 has already been closed, and a previous PR has been merged.

However, I found another occurrence of the same typo (provice → provider) that was missed in that update.

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
      
      **Apologies for submitting a second PR related to the same issue.
I just wanted to ensure all instances of the typo are fully addressed.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a typographical error and improved clarity in the Korean documentation related to error handling and callbacks when using WebSockets synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->