### PR TITLE
Unify codegen and non-codegen overrides

### DIFF
--- a/examples/pub/lib/detail.g.dart
+++ b/examples/pub/lib/detail.g.dart
@@ -63,7 +63,8 @@ final class FetchPackageDetailsProvider
 String _$fetchPackageDetailsHash() =>
     r'16ad07d6f69412f6d456c6d482f15dc53421df74';
 
-final class FetchPackageDetailsFamily extends $Family {
+final class FetchPackageDetailsFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<Package>, String> {
   const FetchPackageDetailsFamily._()
       : super(
           retry: null,
@@ -80,22 +81,6 @@ final class FetchPackageDetailsFamily extends $Family {
 
   @override
   String toString() => r'fetchPackageDetailsProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FutureOr<Package> Function(
-            Ref ref,
-            String args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FetchPackageDetailsProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(likedPackages)
@@ -242,7 +227,10 @@ String _$packageMetricsHash() => r'67cd25e50357e6e970d432c1d255085a23b856ac';
 ///
 /// It also exposes utilities to like/unlike a package, assuming the user
 /// is logged-in.
-final class PackageMetricsFamily extends $Family {
+final class PackageMetricsFamily extends $Family
+    with
+        $ClassFamilyOverride<PackageMetrics, AsyncValue<PackageMetricsScore>,
+            PackageMetricsScore, FutureOr<PackageMetricsScore>, String> {
   const PackageMetricsFamily._()
       : super(
           retry: null,
@@ -264,38 +252,6 @@ final class PackageMetricsFamily extends $Family {
 
   @override
   String toString() => r'packageMetricsProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          PackageMetrics Function(
-            String args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as PackageMetricsProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          FutureOr<PackageMetricsScore> Function(
-                  Ref ref, PackageMetrics notifier, String argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as PackageMetricsProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$PackageMetrics extends $AsyncNotifier<PackageMetricsScore> {

--- a/examples/pub/lib/search.g.dart
+++ b/examples/pub/lib/search.g.dart
@@ -71,7 +71,14 @@ final class FetchPackagesProvider extends $FunctionalProvider<
 
 String _$fetchPackagesHash() => r'b52d4beb5d9ac53769d76ccd1d81bb005c66edd5';
 
-final class FetchPackagesFamily extends $Family {
+final class FetchPackagesFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+            FutureOr<List<Package>>,
+            ({
+              int page,
+              String search,
+            })> {
   const FetchPackagesFamily._()
       : super(
           retry: null,
@@ -92,28 +99,6 @@ final class FetchPackagesFamily extends $Family {
 
   @override
   String toString() => r'fetchPackagesProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FutureOr<List<Package>> Function(
-            Ref ref,
-            ({
-              int page,
-              String search,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FetchPackagesProvider;
-            final argument = provider.argument as ({
-              int page,
-              String search,
-            });
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_annotation/lib/riverpod_annotation.dart
+++ b/packages/riverpod_annotation/lib/riverpod_annotation.dart
@@ -72,7 +72,9 @@ export './src/internal.dart'
         Riverpod,
         ProviderFor,
         Raw,
-        MissingScopeException;
+        MissingScopeException,
+        $FunctionalFamilyOverride,
+        $ClassFamilyOverride;
 
 /// An implementation detail of `riverpod_generator`.
 /// Do not use.

--- a/packages/riverpod_generator/integration/build_yaml/lib/dependencies.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/dependencies.g.dart
@@ -82,7 +82,8 @@ final class Calc2Provider extends $FunctionalProvider<int, int>
 
 String _$calc2Hash() => r'ae1d601ff7cdda569255e8014bd5d8d1c178b3eb';
 
-final class Calc2Family extends $Family {
+final class Calc2Family extends $Family
+    with $FunctionalFamilyOverride<int, String> {
   const Calc2Family._()
       : super(
           retry: null,
@@ -125,22 +126,6 @@ final class Calc2Family extends $Family {
 
   @override
   String toString() => r'myFamilyCalc2ProviderFamily';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            String args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as Calc2Provider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
@@ -317,7 +317,8 @@ final class Count2Provider extends $FunctionalProvider<int, int>
 
 String _$count2Hash() => r'4146ae486161f9d444b4d80ec846199b13eeaae2';
 
-final class Count2Family extends $Family {
+final class Count2Family extends $Family
+    with $FunctionalFamilyOverride<int, int> {
   const Count2Family._()
       : super(
           retry: null,
@@ -334,22 +335,6 @@ final class Count2Family extends $Family {
 
   @override
   String toString() => r'myFamilyCount2ProviderFamily';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as Count2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(countFuture2)
@@ -405,7 +390,8 @@ final class CountFuture2Provider
 
 String _$countFuture2Hash() => r'6acaa58de0116853fd831efb4ac1a8047205f12b';
 
-final class CountFuture2Family extends $Family {
+final class CountFuture2Family extends $Family
+    with $FunctionalFamilyOverride<FutureOr<int>, int> {
   const CountFuture2Family._()
       : super(
           retry: null,
@@ -422,22 +408,6 @@ final class CountFuture2Family extends $Family {
 
   @override
   String toString() => r'myFamilyCountFuture2ProviderFamily';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FutureOr<int> Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as CountFuture2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(countStream2)
@@ -493,7 +463,8 @@ final class CountStream2Provider
 
 String _$countStream2Hash() => r'96c9a0935240f1727986800c1fe6dea974b9accc';
 
-final class CountStream2Family extends $Family {
+final class CountStream2Family extends $Family
+    with $FunctionalFamilyOverride<Stream<int>, int> {
   const CountStream2Family._()
       : super(
           retry: null,
@@ -510,22 +481,6 @@ final class CountStream2Family extends $Family {
 
   @override
   String toString() => r'myFamilyCountStream2ProviderFamily';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          Stream<int> Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as CountStream2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(CountNotifier2)
@@ -584,7 +539,8 @@ final class CountNotifier2Provider
 
 String _$countNotifier2Hash() => r'ef12bb4f94add336804ae43bcdbcd8e9b0bec420';
 
-final class CountNotifier2Family extends $Family {
+final class CountNotifier2Family extends $Family
+    with $ClassFamilyOverride<CountNotifier2, int, int, int, int> {
   const CountNotifier2Family._()
       : super(
           retry: null,
@@ -601,36 +557,6 @@ final class CountNotifier2Family extends $Family {
 
   @override
   String toString() => r'myFamilyCountNotifier2ProviderFamily';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          CountNotifier2 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as CountNotifier2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(Ref ref, CountNotifier2 notifier, int argument) build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as CountNotifier2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$CountNotifier2 extends $Notifier<int> {
@@ -703,7 +629,10 @@ final class CountAsyncNotifier2Provider
 String _$countAsyncNotifier2Hash() =>
     r'e4bd4d858edbb47fa0d7581f3cfa72e13c914d3d';
 
-final class CountAsyncNotifier2Family extends $Family {
+final class CountAsyncNotifier2Family extends $Family
+    with
+        $ClassFamilyOverride<CountAsyncNotifier2, AsyncValue<int>, int,
+            FutureOr<int>, int> {
   const CountAsyncNotifier2Family._()
       : super(
           retry: null,
@@ -720,38 +649,6 @@ final class CountAsyncNotifier2Family extends $Family {
 
   @override
   String toString() => r'myFamilyCountAsyncNotifier2ProviderFamily';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          CountAsyncNotifier2 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as CountAsyncNotifier2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          FutureOr<int> Function(
-                  Ref ref, CountAsyncNotifier2 notifier, int argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as CountAsyncNotifier2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$CountAsyncNotifier2 extends $AsyncNotifier<int> {
@@ -825,7 +722,10 @@ final class CountStreamNotifier2Provider
 String _$countStreamNotifier2Hash() =>
     r'13be1b7aa32801b33c68f2a228851d2fb6a4a9ee';
 
-final class CountStreamNotifier2Family extends $Family {
+final class CountStreamNotifier2Family extends $Family
+    with
+        $ClassFamilyOverride<CountStreamNotifier2, AsyncValue<int>, int,
+            Stream<int>, int> {
   const CountStreamNotifier2Family._()
       : super(
           retry: null,
@@ -842,38 +742,6 @@ final class CountStreamNotifier2Family extends $Family {
 
   @override
   String toString() => r'myFamilyCountStreamNotifier2ProviderFamily';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          CountStreamNotifier2 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as CountStreamNotifier2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          Stream<int> Function(
-                  Ref ref, CountStreamNotifier2 notifier, int argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as CountStreamNotifier2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$CountStreamNotifier2 extends $StreamNotifier<int> {

--- a/packages/riverpod_generator/test/async_notifier_test.dart
+++ b/packages/riverpod_generator/test/async_notifier_test.dart
@@ -43,6 +43,9 @@ void main() {
   test('Supports overriding family notifiers', () {
     final container = ProviderContainer.test(
       overrides: [
+        genericClassProvider
+            .overrideWith(<T extends num>() => GenericClass<T>()),
+        familyClassProvider.overrideWith(() => FamilyClass('Hello foo')),
         familyClassProvider(42, third: .42)
             .overrideWith(() => FamilyClass('Hello world')),
       ],

--- a/packages/riverpod_generator/test/async_test.dart
+++ b/packages/riverpod_generator/test/async_test.dart
@@ -151,7 +151,7 @@ void main() {
             return result;
           },
         ),
-        familyClassProvider.overrideWith(FamilyClass.new),
+        familyClassProvider.overrideWith(() => FamilyClass(42)),
       ],
     );
 
@@ -165,7 +165,7 @@ void main() {
       container
           .read(familyClassProvider(42, second: '42', third: .42).notifier)
           .param,
-      (42, second: '42', third: 0.42, fourth: true, fifth: null),
+      42,
     );
   });
 

--- a/packages/riverpod_generator/test/integration/annotated.g.dart
+++ b/packages/riverpod_generator/test/integration/annotated.g.dart
@@ -69,7 +69,8 @@ final class FunctionalProvider extends $FunctionalProvider<String, String>
 
 String _$functionalHash() => r'ba8606cd0526e2dde0f775eb8f4c9d8b5b6fdf2c';
 
-final class FunctionalFamily extends $Family {
+final class FunctionalFamily extends $Family
+    with $FunctionalFamilyOverride<String, int> {
   const FunctionalFamily._()
       : super(
           retry: null,
@@ -86,22 +87,6 @@ final class FunctionalFamily extends $Family {
 
   @override
   String toString() => r'functionalProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FunctionalProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(ClassBased)
@@ -162,7 +147,8 @@ final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
 
 String _$classBasedHash() => r'92b444806ef8a304c6e0dc3d8e2383601e781183';
 
-final class ClassBasedFamily extends $Family {
+final class ClassBasedFamily extends $Family
+    with $ClassFamilyOverride<ClassBased, String, String, String, int> {
   const ClassBasedFamily._()
       : super(
           retry: null,
@@ -179,36 +165,6 @@ final class ClassBasedFamily extends $Family {
 
   @override
   String toString() => r'classBasedProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          ClassBased Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ClassBasedProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          String Function(Ref ref, ClassBased notifier, int argument) build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ClassBasedProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$ClassBased extends $Notifier<String> {
@@ -295,7 +251,8 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
 
 String _$familyHash() => r'14b97009aec20a0332208f8a60bc177b44c9d1d4';
 
-final class FamilyFamily extends $Family {
+final class FamilyFamily extends $Family
+    with $FunctionalFamilyOverride<String, int> {
   const FamilyFamily._()
       : super(
           retry: null,
@@ -312,22 +269,6 @@ final class FamilyFamily extends $Family {
 
   @override
   String toString() => r'familyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(notCopiedFunctional)
@@ -485,7 +426,8 @@ final class NotCopiedFamilyProvider extends $FunctionalProvider<String, String>
 
 String _$notCopiedFamilyHash() => r'ea652776532e2bf993a249b25b5254fc3dfff4b9';
 
-final class NotCopiedFamilyFamily extends $Family {
+final class NotCopiedFamilyFamily extends $Family
+    with $FunctionalFamilyOverride<String, int> {
   const NotCopiedFamilyFamily._()
       : super(
           retry: null,
@@ -502,22 +444,6 @@ final class NotCopiedFamilyFamily extends $Family {
 
   @override
   String toString() => r'notCopiedFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as NotCopiedFamilyProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_generator/test/integration/async.dart
+++ b/packages/riverpod_generator/test/integration/async.dart
@@ -16,6 +16,12 @@ class GenericClass<T extends num> extends _$GenericClass<T> {
 }
 
 @riverpod
+class GenericArg<T extends num> extends _$GenericArg<T> {
+  @override
+  Future<String> build(T arg) async => 'Hello $T $arg';
+}
+
+@riverpod
 FutureOr<String> public(Ref ref) {
   return 'Hello world';
 }

--- a/packages/riverpod_generator/test/integration/async.g.dart
+++ b/packages/riverpod_generator/test/integration/async.g.dart
@@ -206,6 +206,128 @@ abstract class _$GenericClass<T extends num> extends $AsyncNotifier<List<T>> {
   }
 }
 
+@ProviderFor(GenericArg)
+const genericArgProvider = GenericArgFamily._();
+
+final class GenericArgProvider<T extends num>
+    extends $AsyncNotifierProvider<GenericArg<T>, String> {
+  const GenericArgProvider._(
+      {required GenericArgFamily super.from, required T super.argument})
+      : super(
+          retry: null,
+          name: r'genericArgProvider',
+          isAutoDispose: true,
+          dependencies: null,
+          allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$genericArgHash();
+
+  @override
+  String toString() {
+    return r'genericArgProvider'
+        '<${T}>'
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  GenericArg<T> create() => GenericArg<T>();
+
+  @$internal
+  @override
+  $AsyncNotifierProviderElement<GenericArg<T>, String> $createElement(
+          $ProviderPointer pointer) =>
+      $AsyncNotifierProviderElement(pointer);
+
+  $R _captureGenerics<$R>($R Function<T extends num>() cb) {
+    return cb<T>();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is GenericArgProvider &&
+        other.runtimeType == runtimeType &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(runtimeType, argument);
+  }
+}
+
+String _$genericArgHash() => r'26ad32d0efc4b0ee9da2d1a34fd7b9e3473f8520';
+
+final class GenericArgFamily extends $Family {
+  const GenericArgFamily._()
+      : super(
+          retry: null,
+          name: r'genericArgProvider',
+          dependencies: null,
+          allTransitiveDependencies: null,
+          isAutoDispose: true,
+        );
+
+  GenericArgProvider<T> call<T extends num>(
+    T arg,
+  ) =>
+      GenericArgProvider<T>._(argument: arg, from: this);
+
+  @override
+  String toString() => r'genericArgProvider';
+
+  /// {@macro riverpod.override_with}
+  Override overrideWith(GenericArg<T> Function<T extends num>() create) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericArgProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericArgProvider<T>;
+              return provider.$view(create: create<T>).$createElement(pointer);
+            });
+          });
+
+  /// {@macro riverpod.override_with_build}
+  Override overrideWithBuild(
+          FutureOr<String> Function<T extends num>(
+                  Ref ref, GenericArg<T> notifier)
+              build) =>
+      $FamilyOverride(
+          from: this,
+          createElement: (pointer) {
+            final provider = pointer.origin as GenericArgProvider;
+            return provider._captureGenerics(<T extends num>() {
+              provider as GenericArgProvider<T>;
+              return provider
+                  .$view(runNotifierBuildOverride: build<T>)
+                  .$createElement(pointer);
+            });
+          });
+}
+
+abstract class _$GenericArg<T extends num> extends $AsyncNotifier<String> {
+  late final _$args = ref.$arg as T;
+  T get arg => _$args;
+
+  FutureOr<String> build(
+    T arg,
+  );
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(
+      _$args,
+    );
+    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<AsyncValue<String>>, AsyncValue<String>, Object?, Object?>;
+    element.handleValue(ref, created);
+  }
+}
+
 @ProviderFor(public)
 const publicProvider = PublicProvider._();
 
@@ -325,7 +447,8 @@ final class FamilyOrProvider
 
 String _$familyOrHash() => r'97cce80a626e228202fa30b87c07ae8319b48023';
 
-final class FamilyOrFamily extends $Family {
+final class FamilyOrFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<String>, int> {
   const FamilyOrFamily._()
       : super(
           retry: null,
@@ -342,22 +465,6 @@ final class FamilyOrFamily extends $Family {
 
   @override
   String toString() => r'familyOrProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FutureOr<String> Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyOrProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(family)
@@ -431,7 +538,17 @@ final class FamilyProvider
 
 String _$familyHash() => r'1da6c928ee85a03729a1c147f33e018521bb9c89';
 
-final class FamilyFamily extends $Family {
+final class FamilyFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+            FutureOr<String>,
+            (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            })> {
   const FamilyFamily._()
       : super(
           retry: null,
@@ -458,34 +575,6 @@ final class FamilyFamily extends $Family {
 
   @override
   String toString() => r'familyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FutureOr<String> Function(
-            Ref ref,
-            (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(PublicClass)
@@ -626,7 +715,10 @@ final class FamilyOrClassProvider
 
 String _$familyOrClassHash() => r'b4882d4e79a03c63005d35eb7a021c9c4373a8d9';
 
-final class FamilyOrClassFamily extends $Family {
+final class FamilyOrClassFamily extends $Family
+    with
+        $ClassFamilyOverride<FamilyOrClass, AsyncValue<String>, String,
+            FutureOr<String>, int> {
   const FamilyOrClassFamily._()
       : super(
           retry: null,
@@ -643,38 +735,6 @@ final class FamilyOrClassFamily extends $Family {
 
   @override
   String toString() => r'familyOrClassProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FamilyOrClass Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyOrClassProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          FutureOr<String> Function(
-                  Ref ref, FamilyOrClass notifier, int argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyOrClassProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$FamilyOrClass extends $AsyncNotifier<String> {
@@ -753,7 +813,20 @@ final class FamilyClassProvider
 
 String _$familyClassHash() => r'b7e3ca6091f12bbc99972e961acd885e05f42a15';
 
-final class FamilyClassFamily extends $Family {
+final class FamilyClassFamily extends $Family
+    with
+        $ClassFamilyOverride<
+            FamilyClass,
+            AsyncValue<String>,
+            String,
+            FutureOr<String>,
+            (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            })> {
   const FamilyClassFamily._()
       : super(
           retry: null,
@@ -780,64 +853,6 @@ final class FamilyClassFamily extends $Family {
 
   @override
   String toString() => r'familyClassProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FamilyClass Function(
-            (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyClassProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          FutureOr<String> Function(
-                  Ref ref,
-                  FamilyClass notifier,
-                  (
-                    int, {
-                    String? second,
-                    double third,
-                    bool fourth,
-                    List<String>? fifth,
-                  }) argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyClassProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$FamilyClass extends $AsyncNotifier<String> {
@@ -973,26 +988,16 @@ final class Regression3490Family extends $Family {
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-          Regression3490<Model, Sort, Cursor> Function<Model, Sort, Cursor>(
-            ({
-              String type,
-              Regression3490Cb<Model, Sort, Cursor> getData,
-              String? parentId,
-            }) args,
-          ) create) =>
+          Regression3490<Model, Sort, Cursor> Function<Model, Sort, Cursor>()
+              create) =>
       $FamilyOverride(
           from: this,
           createElement: (pointer) {
             final provider = pointer.origin as Regression3490Provider;
             return provider._captureGenerics(<Model, Sort, Cursor>() {
               provider as Regression3490Provider<Model, Sort, Cursor>;
-              final argument = provider.argument as ({
-                String type,
-                Regression3490Cb<Model, Sort, Cursor> getData,
-                String? parentId,
-              });
               return provider
-                  .$view(create: () => create(argument))
+                  .$view(create: create<Model, Sort, Cursor>)
                   .$createElement(pointer);
             });
           });
@@ -1000,13 +1005,7 @@ final class Regression3490Family extends $Family {
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
           void Function<Model, Sort, Cursor>(
-                  Ref ref,
-                  Regression3490<Model, Sort, Cursor> notifier,
-                  ({
-                    String type,
-                    Regression3490Cb<Model, Sort, Cursor> getData,
-                    String? parentId,
-                  }) argument)
+                  Ref ref, Regression3490<Model, Sort, Cursor> notifier)
               build) =>
       $FamilyOverride(
           from: this,
@@ -1014,15 +1013,8 @@ final class Regression3490Family extends $Family {
             final provider = pointer.origin as Regression3490Provider;
             return provider._captureGenerics(<Model, Sort, Cursor>() {
               provider as Regression3490Provider<Model, Sort, Cursor>;
-              final argument = provider.argument as ({
-                String type,
-                Regression3490Cb<Model, Sort, Cursor> getData,
-                String? parentId,
-              });
               return provider
-                  .$view(
-                      runNotifierBuildOverride: (ref, notifier) =>
-                          build<Model, Sort, Cursor>(ref, notifier, argument))
+                  .$view(runNotifierBuildOverride: build<Model, Sort, Cursor>)
                   .$createElement(pointer);
             });
           });

--- a/packages/riverpod_generator/test/integration/auto_dispose.g.dart
+++ b/packages/riverpod_generator/test/integration/auto_dispose.g.dart
@@ -186,7 +186,8 @@ final class KeepAliveFamilyProvider extends $FunctionalProvider<int, int>
 
 String _$keepAliveFamilyHash() => r'd1eb1243ea9463617b08a6e9cc5ae6b2df499ba2';
 
-final class KeepAliveFamilyFamily extends $Family {
+final class KeepAliveFamilyFamily extends $Family
+    with $FunctionalFamilyOverride<int, int> {
   const KeepAliveFamilyFamily._()
       : super(
           retry: null,
@@ -203,22 +204,6 @@ final class KeepAliveFamilyFamily extends $Family {
 
   @override
   String toString() => r'keepAliveFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as KeepAliveFamilyProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(notKeepAliveFamily)
@@ -283,7 +268,8 @@ final class NotKeepAliveFamilyProvider extends $FunctionalProvider<int, int>
 String _$notKeepAliveFamilyHash() =>
     r'a721713b026088b65be6c0f7f9beb1083a377a7c';
 
-final class NotKeepAliveFamilyFamily extends $Family {
+final class NotKeepAliveFamilyFamily extends $Family
+    with $FunctionalFamilyOverride<int, int> {
   const NotKeepAliveFamilyFamily._()
       : super(
           retry: null,
@@ -300,22 +286,6 @@ final class NotKeepAliveFamilyFamily extends $Family {
 
   @override
   String toString() => r'notKeepAliveFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as NotKeepAliveFamilyProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(defaultKeepAliveFamily)
@@ -381,7 +351,8 @@ final class DefaultKeepAliveFamilyProvider extends $FunctionalProvider<int, int>
 String _$defaultKeepAliveFamilyHash() =>
     r'e79f3d9ccd6713aade34c1701699c578f9236e9e';
 
-final class DefaultKeepAliveFamilyFamily extends $Family {
+final class DefaultKeepAliveFamilyFamily extends $Family
+    with $FunctionalFamilyOverride<int, int> {
   const DefaultKeepAliveFamilyFamily._()
       : super(
           retry: null,
@@ -398,22 +369,6 @@ final class DefaultKeepAliveFamilyFamily extends $Family {
 
   @override
   String toString() => r'defaultKeepAliveFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as DefaultKeepAliveFamilyProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_generator/test/integration/dependencies.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies.g.dart
@@ -106,7 +106,8 @@ final class FamilyProvider extends $FunctionalProvider<int, int>
 
 String _$familyHash() => r'940eb87eb11206499f73f05791a6266b38cda88a';
 
-final class FamilyFamily extends $Family {
+final class FamilyFamily extends $Family
+    with $FunctionalFamilyOverride<int, int> {
   const FamilyFamily._()
       : super(
           retry: null,
@@ -123,22 +124,6 @@ final class FamilyFamily extends $Family {
 
   @override
   String toString() => r'familyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(Dep2)
@@ -248,7 +233,8 @@ final class Family2Provider extends $NotifierProvider<Family2, int> {
 
 String _$family2Hash() => r'ce727b262aae067b0d4f703f03670abb70ad8977';
 
-final class Family2Family extends $Family {
+final class Family2Family extends $Family
+    with $ClassFamilyOverride<Family2, int, int, int, int> {
   const Family2Family._()
       : super(
           retry: null,
@@ -265,36 +251,6 @@ final class Family2Family extends $Family {
 
   @override
   String toString() => r'family2Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          Family2 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as Family2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(Ref ref, Family2 notifier, int argument) build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as Family2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$Family2 extends $Notifier<int> {
@@ -554,7 +510,8 @@ final class Provider4Provider extends $NotifierProvider<Provider4, int> {
 
 String _$provider4Hash() => r'1c955214d99695bb694c96374b277aac58e734df';
 
-final class Provider4Family extends $Family {
+final class Provider4Family extends $Family
+    with $ClassFamilyOverride<Provider4, int, int, int, int> {
   const Provider4Family._()
       : super(
           retry: null,
@@ -581,36 +538,6 @@ final class Provider4Family extends $Family {
 
   @override
   String toString() => r'provider4Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          Provider4 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as Provider4Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(Ref ref, Provider4 notifier, int argument) build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as Provider4Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$Provider4 extends $Notifier<int> {

--- a/packages/riverpod_generator/test/integration/dependencies2.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies2.g.dart
@@ -136,7 +136,8 @@ final class FamilyWithDependencies2Provider
 String _$familyWithDependencies2Hash() =>
     r'd064c06ca5a85a62cbe2b47943e98fc2e858fb03';
 
-final class FamilyWithDependencies2Family extends $Family {
+final class FamilyWithDependencies2Family extends $Family
+    with $FunctionalFamilyOverride<int, int?> {
   const FamilyWithDependencies2Family._()
       : super(
           retry: null,
@@ -163,22 +164,6 @@ final class FamilyWithDependencies2Family extends $Family {
 
   @override
   String toString() => r'familyWithDependencies2Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            int? args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyWithDependencies2Provider;
-            final argument = provider.argument as int?;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(NotifierWithDependencies)
@@ -321,7 +306,10 @@ final class NotifierFamilyWithDependenciesProvider
 String _$notifierFamilyWithDependenciesHash() =>
     r'b185ba93857cd028964c1412e748ee887dbd45c8';
 
-final class NotifierFamilyWithDependenciesFamily extends $Family {
+final class NotifierFamilyWithDependenciesFamily extends $Family
+    with
+        $ClassFamilyOverride<NotifierFamilyWithDependencies, int, int, int,
+            int?> {
   const NotifierFamilyWithDependenciesFamily._()
       : super(
           retry: null,
@@ -348,40 +336,6 @@ final class NotifierFamilyWithDependenciesFamily extends $Family {
 
   @override
   String toString() => r'notifierFamilyWithDependenciesProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          NotifierFamilyWithDependencies Function(
-            int? args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider =
-                pointer.origin as NotifierFamilyWithDependenciesProvider;
-            final argument = provider.argument as int?;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(Ref ref, NotifierFamilyWithDependencies notifier,
-                  int? argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider =
-                pointer.origin as NotifierFamilyWithDependenciesProvider;
-            final argument = provider.argument as int?;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$NotifierFamilyWithDependencies extends $Notifier<int> {

--- a/packages/riverpod_generator/test/integration/documented.g.dart
+++ b/packages/riverpod_generator/test/integration/documented.g.dart
@@ -178,7 +178,8 @@ String _$familyHash() => r'5164f4ea1f2d6c741e5c600c48a1b2ac2be7a1eb';
 
 /// Hello world
 // Foo
-final class FamilyFamily extends $Family {
+final class FamilyFamily extends $Family
+    with $FunctionalFamilyOverride<String, int> {
   const FamilyFamily._()
       : super(
           retry: null,
@@ -197,22 +198,6 @@ final class FamilyFamily extends $Family {
 
   @override
   String toString() => r'familyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 /// Hello world
@@ -279,7 +264,8 @@ String _$classFamilyBasedHash() => r'8d83e9a88356796298419574f360e8bf95aa0729';
 
 /// Hello world
 // Foo
-final class ClassFamilyBasedFamily extends $Family {
+final class ClassFamilyBasedFamily extends $Family
+    with $ClassFamilyOverride<ClassFamilyBased, String, String, String, int> {
   const ClassFamilyBasedFamily._()
       : super(
           retry: null,
@@ -298,37 +284,6 @@ final class ClassFamilyBasedFamily extends $Family {
 
   @override
   String toString() => r'classFamilyBasedProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          ClassFamilyBased Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ClassFamilyBasedProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          String Function(Ref ref, ClassFamilyBased notifier, int argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ClassFamilyBasedProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$ClassFamilyBased extends $Notifier<String> {

--- a/packages/riverpod_generator/test/integration/generated.g.dart
+++ b/packages/riverpod_generator/test/integration/generated.g.dart
@@ -107,7 +107,8 @@ final class GeneratedFamilyProvider extends $FunctionalProvider<_Test, _Test>
 
 String _$generatedFamilyHash() => r'8ac3b633763cb8dbad6e0686a732df3a081a0d64';
 
-final class GeneratedFamilyFamily extends $Family {
+final class GeneratedFamilyFamily extends $Family
+    with $FunctionalFamilyOverride<_Test, _Test> {
   const GeneratedFamilyFamily._()
       : super(
           retry: null,
@@ -124,22 +125,6 @@ final class GeneratedFamilyFamily extends $Family {
 
   @override
   String toString() => r'generatedFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          _Test Function(
-            Ref ref,
-            _Test args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as GeneratedFamilyProvider;
-            final argument = provider.argument as _Test;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(GeneratedClass)
@@ -253,7 +238,9 @@ final class GeneratedClassFamilyProvider
 String _$generatedClassFamilyHash() =>
     r'28d0a5a82af5b254f6ef07b492916e2feb7e6e63';
 
-final class GeneratedClassFamilyFamily extends $Family {
+final class GeneratedClassFamilyFamily extends $Family
+    with
+        $ClassFamilyOverride<GeneratedClassFamily, _Test, _Test, _Test, _Test> {
   const GeneratedClassFamilyFamily._()
       : super(
           retry: null,
@@ -270,37 +257,6 @@ final class GeneratedClassFamilyFamily extends $Family {
 
   @override
   String toString() => r'generatedClassFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          GeneratedClassFamily Function(
-            _Test args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as GeneratedClassFamilyProvider;
-            final argument = provider.argument as _Test;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          _Test Function(Ref ref, GeneratedClassFamily notifier, _Test argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as GeneratedClassFamilyProvider;
-            final argument = provider.argument as _Test;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$GeneratedClassFamily extends $Notifier<_Test> {
@@ -424,7 +380,8 @@ final class $DynamicFamilyProvider extends $FunctionalProvider<Object?, Object?>
 
 String _$$dynamicFamilyHash() => r'6897846251c8b4b5b2fa72d8d3e14ae3381c0c0f';
 
-final class $DynamicFamilyFamily extends $Family {
+final class $DynamicFamilyFamily extends $Family
+    with $FunctionalFamilyOverride<Object?, dynamic> {
   const $DynamicFamilyFamily._()
       : super(
           retry: null,
@@ -441,22 +398,6 @@ final class $DynamicFamilyFamily extends $Family {
 
   @override
   String toString() => r'$dynamicFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          Object? Function(
-            Ref ref,
-            dynamic args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as $DynamicFamilyProvider;
-            final argument = provider.argument as dynamic;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor($DynamicClass)
@@ -570,7 +511,10 @@ final class $DynamicClassFamilyProvider
 String _$$dynamicClassFamilyHash() =>
     r'bdda961386f3b647c071d79293a8da441580c470';
 
-final class $DynamicClassFamilyFamily extends $Family {
+final class $DynamicClassFamilyFamily extends $Family
+    with
+        $ClassFamilyOverride<$DynamicClassFamily, Object?, Object?, Object?,
+            dynamic> {
   const $DynamicClassFamilyFamily._()
       : super(
           retry: null,
@@ -587,38 +531,6 @@ final class $DynamicClassFamilyFamily extends $Family {
 
   @override
   String toString() => r'$dynamicClassFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          $DynamicClassFamily Function(
-            dynamic args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as $DynamicClassFamilyProvider;
-            final argument = provider.argument as dynamic;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          Object? Function(
-                  Ref ref, $DynamicClassFamily notifier, dynamic argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as $DynamicClassFamilyProvider;
-            final argument = provider.argument as dynamic;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$$DynamicClassFamily extends $Notifier<Object?> {
@@ -701,7 +613,8 @@ final class _DynamicProvider extends $FunctionalProvider<Object?, Object?>
 
 String _$dynamicHash() => r'e08bd08481e4ea0d3da2ab7c38f940c34e96ba7f';
 
-final class _DynamicFamily extends $Family {
+final class _DynamicFamily extends $Family
+    with $FunctionalFamilyOverride<Object?, dynamic> {
   const _DynamicFamily._()
       : super(
           retry: null,
@@ -718,22 +631,6 @@ final class _DynamicFamily extends $Family {
 
   @override
   String toString() => r'_dynamicProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          Object? Function(
-            Ref ref,
-            dynamic args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as _DynamicProvider;
-            final argument = provider.argument as dynamic;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(alias)
@@ -839,7 +736,8 @@ final class AliasFamilyProvider
 
 String _$aliasFamilyHash() => r'6afe0afc21cfd2f0f26862e9d8c1095eca5f6e42';
 
-final class AliasFamilyFamily extends $Family {
+final class AliasFamilyFamily extends $Family
+    with $FunctionalFamilyOverride<AsyncValue<int>, AsyncValue<int>> {
   const AliasFamilyFamily._()
       : super(
           retry: null,
@@ -856,22 +754,6 @@ final class AliasFamilyFamily extends $Family {
 
   @override
   String toString() => r'aliasFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          AsyncValue<int> Function(
-            Ref ref,
-            AsyncValue<int> args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as AliasFamilyProvider;
-            final argument = provider.argument as AsyncValue<int>;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(AliasClass)
@@ -984,7 +866,10 @@ final class AliasClassFamilyProvider
 
 String _$aliasClassFamilyHash() => r'd4374c0ffbbca9d65fb967255129b3ceddaa764e';
 
-final class AliasClassFamilyFamily extends $Family {
+final class AliasClassFamilyFamily extends $Family
+    with
+        $ClassFamilyOverride<AliasClassFamily, AsyncValue<int>, AsyncValue<int>,
+            AsyncValue<int>, AsyncValue<int>> {
   const AliasClassFamilyFamily._()
       : super(
           retry: null,
@@ -1001,38 +886,6 @@ final class AliasClassFamilyFamily extends $Family {
 
   @override
   String toString() => r'aliasClassFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          AliasClassFamily Function(
-            AsyncValue<int> args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as AliasClassFamilyProvider;
-            final argument = provider.argument as AsyncValue<int>;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          AsyncValue<int> Function(
-                  Ref ref, AliasClassFamily notifier, AsyncValue<int> argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as AliasClassFamilyProvider;
-            final argument = provider.argument as AsyncValue<int>;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$AliasClassFamily extends $Notifier<AsyncValue<int>> {

--- a/packages/riverpod_generator/test/integration/hash/retry.g.dart
+++ b/packages/riverpod_generator/test/integration/hash/retry.g.dart
@@ -105,7 +105,8 @@ final class BProvider extends $FunctionalProvider<String, String>
 
 String _$bHash() => r'95798a157250c86a901bca5701b487f508f8a5a4';
 
-final class BFamily extends $Family {
+final class BFamily extends $Family
+    with $FunctionalFamilyOverride<String, int> {
   const BFamily._()
       : super(
           retry: myRetry2,
@@ -122,22 +123,6 @@ final class BFamily extends $Family {
 
   @override
   String toString() => r'bProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as BProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_generator/test/integration/mutation.g.dart
+++ b/packages/riverpod_generator/test/integration/mutation.g.dart
@@ -708,7 +708,8 @@ final class SimpleFamilyProvider extends $NotifierProvider<SimpleFamily, int> {
 
 String _$simpleFamilyHash() => r'5a1afef2fb83836b8cbdc48fda6975a9149d9f2d';
 
-final class SimpleFamilyFamily extends $Family {
+final class SimpleFamilyFamily extends $Family
+    with $ClassFamilyOverride<SimpleFamily, int, int, int, String> {
   const SimpleFamilyFamily._()
       : super(
           retry: null,
@@ -725,37 +726,6 @@ final class SimpleFamilyFamily extends $Family {
 
   @override
   String toString() => r'simpleFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          SimpleFamily Function(
-            String args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as SimpleFamilyProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(Ref ref, SimpleFamily notifier, String argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as SimpleFamilyProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$SimpleFamily extends $Notifier<int> {
@@ -1139,7 +1109,10 @@ final class SimpleAsync2Provider
 
 String _$simpleAsync2Hash() => r'b2268a85a058e6f40c5bbfce8c20c9d285270967';
 
-final class SimpleAsync2Family extends $Family {
+final class SimpleAsync2Family extends $Family
+    with
+        $ClassFamilyOverride<SimpleAsync2, AsyncValue<int>, int, Stream<int>,
+            String> {
   const SimpleAsync2Family._()
       : super(
           retry: null,
@@ -1156,37 +1129,6 @@ final class SimpleAsync2Family extends $Family {
 
   @override
   String toString() => r'simpleAsync2Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          SimpleAsync2 Function(
-            String args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as SimpleAsync2Provider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          Stream<int> Function(Ref ref, SimpleAsync2 notifier, String argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as SimpleAsync2Provider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$SimpleAsync2 extends $StreamNotifier<int> {

--- a/packages/riverpod_generator/test/integration/offline.g.dart
+++ b/packages/riverpod_generator/test/integration/offline.g.dart
@@ -137,7 +137,10 @@ final class JsonProvider
 
 String _$jsonHash() => r'fb36d984214529f587e141faf4aae78f2a39474c';
 
-final class JsonFamily extends $Family {
+final class JsonFamily extends $Family
+    with
+        $ClassFamilyOverride<Json, AsyncValue<Map<String, List<int>>>,
+            Map<String, List<int>>, FutureOr<Map<String, List<int>>>, String> {
   const JsonFamily._()
       : super(
           retry: null,
@@ -154,38 +157,6 @@ final class JsonFamily extends $Family {
 
   @override
   String toString() => r'jsonProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          Json Function(
-            String args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as JsonProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          FutureOr<Map<String, List<int>>> Function(
-                  Ref ref, Json notifier, String argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as JsonProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$JsonBase extends $AsyncNotifier<Map<String, List<int>>> {

--- a/packages/riverpod_generator/test/integration/scopes.g.dart
+++ b/packages/riverpod_generator/test/integration/scopes.g.dart
@@ -115,7 +115,8 @@ final class ScopedClassFamilyProvider
 
 String _$scopedClassFamilyHash() => r'04aeb0bbfdc363e2c8714c7a5967368a7f990d58';
 
-final class ScopedClassFamilyFamily extends $Family {
+final class ScopedClassFamilyFamily extends $Family
+    with $ClassFamilyOverride<ScopedClassFamily, int, int, int, int> {
   const ScopedClassFamilyFamily._()
       : super(
           retry: null,
@@ -132,37 +133,6 @@ final class ScopedClassFamilyFamily extends $Family {
 
   @override
   String toString() => r'scopedClassFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          ScopedClassFamily Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ScopedClassFamilyProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(Ref ref, ScopedClassFamily notifier, int argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ScopedClassFamilyProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$ScopedClassFamily extends $Notifier<int> {

--- a/packages/riverpod_generator/test/integration/stream.g.dart
+++ b/packages/riverpod_generator/test/integration/stream.g.dart
@@ -343,7 +343,17 @@ final class FamilyProvider
 
 String _$familyHash() => r'ba1df8eab0af0f3f71ae29d23ccb7a491d8e2825';
 
-final class FamilyFamily extends $Family {
+final class FamilyFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+            Stream<String>,
+            (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            })> {
   const FamilyFamily._()
       : super(
           retry: null,
@@ -370,34 +380,6 @@ final class FamilyFamily extends $Family {
 
   @override
   String toString() => r'familyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          Stream<String> Function(
-            Ref ref,
-            (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(PublicClass)
@@ -546,7 +528,20 @@ final class FamilyClassProvider
 
 String _$familyClassHash() => r'6ec16ca23da8df4c010ecb5eed72e3e655504460';
 
-final class FamilyClassFamily extends $Family {
+final class FamilyClassFamily extends $Family
+    with
+        $ClassFamilyOverride<
+            FamilyClass,
+            AsyncValue<String>,
+            String,
+            Stream<String>,
+            (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            })> {
   const FamilyClassFamily._()
       : super(
           retry: null,
@@ -573,64 +568,6 @@ final class FamilyClassFamily extends $Family {
 
   @override
   String toString() => r'familyClassProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FamilyClass Function(
-            (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyClassProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          Stream<String> Function(
-                  Ref ref,
-                  FamilyClass notifier,
-                  (
-                    int, {
-                    String? second,
-                    double third,
-                    bool fourth,
-                    List<String>? fifth,
-                  }) argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyClassProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$FamilyClass extends $StreamNotifier<String> {

--- a/packages/riverpod_generator/test/integration/sync.g.dart
+++ b/packages/riverpod_generator/test/integration/sync.g.dart
@@ -599,7 +599,8 @@ final class RawFamilyFutureProvider
 
 String _$rawFamilyFutureHash() => r'0ac70d7a2133691f1a9a38cedaeeb6b3bc667ade';
 
-final class RawFamilyFutureFamily extends $Family {
+final class RawFamilyFutureFamily extends $Family
+    with $FunctionalFamilyOverride<Raw<Future<String>>, int> {
   const RawFamilyFutureFamily._()
       : super(
           retry: null,
@@ -616,22 +617,6 @@ final class RawFamilyFutureFamily extends $Family {
 
   @override
   String toString() => r'rawFamilyFutureProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          Raw<Future<String>> Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as RawFamilyFutureProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(rawFamilyStream)
@@ -696,7 +681,8 @@ final class RawFamilyStreamProvider
 
 String _$rawFamilyStreamHash() => r'6eacfa3a3576d884099c08c298751a3d395271be';
 
-final class RawFamilyStreamFamily extends $Family {
+final class RawFamilyStreamFamily extends $Family
+    with $FunctionalFamilyOverride<Raw<Stream<String>>, int> {
   const RawFamilyStreamFamily._()
       : super(
           retry: null,
@@ -713,22 +699,6 @@ final class RawFamilyStreamFamily extends $Family {
 
   @override
   String toString() => r'rawFamilyStreamProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          Raw<Stream<String>> Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as RawFamilyStreamProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(RawFamilyFutureClass)
@@ -789,7 +759,10 @@ final class RawFamilyFutureClassProvider
 String _$rawFamilyFutureClassHash() =>
     r'd7cacb0f2c51697d107de6daa68b242c04085dca';
 
-final class RawFamilyFutureClassFamily extends $Family {
+final class RawFamilyFutureClassFamily extends $Family
+    with
+        $ClassFamilyOverride<RawFamilyFutureClass, Raw<Future<String>>,
+            Raw<Future<String>>, Raw<Future<String>>, int> {
   const RawFamilyFutureClassFamily._()
       : super(
           retry: null,
@@ -806,38 +779,6 @@ final class RawFamilyFutureClassFamily extends $Family {
 
   @override
   String toString() => r'rawFamilyFutureClassProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          RawFamilyFutureClass Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as RawFamilyFutureClassProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          Raw<Future<String>> Function(
-                  Ref ref, RawFamilyFutureClass notifier, int argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as RawFamilyFutureClassProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$RawFamilyFutureClass extends $Notifier<Raw<Future<String>>> {
@@ -921,7 +862,10 @@ final class RawFamilyStreamClassProvider
 String _$rawFamilyStreamClassHash() =>
     r'321796a0befc43fb83f7ccfdcb6b011fc8c7c599';
 
-final class RawFamilyStreamClassFamily extends $Family {
+final class RawFamilyStreamClassFamily extends $Family
+    with
+        $ClassFamilyOverride<RawFamilyStreamClass, Raw<Stream<String>>,
+            Raw<Stream<String>>, Raw<Stream<String>>, int> {
   const RawFamilyStreamClassFamily._()
       : super(
           retry: null,
@@ -938,38 +882,6 @@ final class RawFamilyStreamClassFamily extends $Family {
 
   @override
   String toString() => r'rawFamilyStreamClassProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          RawFamilyStreamClass Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as RawFamilyStreamClassProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          Raw<Stream<String>> Function(
-                  Ref ref, RawFamilyStreamClass notifier, int argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as RawFamilyStreamClassProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$RawFamilyStreamClass extends $Notifier<Raw<Stream<String>>> {
@@ -1160,7 +1072,17 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
 String _$familyHash() => r'f58149448f80f10ec054f2f8a6f37bae61e38f49';
 
 /// This is some documentation
-final class FamilyFamily extends $Family {
+final class FamilyFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+            String,
+            (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            })> {
   const FamilyFamily._()
       : super(
           retry: null,
@@ -1188,34 +1110,6 @@ final class FamilyFamily extends $Family {
 
   @override
   String toString() => r'familyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(_private)
@@ -1433,7 +1327,20 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
 String _$familyClassHash() => r'f49696c6caf3cd8e3661369c43c4d61c4024fe93';
 
 /// This is some documentation
-final class FamilyClassFamily extends $Family {
+final class FamilyClassFamily extends $Family
+    with
+        $ClassFamilyOverride<
+            FamilyClass,
+            String,
+            String,
+            String,
+            (
+              int, {
+              String? second,
+              double third,
+              bool fourth,
+              List<String>? fifth,
+            })> {
   const FamilyClassFamily._()
       : super(
           retry: null,
@@ -1461,64 +1368,6 @@ final class FamilyClassFamily extends $Family {
 
   @override
   String toString() => r'familyClassProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FamilyClass Function(
-            (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyClassProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          String Function(
-                  Ref ref,
-                  FamilyClass notifier,
-                  (
-                    int, {
-                    String? second,
-                    double third,
-                    bool fourth,
-                    List<String>? fifth,
-                  }) argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyClassProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool fourth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$FamilyClass extends $Notifier<String> {
@@ -2006,13 +1855,7 @@ final class Supports$InClassFamilyNameFamily extends $Family {
 
   /// {@macro riverpod.override_with}
   Override overrideWith(
-          Supports$InClassFamilyName<And$InT> Function<And$InT>(
-            (
-              And$InT, {
-              And$InT named$arg,
-              String defaultArg,
-            }) args,
-          ) create) =>
+          Supports$InClassFamilyName<And$InT> Function<And$InT>() create) =>
       $FamilyOverride(
           from: this,
           createElement: (pointer) {
@@ -2020,13 +1863,8 @@ final class Supports$InClassFamilyNameFamily extends $Family {
                 pointer.origin as Supports$InClassFamilyNameProvider;
             return provider._captureGenerics(<And$InT>() {
               provider as Supports$InClassFamilyNameProvider<And$InT>;
-              final argument = provider.argument as (
-                And$InT, {
-                And$InT named$arg,
-                String defaultArg,
-              });
               return provider
-                  .$view(create: () => create(argument))
+                  .$view(create: create<And$InT>)
                   .$createElement(pointer);
             });
           });
@@ -2034,13 +1872,7 @@ final class Supports$InClassFamilyNameFamily extends $Family {
   /// {@macro riverpod.override_with_build}
   Override overrideWithBuild(
           String Function<And$InT>(
-                  Ref ref,
-                  Supports$InClassFamilyName<And$InT> notifier,
-                  (
-                    And$InT, {
-                    And$InT named$arg,
-                    String defaultArg,
-                  }) argument)
+                  Ref ref, Supports$InClassFamilyName<And$InT> notifier)
               build) =>
       $FamilyOverride(
           from: this,
@@ -2049,15 +1881,8 @@ final class Supports$InClassFamilyNameFamily extends $Family {
                 pointer.origin as Supports$InClassFamilyNameProvider;
             return provider._captureGenerics(<And$InT>() {
               provider as Supports$InClassFamilyNameProvider<And$InT>;
-              final argument = provider.argument as (
-                And$InT, {
-                And$InT named$arg,
-                String defaultArg,
-              });
               return provider
-                  .$view(
-                      runNotifierBuildOverride: (ref, notifier) =>
-                          build<And$InT>(ref, notifier, argument))
+                  .$view(runNotifierBuildOverride: build<And$InT>)
                   .$createElement(pointer);
             });
           });
@@ -2194,7 +2019,8 @@ final class UnnecessaryCastProvider extends $FunctionalProvider<String, String>
 
 String _$unnecessaryCastHash() => r'c64330124f4b03a3e6757e787f62966a32bf83ad';
 
-final class UnnecessaryCastFamily extends $Family {
+final class UnnecessaryCastFamily extends $Family
+    with $FunctionalFamilyOverride<String, Object?> {
   const UnnecessaryCastFamily._()
       : super(
           retry: null,
@@ -2211,22 +2037,6 @@ final class UnnecessaryCastFamily extends $Family {
 
   @override
   String toString() => r'unnecessaryCastProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            Object? args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as UnnecessaryCastProvider;
-            final argument = provider.argument;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(UnnecessaryCastClass)
@@ -2287,7 +2097,10 @@ final class UnnecessaryCastClassProvider
 String _$unnecessaryCastClassHash() =>
     r'8cbf80b29c4edf7f5401e4447feca553e921e734';
 
-final class UnnecessaryCastClassFamily extends $Family {
+final class UnnecessaryCastClassFamily extends $Family
+    with
+        $ClassFamilyOverride<UnnecessaryCastClass, String, String, String,
+            Object?> {
   const UnnecessaryCastClassFamily._()
       : super(
           retry: null,
@@ -2304,38 +2117,6 @@ final class UnnecessaryCastClassFamily extends $Family {
 
   @override
   String toString() => r'unnecessaryCastClassProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          UnnecessaryCastClass Function(
-            Object? args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as UnnecessaryCastClassProvider;
-            final argument = provider.argument;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          String Function(
-                  Ref ref, UnnecessaryCastClass notifier, Object? argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as UnnecessaryCastClassProvider;
-            final argument = provider.argument;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$UnnecessaryCastClass extends $Notifier<String> {

--- a/packages/riverpod_generator/test/stream_test.dart
+++ b/packages/riverpod_generator/test/stream_test.dart
@@ -143,7 +143,7 @@ void main() {
             );
           },
         ),
-        familyClassProvider.overrideWith(FamilyClass.new),
+        familyClassProvider.overrideWith(() => FamilyClass(42)),
       ],
     );
 
@@ -165,7 +165,7 @@ void main() {
       container
           .read(familyClassProvider(42, second: '42', third: .42).notifier)
           .param,
-      (42, second: '42', third: 0.42, fourth: true, fifth: null),
+      42,
     );
   });
 

--- a/packages/riverpod_generator/test/sync_test.dart
+++ b/packages/riverpod_generator/test/sync_test.dart
@@ -321,7 +321,7 @@ void main() {
               'test (first: ${args.$1}, second: ${args.second}, third: ${args.third}, fourth: ${args.fourth}, fifth: ${args.fifth})',
         ),
         familyProvider(21, third: .21).overrideWithValue('Override'),
-        familyClassProvider.overrideWith(FamilyClass.new),
+        familyClassProvider.overrideWith(() => FamilyClass(42)),
       ],
     );
     final container2 = ProviderContainer.test(
@@ -347,7 +347,7 @@ void main() {
       container
           .read(familyClassProvider(42, second: '42', third: .42).notifier)
           .param,
-      (42, second: '42', third: 0.42, fourth: true, fifth: null),
+      42,
     );
 
     expect(container2.read(publicClassProvider), 'Hello world');

--- a/packages/riverpod_generator/test/sync_test.dart
+++ b/packages/riverpod_generator/test/sync_test.dart
@@ -327,8 +327,8 @@ void main() {
     final container2 = ProviderContainer.test(
       overrides: [
         publicClassProvider.overrideWithBuild((ref, notifier) => 'Hello world'),
-        familyClassProvider.overrideWithBuild((ref, notifier, args) {
-          return 'FamilyClass$args';
+        familyClassProvider.overrideWithBuild((ref, notifier) {
+          return 'FamilyClass';
         }),
         familyClassProvider(21, third: .21).overrideWithBuild((ref, notifier) {
           return 'Override';
@@ -353,7 +353,7 @@ void main() {
     expect(container2.read(publicClassProvider), 'Hello world');
     expect(
       container2.read(familyClassProvider(42, third: .42)),
-      'FamilyClass(42, fifth: null, fourth: true, second: null, third: 0.42)',
+      'FamilyClass',
     );
     expect(
       container2.read(familyClassProvider(21, third: .21)),

--- a/packages/riverpod_graph/test/integration/generated/golden/lib/sync.g.dart
+++ b/packages/riverpod_graph/test/integration/generated/golden/lib/sync.g.dart
@@ -174,7 +174,17 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
 String _$familyHash() => r'062561e0cad8585939dc9adc23de6452be2c9788';
 
 /// A generated family provider.
-final class FamilyFamily extends $Family {
+final class FamilyFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+            String,
+            (
+              int, {
+              String? second,
+              double third,
+              bool forth,
+              List<String>? fifth,
+            })> {
   const FamilyFamily._()
       : super(
           retry: null,
@@ -202,34 +212,6 @@ final class FamilyFamily extends $Family {
 
   @override
   String toString() => r'familyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            (
-              int, {
-              String? second,
-              double third,
-              bool forth,
-              List<String>? fifth,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool forth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(_private)
@@ -447,7 +429,20 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
 String _$familyClassHash() => r'721bdd2f1ca0d7cee1a0ae476d7bfe93f9ce6875';
 
 /// A generated family provider from a class.
-final class FamilyClassFamily extends $Family {
+final class FamilyClassFamily extends $Family
+    with
+        $ClassFamilyOverride<
+            FamilyClass,
+            String,
+            String,
+            String,
+            (
+              int, {
+              String? second,
+              double third,
+              bool forth,
+              List<String>? fifth,
+            })> {
   const FamilyClassFamily._()
       : super(
           retry: null,
@@ -475,64 +470,6 @@ final class FamilyClassFamily extends $Family {
 
   @override
   String toString() => r'familyClassProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FamilyClass Function(
-            (
-              int, {
-              String? second,
-              double third,
-              bool forth,
-              List<String>? fifth,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyClassProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool forth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          String Function(
-                  Ref ref,
-                  FamilyClass notifier,
-                  (
-                    int, {
-                    String? second,
-                    double third,
-                    bool forth,
-                    List<String>? fifth,
-                  }) argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyClassProvider;
-            final argument = provider.argument as (
-              int, {
-              String? second,
-              double third,
-              bool forth,
-              List<String>? fifth,
-            });
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$FamilyClass extends $Notifier<String> {

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional/convert_class_based_provider_to_functional.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional/convert_class_based_provider_to_functional.g.dart
@@ -126,7 +126,17 @@ final class ExampleFamilyProvider
 String _$exampleFamilyHash() => r'37d4a4fd66999562cd92051f91266270d5a1e5ea';
 
 /// Some comment
-final class ExampleFamilyFamily extends $Family {
+final class ExampleFamilyFamily extends $Family
+    with
+        $ClassFamilyOverride<
+            ExampleFamily,
+            int,
+            int,
+            int,
+            ({
+              int a,
+              String b,
+            })> {
   const ExampleFamilyFamily._()
       : super(
           retry: null,
@@ -148,52 +158,6 @@ final class ExampleFamilyFamily extends $Family {
 
   @override
   String toString() => r'exampleFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          ExampleFamily Function(
-            ({
-              int a,
-              String b,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ExampleFamilyProvider;
-            final argument = provider.argument as ({
-              int a,
-              String b,
-            });
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(
-                  Ref ref,
-                  ExampleFamily notifier,
-                  ({
-                    int a,
-                    String b,
-                  }) argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ExampleFamilyProvider;
-            final argument = provider.argument as ({
-              int a,
-              String b,
-            });
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$ExampleFamily extends $Notifier<int> {

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based/convert_functional_provider_to_class_based.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based/convert_functional_provider_to_class_based.g.dart
@@ -122,7 +122,14 @@ final class ExampleFamilyProvider extends $FunctionalProvider<int, int>
 String _$exampleFamilyHash() => r'70dfc6f4b2d7d251edbc3a66c3ac0f2c56aebf8b';
 
 /// Some comment
-final class ExampleFamilyFamily extends $Family {
+final class ExampleFamilyFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+            int,
+            ({
+              int a,
+              String b,
+            })> {
   const ExampleFamilyFamily._()
       : super(
           retry: null,
@@ -144,28 +151,6 @@ final class ExampleFamilyFamily extends $Family {
 
   @override
   String toString() => r'exampleFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            ({
-              int a,
-              String b,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ExampleFamilyProvider;
-            final argument = provider.argument as ({
-              int a,
-              String b,
-            });
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_lint_flutter_test/test/lints/avoid_build_context_in_providers.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/avoid_build_context_in_providers.g.dart
@@ -75,7 +75,14 @@ final class FnProvider extends $FunctionalProvider<int, int>
 
 String _$fnHash() => r'8a726da6104b38a55782e44062757e6771b19de3';
 
-final class FnFamily extends $Family {
+final class FnFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+            int,
+            (
+              BuildContext, {
+              BuildContext context2,
+            })> {
   const FnFamily._()
       : super(
           retry: null,
@@ -96,28 +103,6 @@ final class FnFamily extends $Family {
 
   @override
   String toString() => r'fnProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            (
-              BuildContext, {
-              BuildContext context2,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FnProvider;
-            final argument = provider.argument as (
-              BuildContext, {
-              BuildContext context2,
-            });
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(MyNotifier)
@@ -180,7 +165,17 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
 
 String _$myNotifierHash() => r'04a0cf33dbda80e3fa80748fe46546b1c968da22';
 
-final class MyNotifierFamily extends $Family {
+final class MyNotifierFamily extends $Family
+    with
+        $ClassFamilyOverride<
+            MyNotifier,
+            int,
+            int,
+            int,
+            (
+              BuildContext, {
+              BuildContext context2,
+            })> {
   const MyNotifierFamily._()
       : super(
           retry: null,
@@ -201,52 +196,6 @@ final class MyNotifierFamily extends $Family {
 
   @override
   String toString() => r'myNotifierProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          MyNotifier Function(
-            (
-              BuildContext, {
-              BuildContext context2,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as MyNotifierProvider;
-            final argument = provider.argument as (
-              BuildContext, {
-              BuildContext context2,
-            });
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(
-                  Ref ref,
-                  MyNotifier notifier,
-                  (
-                    BuildContext, {
-                    BuildContext context2,
-                  }) argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as MyNotifierProvider;
-            final argument = provider.argument as (
-              BuildContext, {
-              BuildContext context2,
-            });
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$MyNotifier extends $Notifier<int> {

--- a/packages/riverpod_lint_flutter_test/test/lints/avoid_public_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/avoid_public_notifier_properties.g.dart
@@ -63,7 +63,8 @@ final class GeneratedNotifierProvider
 
 String _$generatedNotifierHash() => r'2b7f4fba816b6e8ccd0e8b7d11fcd207bbb79828';
 
-final class GeneratedNotifierFamily extends $Family {
+final class GeneratedNotifierFamily extends $Family
+    with $ClassFamilyOverride<GeneratedNotifier, int, int, int, int> {
   const GeneratedNotifierFamily._()
       : super(
           retry: null,
@@ -80,37 +81,6 @@ final class GeneratedNotifierFamily extends $Family {
 
   @override
   String toString() => r'generatedNotifierProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          GeneratedNotifier Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as GeneratedNotifierProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(Ref ref, GeneratedNotifier notifier, int argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as GeneratedNotifierProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$GeneratedNotifier extends $Notifier<int> {

--- a/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
@@ -162,7 +162,8 @@ final class A3Provider extends $NotifierProvider<A3, int> {
 
 String _$a3Hash() => r'2e21e9af8b67b5412611e0d23b862ead56deb8e1';
 
-final class A3Family extends $Family {
+final class A3Family extends $Family
+    with $ClassFamilyOverride<A3, int, int, int, int> {
   const A3Family._()
       : super(
           retry: null,
@@ -179,36 +180,6 @@ final class A3Family extends $Family {
 
   @override
   String toString() => r'a3Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          A3 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A3Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(Ref ref, A3 notifier, int argument) build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A3Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$A3 extends $Notifier<int> {
@@ -285,7 +256,8 @@ final class A4Provider extends $NotifierProvider<A4, int> {
 
 String _$a4Hash() => r'cdd9ad09099881cafe06d7b3095a8b06dbe7d876';
 
-final class A4Family extends $Family {
+final class A4Family extends $Family
+    with $ClassFamilyOverride<A4, int, int, int, int> {
   const A4Family._()
       : super(
           retry: null,
@@ -302,36 +274,6 @@ final class A4Family extends $Family {
 
   @override
   String toString() => r'a4Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          A4 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A4Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          int Function(Ref ref, A4 notifier, int argument) build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A4Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$A4 extends $Notifier<int> {
@@ -401,7 +343,8 @@ final class A5Provider extends $AsyncNotifierProvider<A5, int> {
 
 String _$a5Hash() => r'c83634c22b6a9149aa8787e45c3b7cd6c88b5958';
 
-final class A5Family extends $Family {
+final class A5Family extends $Family
+    with $ClassFamilyOverride<A5, AsyncValue<int>, int, FutureOr<int>, int> {
   const A5Family._()
       : super(
           retry: null,
@@ -418,36 +361,6 @@ final class A5Family extends $Family {
 
   @override
   String toString() => r'a5Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          A5 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A5Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          FutureOr<int> Function(Ref ref, A5 notifier, int argument) build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A5Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$A5 extends $AsyncNotifier<int> {
@@ -517,7 +430,8 @@ final class A6Provider extends $AsyncNotifierProvider<A6, int> {
 
 String _$a6Hash() => r'fe641c72cacf3dd119eb77a34fe8fc71c5c30139';
 
-final class A6Family extends $Family {
+final class A6Family extends $Family
+    with $ClassFamilyOverride<A6, AsyncValue<int>, int, FutureOr<int>, int> {
   const A6Family._()
       : super(
           retry: null,
@@ -534,36 +448,6 @@ final class A6Family extends $Family {
 
   @override
   String toString() => r'a6Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          A6 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A6Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          FutureOr<int> Function(Ref ref, A6 notifier, int argument) build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A6Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$A6 extends $AsyncNotifier<int> {
@@ -633,7 +517,8 @@ final class A7Provider extends $StreamNotifierProvider<A7, int> {
 
 String _$a7Hash() => r'd3d9ab5090e21987d65522f14ebb70d0058fc56a';
 
-final class A7Family extends $Family {
+final class A7Family extends $Family
+    with $ClassFamilyOverride<A7, AsyncValue<int>, int, Stream<int>, int> {
   const A7Family._()
       : super(
           retry: null,
@@ -650,36 +535,6 @@ final class A7Family extends $Family {
 
   @override
   String toString() => r'a7Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          A7 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A7Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          Stream<int> Function(Ref ref, A7 notifier, int argument) build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A7Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$A7 extends $StreamNotifier<int> {
@@ -749,7 +604,8 @@ final class A8Provider extends $StreamNotifierProvider<A8, int> {
 
 String _$a8Hash() => r'54f4a841a283161bed3d444dcee53bf367958678';
 
-final class A8Family extends $Family {
+final class A8Family extends $Family
+    with $ClassFamilyOverride<A8, AsyncValue<int>, int, Stream<int>, int> {
   const A8Family._()
       : super(
           retry: null,
@@ -766,36 +622,6 @@ final class A8Family extends $Family {
 
   @override
   String toString() => r'a8Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          A8 Function(
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A8Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          Stream<int> Function(Ref ref, A8 notifier, int argument) build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as A8Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$A8 extends $StreamNotifier<int> {

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies.g.dart
@@ -190,7 +190,8 @@ final class DepFamilyProvider extends $FunctionalProvider<int, int>
 
 String _$depFamilyHash() => r'6cca68b98693e352e9b801b1fc441d438fc72525';
 
-final class DepFamilyFamily extends $Family {
+final class DepFamilyFamily extends $Family
+    with $FunctionalFamilyOverride<int, int> {
   const DepFamilyFamily._()
       : super(
           retry: null,
@@ -207,22 +208,6 @@ final class DepFamilyFamily extends $Family {
 
   @override
   String toString() => r'depFamilyProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as DepFamilyProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 ////////////

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.g.dart
@@ -1025,7 +1025,8 @@ final class FamilyDepProvider extends $FunctionalProvider<int, int>
 
 String _$familyDepHash() => r'ed674a44492b3871b72b4fbc68180ea0839723e5';
 
-final class FamilyDepFamily extends $Family {
+final class FamilyDepFamily extends $Family
+    with $FunctionalFamilyOverride<int, int> {
   const FamilyDepFamily._()
       : super(
           retry: null,
@@ -1044,22 +1045,6 @@ final class FamilyDepFamily extends $Family {
 
   @override
   String toString() => r'familyDepProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyDepProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(familyDep2)
@@ -1126,7 +1111,8 @@ final class FamilyDep2Provider extends $FunctionalProvider<int, int>
 
 String _$familyDep2Hash() => r'ee9c96f7a1d65e1b66c29aa8d8c030146995504c';
 
-final class FamilyDep2Family extends $Family {
+final class FamilyDep2Family extends $Family
+    with $FunctionalFamilyOverride<int, int> {
   const FamilyDep2Family._()
       : super(
           retry: null,
@@ -1146,22 +1132,6 @@ final class FamilyDep2Family extends $Family {
 
   @override
   String toString() => r'familyDep2Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FamilyDep2Provider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(alias)

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.g.dart
@@ -66,7 +66,8 @@ final class GeneratorProvider extends $FunctionalProvider<int, int>
 
 String _$generatorHash() => r'd7d1733f8884b6702f363ddb178ae57797d0034f';
 
-final class GeneratorFamily extends $Family {
+final class GeneratorFamily extends $Family
+    with $FunctionalFamilyOverride<int, Object?> {
   const GeneratorFamily._()
       : super(
           retry: null,
@@ -83,22 +84,6 @@ final class GeneratorFamily extends $Family {
 
   @override
   String toString() => r'generatorProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            Object? args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as GeneratorProvider;
-            final argument = provider.argument;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/concepts/about_codegen/main.g.dart
+++ b/website/docs/concepts/about_codegen/main.g.dart
@@ -61,7 +61,8 @@ final class FetchUserProvider
 
 String _$fetchUserHash() => r'0ea61464a124f8af2cf15b830a1a012d4272eb47';
 
-final class FetchUserFamily extends $Family {
+final class FetchUserFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<User>, int> {
   const FetchUserFamily._()
       : super(
           retry: null,
@@ -78,22 +79,6 @@ final class FetchUserFamily extends $Family {
 
   @override
   String toString() => r'fetchUserProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FutureOr<User> Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FetchUserProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/concepts/about_codegen/provider_type/family.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family.g.dart
@@ -68,7 +68,8 @@ final class ExampleProvider extends $FunctionalProvider<String, String>
 
 String _$exampleHash() => r'7cd87bca029ed938b0e314a14fdfaa2875bd3079';
 
-final class ExampleFamily extends $Family {
+final class ExampleFamily extends $Family
+    with $FunctionalFamilyOverride<String, int> {
   const ExampleFamily._()
       : super(
           retry: null,
@@ -85,22 +86,6 @@ final class ExampleFamily extends $Family {
 
   @override
   String toString() => r'exampleProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            int args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ExampleProvider;
-            final argument = provider.argument as int;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/concepts/about_codegen/provider_type/family_class.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_class.g.dart
@@ -68,7 +68,17 @@ final class ExampleProvider extends $NotifierProvider<Example, String> {
 
 String _$exampleHash() => r'8025d93d6f5e9286043b1ce7ae55bead44f30acc';
 
-final class ExampleFamily extends $Family {
+final class ExampleFamily extends $Family
+    with
+        $ClassFamilyOverride<
+            Example,
+            String,
+            String,
+            String,
+            (
+              int, {
+              String param2,
+            })> {
   const ExampleFamily._()
       : super(
           retry: null,
@@ -89,52 +99,6 @@ final class ExampleFamily extends $Family {
 
   @override
   String toString() => r'exampleProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          Example Function(
-            (
-              int, {
-              String param2,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ExampleProvider;
-            final argument = provider.argument as (
-              int, {
-              String param2,
-            });
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          String Function(
-                  Ref ref,
-                  Example notifier,
-                  (
-                    int, {
-                    String param2,
-                  }) argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ExampleProvider;
-            final argument = provider.argument as (
-              int, {
-              String param2,
-            });
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$Example extends $Notifier<String> {

--- a/website/docs/concepts/about_codegen/provider_type/family_fn.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_fn.g.dart
@@ -77,7 +77,14 @@ final class ExampleProvider extends $FunctionalProvider<String, String>
 
 String _$exampleHash() => r'5795b1f6c6f075de18d0e9789a3a52040c144f0c';
 
-final class ExampleFamily extends $Family {
+final class ExampleFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+            String,
+            (
+              int, {
+              String param2,
+            })> {
   const ExampleFamily._()
       : super(
           retry: null,
@@ -98,28 +105,6 @@ final class ExampleFamily extends $Family {
 
   @override
   String toString() => r'exampleProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            (
-              int, {
-              String param2,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ExampleProvider;
-            final argument = provider.argument as (
-              int, {
-              String param2,
-            });
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/essentials/auto_dispose/invalidate_family_example/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/invalidate_family_example/codegen.g.dart
@@ -68,7 +68,8 @@ final class LabelProvider extends $FunctionalProvider<String, String>
 
 String _$labelHash() => r'c53d17dd111313633bd7ca6d6cf6b48dded58ca5';
 
-final class LabelFamily extends $Family {
+final class LabelFamily extends $Family
+    with $FunctionalFamilyOverride<String, String> {
   const LabelFamily._()
       : super(
           retry: null,
@@ -85,22 +86,6 @@ final class LabelFamily extends $Family {
 
   @override
   String toString() => r'labelProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          String Function(
-            Ref ref,
-            String args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as LabelProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/essentials/passing_args/family/codegen.g.dart
+++ b/website/docs/essentials/passing_args/family/codegen.g.dart
@@ -61,7 +61,8 @@ final class ActivityProvider
 
 String _$activityHash() => r'6c815736c0d2b40a92695adcd78516534d7ac2fc';
 
-final class ActivityFamily extends $Family {
+final class ActivityFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<Activity>, String> {
   const ActivityFamily._()
       : super(
           retry: null,
@@ -78,22 +79,6 @@ final class ActivityFamily extends $Family {
 
   @override
   String toString() => r'activityProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FutureOr<Activity> Function(
-            Ref ref,
-            String args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ActivityProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 
 @ProviderFor(ActivityNotifier2)
@@ -145,7 +130,10 @@ final class ActivityNotifier2Provider
 
 String _$activityNotifier2Hash() => r'9e67c655d53a9f98c3b012a0534421385dde0339';
 
-final class ActivityNotifier2Family extends $Family {
+final class ActivityNotifier2Family extends $Family
+    with
+        $ClassFamilyOverride<ActivityNotifier2, AsyncValue<Activity>, Activity,
+            FutureOr<Activity>, String> {
   const ActivityNotifier2Family._()
       : super(
           retry: null,
@@ -162,38 +150,6 @@ final class ActivityNotifier2Family extends $Family {
 
   @override
   String toString() => r'activityNotifier2Provider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          ActivityNotifier2 Function(
-            String args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ActivityNotifier2Provider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          FutureOr<Activity> Function(
-                  Ref ref, ActivityNotifier2 notifier, String argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as ActivityNotifier2Provider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$ActivityNotifier2 extends $AsyncNotifier<Activity> {

--- a/website/docs/from_provider/family/family.g.dart
+++ b/website/docs/from_provider/family/family.g.dart
@@ -77,7 +77,14 @@ final class RandomProvider extends $FunctionalProvider<int, int>
 
 String _$randomHash() => r'ab69799dce84746b22880feae0f1db6dea906f6a';
 
-final class RandomFamily extends $Family {
+final class RandomFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+            int,
+            ({
+              int seed,
+              int max,
+            })> {
   const RandomFamily._()
       : super(
           retry: null,
@@ -98,28 +105,6 @@ final class RandomFamily extends $Family {
 
   @override
   String toString() => r'randomProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          int Function(
-            Ref ref,
-            ({
-              int seed,
-              int max,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as RandomProvider;
-            final argument = provider.argument as ({
-              int seed,
-              int max,
-            });
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/introduction/why_riverpod/codegen.g.dart
+++ b/website/docs/introduction/why_riverpod/codegen.g.dart
@@ -71,7 +71,14 @@ final class FetchPackagesProvider extends $FunctionalProvider<
 
 String _$fetchPackagesHash() => r'4b2c6ea2cd702ab0f9846ba19c945d2c43161605';
 
-final class FetchPackagesFamily extends $Family {
+final class FetchPackagesFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+            FutureOr<List<Package>>,
+            ({
+              int page,
+              String search,
+            })> {
   const FetchPackagesFamily._()
       : super(
           retry: null,
@@ -92,28 +99,6 @@ final class FetchPackagesFamily extends $Family {
 
   @override
   String toString() => r'fetchPackagesProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          FutureOr<List<Package>> Function(
-            Ref ref,
-            ({
-              int page,
-              String search,
-            }) args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as FetchPackagesProvider;
-            final argument = provider.argument as ({
-              int page,
-              String search,
-            });
-            return provider
-                .$view(create: (ref) => create(ref, argument))
-                .$createElement(pointer);
-          });
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
+++ b/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
@@ -100,7 +100,10 @@ final class BugsEncounteredNotifierProvider
 String _$bugsEncounteredNotifierHash() =>
     r'c76e924f84db91c57d226896b062d9f4e8ab79e5';
 
-final class BugsEncounteredNotifierFamily extends $Family {
+final class BugsEncounteredNotifierFamily extends $Family
+    with
+        $ClassFamilyOverride<BugsEncounteredNotifier, AsyncValue<int>, int,
+            FutureOr<int>, String> {
   const BugsEncounteredNotifierFamily._()
       : super(
           retry: null,
@@ -117,38 +120,6 @@ final class BugsEncounteredNotifierFamily extends $Family {
 
   @override
   String toString() => r'bugsEncounteredNotifierProvider';
-
-  /// {@macro riverpod.override_with}
-  Override overrideWith(
-          BugsEncounteredNotifier Function(
-            String args,
-          ) create) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as BugsEncounteredNotifierProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(create: () => create(argument))
-                .$createElement(pointer);
-          });
-
-  /// {@macro riverpod.override_with_build}
-  Override overrideWithBuild(
-          FutureOr<int> Function(
-                  Ref ref, BugsEncounteredNotifier notifier, String argument)
-              build) =>
-      $FamilyOverride(
-          from: this,
-          createElement: (pointer) {
-            final provider = pointer.origin as BugsEncounteredNotifierProvider;
-            final argument = provider.argument as String;
-            return provider
-                .$view(
-                    runNotifierBuildOverride: (ref, notifier) =>
-                        build(ref, notifier, argument))
-                .$createElement(pointer);
-          });
 }
 
 abstract class _$BugsEncounteredNotifier extends $AsyncNotifier<int> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified provider family override logic by introducing generic mixins for functional and class-based families.
  - Removed explicit override methods from all generated and example provider family classes, delegating override behavior to the new mixins.
  - Updated generated code and documentation examples to use mixin-based overrides for cleaner and more maintainable code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->