### PR TITLE
Cap retry at 10, Make retry ignore errors

### DIFF
--- a/packages/flutter_riverpod/test/provider_scope_test.dart
+++ b/packages/flutter_riverpod/test/provider_scope_test.dart
@@ -28,7 +28,7 @@ void main() {
         var buildCount = 0;
         final provider = Provider((ref) {
           buildCount++;
-          throw UnimplementedError();
+          throw Exception();
         });
 
         final element = tester.element(find.byType(Container));

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -58,7 +58,8 @@ abstract class ProviderElement<StateT> implements Node {
   }
 
   static Duration? _defaultRetry(int retryCount, Object error) {
-    if (error is ProviderException) return null;
+    if (retryCount >= 10) return null;
+    if (error is ProviderException || error is Error) return null;
 
     return Duration(
       milliseconds: math.min(200 * math.pow(2, retryCount).toInt(), 6400),

--- a/packages/riverpod/lib/src/core/foundation.dart
+++ b/packages/riverpod/lib/src/core/foundation.dart
@@ -29,14 +29,20 @@ sealed class ProviderOrFamily implements ProviderListenableOrFamily {
 
   /// {@template riverpod.retry}
   /// The default retry logic used by providers associated to this container.
+  /// 
+  /// The function takes two parameters:
+  /// - `retryCount`: The number of times the provider has been retried
+  ///   (starting at 0).
+  /// - `error`: The error that caused the retry.
   ///
   /// The default implementation:
-  /// - has unlimited retries
+  /// - 10 retries
   /// - starts with a delay of 200ms
   /// - doubles the delay on each retry up to 6.4 seconds
   /// - retries all failures
   /// - ignores [ProviderException]s (which happens when a provider
   ///   rethrows the error of another provider)
+  /// - ignores [Error]s (which are generally programming errors)
   /// {@endtemplate}
   final Retry? retry;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and clarified the explanation of provider retry logic, including updated details on retry limits, error handling, and delay intervals.

- **Bug Fixes**
  - Adjusted retry mechanism to cap retries at 10 attempts and prevent retries on programming errors.

- **Tests**
  - Enhanced and expanded test coverage for provider retry behavior, including error handling and retry limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->