### PR TITLE
fix: grammar

### DIFF
--- a/website/docs/concepts/reading.mdx
+++ b/website/docs/concepts/reading.mdx
@@ -30,7 +30,7 @@ It will be updated in the future, but for now you may want to refer to the conte
 in the top of the sidebar instead (introduction/essentials/case-studies/...)
 :::
 
-Before reading this guide, make sure to <Link documentID="concepts/providers"/> first.
+Before reading this guide, make sure to read <Link documentID="concepts/providers"/> first.
 
 In this guide, we will see how to consume a provider.
 


### PR DESCRIPTION
added "read".
before > Before reading this guide, make sure to Providers first. after > Before reading this guide, make sure to read Providers first.