### PR TITLE
Allow disabling mounted check

### DIFF
--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -83,6 +83,7 @@ abstract class ProviderElement<StateT> implements Node {
   /// The [ProviderContainer] that owns this [ProviderElement].
   ProviderContainer get container => pointer.targetContainer;
 
+  bool unsafeCheckIfMounted = true;
   // ignore: library_private_types_in_public_api, not public
   $Ref<StateT>? ref;
 

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -221,7 +221,7 @@ mixin Persistable<ValueT, KeyT, EncodedT> on $Value<ValueT> {
     $Value<Object?> self,
   ) {
     if (kDebugMode) {
-      final selfElement = (self as AnyNotifier).element();
+      final selfElement = (self as AnyNotifier).elementOrNull();
 
       self._debugKey = (key,);
 
@@ -332,8 +332,26 @@ to a different value.
 @internal
 extension ClassBaseX<StateT> on AnyNotifier<StateT> {
   $ClassProviderElement<AnyNotifier<StateT>, StateT, Object?, Object?>?
-      element() => _ref?.element as $ClassProviderElement<AnyNotifier<StateT>,
-          StateT, Object?, Object?>?;
+      elementOrNull() {
+    final ref = _ref;
+    if (ref == null) return null;
+
+    return ref.element as $ClassProviderElement<AnyNotifier<StateT>, StateT,
+        Object?, Object?>?;
+  }
+
+  $ClassProviderElement<AnyNotifier<StateT>, StateT, Object?, Object?>
+      requireElement() {
+    final ref = _ref;
+    final element = elementOrNull();
+    if (ref == null || element == null) {
+      throw StateError(uninitializedElementError);
+    }
+
+    ref._throwIfInvalidUsage();
+
+    return element;
+  }
 
   @internal
   // ignore: library_private_types_in_public_api, not public

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -61,6 +61,33 @@ sealed class Ref {
   List<void Function()>? _onAddListeners;
   List<void Function()>? _onRemoveListeners;
 
+  /// An option flag to disable the exception when a [Ref]/[Notifier] is interacted
+  /// after it has been disposed.
+  ///
+  /// Avoid disabling this flag at all costs. This flag is meant to ease migration
+  /// between 2.0.0 and 3.0.0.
+  /// Do not write new code that relies on this flag.
+  ///
+  /// Disabling mounted checks may cause unexpected behavior, such as:
+  /// - Memory leaks
+  ///   A provider may not have aborted its computation upon refresh and
+  ///   is still holding references to objects that should have been
+  ///   disposed
+  /// - Race conditions / Concurrent modification
+  ///   After a provider has been refreshed, it is possible that both the
+  ///   old "build" and new "build" are trying to update `state` at the
+  ///   same time.
+  ///
+  /// These errors could be particularly hard to debug, as they may not
+  /// happen immediately, or only under specific conditions.
+  /// As such, it is highly recommended to keep this flag enabled, to
+  /// avoid these issues.
+  // ignore: non_constant_identifier_names
+  bool get unsafe_checkIfMounted => _element.unsafeCheckIfMounted;
+  // ignore: non_constant_identifier_names
+  set unsafe_checkIfMounted(bool value) =>
+      _element.unsafeCheckIfMounted = value;
+
   /// Whether we're initializing this provider for the first time.
   ///
   /// **Note**:
@@ -186,7 +213,7 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
       _debugCallbackStack == 0,
       'Cannot use Ref inside life-cycles/selectors.',
     );
-    if (_status == _RefStatus.unmounted) {
+    if (unsafe_checkIfMounted && _status == _RefStatus.unmounted) {
       throw UnmountedRefException(_element.origin);
     }
   }

--- a/packages/riverpod/lib/src/providers/async_notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/family.dart
@@ -26,7 +26,7 @@ abstract class FamilyAsyncNotifier<StateT, ArgT>
   @override
   void runBuild() {
     final created = build(arg);
-    element()!.handleValue(ref, created);
+    requireElement().handleValue(ref, created);
   }
 }
 

--- a/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
@@ -38,7 +38,7 @@ abstract class AsyncNotifier<StateT> extends $AsyncNotifier<StateT> {
   @override
   void runBuild() {
     final created = build();
-    element()!.handleValue(ref, created);
+    requireElement().handleValue(ref, created);
   }
 }
 

--- a/packages/riverpod/lib/src/providers/notifier.dart
+++ b/packages/riverpod/lib/src/providers/notifier.dart
@@ -32,8 +32,7 @@ abstract class $Notifier<StateT> extends $SyncNotifierBase<StateT> {
   @protected
   @visibleForTesting
   StateT? get stateOrNull {
-    final element = this.element();
-    if (element == null) throw StateError(uninitializedElementError);
+    final element = requireElement();
 
     element.flush();
     return element.stateResult?.value;

--- a/packages/riverpod/lib/src/providers/notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/notifier/family.dart
@@ -15,7 +15,7 @@ abstract class FamilyNotifier<StateT, ArgT> extends $Notifier<StateT> {
   @override
   void runBuild() {
     final created = build(arg);
-    element()!.handleValue(ref, created);
+    requireElement().handleValue(ref, created);
   }
 }
 

--- a/packages/riverpod/lib/src/providers/notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/notifier/orphan.dart
@@ -73,7 +73,7 @@ abstract class Notifier<StateT> extends $Notifier<StateT> {
   @override
   void runBuild() {
     final created = build();
-    element()!.handleValue(ref, created);
+    requireElement().handleValue(ref, created);
   }
 }
 

--- a/packages/riverpod/lib/src/providers/stream_notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier/family.dart
@@ -26,7 +26,7 @@ abstract class FamilyStreamNotifier<StateT, ArgT>
   @override
   void runBuild() {
     final created = build(arg);
-    element()!.handleValue(ref, created);
+    requireElement().handleValue(ref, created);
   }
 }
 

--- a/packages/riverpod/lib/src/providers/stream_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier/orphan.dart
@@ -25,7 +25,7 @@ abstract class StreamNotifier<StateT> extends $StreamNotifier<StateT> {
   @override
   void runBuild() {
     final created = build();
-    element()!.handleValue(ref, created);
+    requireElement().handleValue(ref, created);
   }
 }
 

--- a/packages/riverpod/test/src/core/ref_test.dart
+++ b/packages/riverpod/test/src/core/ref_test.dart
@@ -108,6 +108,40 @@ void main() {
       );
     });
 
+    test('Lifecycle can be used if mounted check is disabled', () async {
+      late Ref ref;
+      final container = ProviderContainer.test();
+      final dep = StateProvider((ref) => 0);
+      final provider = Provider<Object?>((r) {
+        r.watch(dep);
+        ref = r;
+        return Object();
+      });
+
+      container.read(provider);
+      container.read(dep.notifier).state++;
+
+      await null;
+
+      final another = Provider((ref) => 0);
+      ref.unsafe_checkIfMounted = false;
+
+      expect(() => ref.watch(another), returnsNormally);
+      expect(() => ref.invalidateSelf(), returnsNormally);
+      expect(() => ref.invalidate(dep), returnsNormally);
+      expect(() => ref.refresh(another), returnsNormally);
+      expect(() => ref.read(another), returnsNormally);
+      expect(() => ref.onDispose(() {}), returnsNormally);
+      expect(() => ref.onAddListener(() {}), returnsNormally);
+      expect(() => ref.onCancel(() {}), returnsNormally);
+      expect(() => ref.onRemoveListener(() {}), returnsNormally);
+      expect(() => ref.onResume(() {}), returnsNormally);
+      expect(() => ref.notifyListeners(), returnsNormally);
+      expect(() => ref.listen(another, (_, __) {}), returnsNormally);
+      expect(() => ref.exists(another), returnsNormally);
+      expect(() => ref.keepAlive(), returnsNormally);
+    });
+
     test('asserts that a lifecycle cannot be used inside selectors', () {
       late Ref ref;
       final container = ProviderContainer.test();

--- a/packages/riverpod/test/src/providers/async_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/async_notifier_test.dart
@@ -283,6 +283,25 @@ void main() {
       );
     });
 
+    test('Using the notifier after dispose does not throw if flag is disabled',
+        () async {
+      final container = ProviderContainer.test();
+      final provider = factory.simpleTestProvider((ref, _) => 0);
+
+      container.listen(provider.notifier, (prev, next) {});
+      final notifier = container.read(provider.notifier);
+      notifier.ref.unsafe_checkIfMounted = false;
+
+      container.invalidate(provider);
+      await null;
+
+      expect(notifier.ref.mounted, false);
+      expect(() => notifier.state, returnsNormally);
+      expect(() => notifier.future, returnsNormally);
+      expect(() => notifier.state = const AsyncData(42), returnsNormally);
+      expect(() => notifier.update((p1) => 42), returnsNormally);
+    });
+
     test('Can assign `AsyncLoading<T>` to `AsyncValue<void>`', () {
       // Regression test for https://github.com/rrousselGit/riverpod/issues/2120
       final provider = factory.simpleTestProvider<void>((ref, _) => 42);

--- a/packages/riverpod/test/src/providers/notifier_test.dart
+++ b/packages/riverpod/test/src/providers/notifier_test.dart
@@ -102,14 +102,27 @@ void main() {
       await null;
 
       expect(notifier.ref.mounted, false);
-      expect(
-        () => notifier.state,
-        throwsA(isA<UnmountedRefException>()),
-      );
-      expect(
-        () => notifier.state = 42,
-        throwsA(isA<UnmountedRefException>()),
-      );
+      expect(() => notifier.state, throwsA(isA<UnmountedRefException>()));
+      expect(() => notifier.state = 42, throwsA(isA<UnmountedRefException>()));
+      expect(() => notifier.stateOrNull, throwsA(isA<UnmountedRefException>()));
+    });
+
+    test('Using the notifier after dispose does not throw if flag is disabled',
+        () async {
+      final container = ProviderContainer.test();
+      final provider = factory.simpleTestProvider((ref, _) => 0);
+
+      container.listen(provider.notifier, (prev, next) {});
+      final notifier = container.read(provider.notifier);
+      notifier.ref.unsafe_checkIfMounted = false;
+
+      container.invalidate(provider);
+      await null;
+
+      expect(notifier.ref.mounted, false);
+      expect(() => notifier.state, returnsNormally);
+      expect(() => notifier.state = 42, returnsNormally);
+      expect(() => notifier.stateOrNull, returnsNormally);
     });
 
     test(


### PR DESCRIPTION
This ease 2.0.0 > 3.0.0 migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an option to disable mounted state checks for advanced usage, allowing continued access to certain provider lifecycle methods after disposal.
- **Bug Fixes**
	- Improved error handling when accessing notifier elements, providing clearer exceptions if accessed while uninitialized.
- **Tests**
	- Added tests to verify behavior when mounted state checks are disabled and to ensure correct error handling in various notifier scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->