### PR TITLE
Fix a bug related to pause/resume order

### DIFF
--- a/packages/riverpod/lib/src/core/provider_subscription.dart
+++ b/packages/riverpod/lib/src/core/provider_subscription.dart
@@ -97,13 +97,11 @@ abstract base class ProviderSubscriptionImpl<OutT, OriginT>
   void Function(OutT? prev, OutT next) get _listener;
   OnError get _errorListener;
 
-  @mustCallSuper
   @override
   void onCancel() {
     _listenedElement.onSubscriptionPause(this);
   }
 
-  @mustCallSuper
   @override
   void onResume() {
     _listenedElement.onSubscriptionResume(this);
@@ -245,33 +243,21 @@ base class ProviderSubscriptionView<OutT, OriginT>
   }
 
   @override
-  void onCancel() {
-    super.onCancel();
-    switch (innerSubscription) {
-      case final ProviderSubscriptionImpl<Object?, OriginT> sub:
-        sub.onCancel();
-    }
-  }
+  void onCancel() {}
 
   @override
-  void onResume() {
-    super.onResume();
-    switch (innerSubscription) {
-      case final ProviderSubscriptionImpl<Object?, OriginT> sub:
-        sub.onResume();
-    }
-  }
+  void onResume() {}
 
   @override
   void pause() {
-    innerSubscription.pause();
     super.pause();
+    innerSubscription.pause();
   }
 
   @override
   void resume() {
-    innerSubscription.resume();
     super.resume();
+    innerSubscription.resume();
   }
 
   @override
@@ -279,8 +265,8 @@ base class ProviderSubscriptionView<OutT, OriginT>
     if (_closed) return;
 
     _onClose?.call();
-    innerSubscription.close();
     super.close();
+    innerSubscription.close();
   }
 
   @override

--- a/packages/riverpod/test/src/core/provider_element_test.dart
+++ b/packages/riverpod/test/src/core/provider_element_test.dart
@@ -60,6 +60,24 @@ void main() {
       expect(depS.isActive, false);
     });
 
+    test(
+        'Adding a listener on a provider with only paused proxy subscriptions unpauses the provider',
+        () async {
+      // Regression test for when "resume" somehow triggers too late
+      final container = ProviderContainer.test();
+      final onResume = OnResume();
+      final dep = FutureProvider<int>((ref) {
+        ref.onResume(onResume.call);
+        return 0;
+      });
+
+      final sub = container.listen(dep.future, (_, __) {})..pause();
+      clearInteractions(onResume);
+
+      container.listen(dep, (_, __) {});
+      verifyOnly(onResume, onResume.call());
+    });
+
     test('Only includes direct subscriptions in subscription lists', () {
       final container = ProviderContainer.test();
       final provider = FutureProvider((ref) => 0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of asynchronous listeners to prevent potential race conditions and ensure more reliable completion behavior.
  - Adjusted provider subscription logic to simplify cancellation and resumption, reducing unnecessary internal calls.

- **Tests**
  - Added a new test to ensure providers correctly resume when a new listener is added, addressing a regression scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->