### PR TITLE
Revert "Notifiers are recreated on rebuild"

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased build
 
+- Revert Notifier life-cycle change. They are once again preserved across rebuilds.
 - Provider errors are now reported to the
   `ProviderContainer`'s `Zone` instead of whatever last used the provider.
 - **Breaking**: When a `ref.watch`/`ref.read` rethrows an error,

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased build
 
+- Revert Notifier life-cycle change. They are once again preserved across rebuilds.
 - Provider errors are now reported to the
   `ProviderContainer`'s `Zone` instead of whatever last used the provider.
 - **Breaking**: When a `ref.watch`/`ref.read` rethrows an error,

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased build
 
+- Revert Notifier life-cycle change. They are once again preserved across rebuilds.
 - Provider errors are now reported to the
   `ProviderContainer`'s `Zone` instead of whatever last used the provider.
 - **Breaking**: When a `ref.watch`/`ref.read` rethrows an error,

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -812,7 +812,6 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     runOnDispose();
     _didMount = false;
     _stateResult = null;
-    ref = null;
 
     if (dependents case final subs?) {
       _closeSubscriptions(subs);

--- a/packages/riverpod/lib/src/core/modifiers/future.dart
+++ b/packages/riverpod/lib/src/core/modifiers/future.dart
@@ -42,18 +42,10 @@ mixin $AsyncClassModifier<StateT, CreatedT, ValueT>
   @visibleForTesting
   @protected
   Future<StateT> get future {
-    final ref = _ref;
-    if (ref == null) {
-      throw StateError(uninitializedElementError);
-    }
-
-    ref._throwIfInvalidUsage();
-
-    final element = ref._element;
-    element as FutureModifierElement<StateT>;
+    final element = requireElement();
 
     element.flush();
-    return element.futureNotifier.value;
+    return (element as FutureModifierElement<StateT>).futureNotifier.value;
   }
 
   /// A function to update [state] from its previous value, while

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -63,7 +63,8 @@ mixin AnyNotifier<StateT, ValueT> {
     StorageOptions options,
   );
 
-  $Ref<StateT>? _ref;
+  $ClassProviderElement<AnyNotifier<StateT, ValueT>, StateT, ValueT, Object?>?
+      _element;
 
   /// The [Ref] associated with this notifier.
   @protected
@@ -321,19 +322,12 @@ abstract class $SyncNotifierBase<StateT> with AnyNotifier<StateT, StateT> {
 @internal
 extension ClassBaseX<StateT, ValueT> on AnyNotifier<StateT, ValueT> {
   $ClassProviderElement<AnyNotifier<StateT, ValueT>, StateT, Object?, Object?>?
-      elementOrNull() {
-    final ref = _ref;
-    if (ref == null) return null;
-
-    return ref.element as $ClassProviderElement<AnyNotifier<StateT, ValueT>,
-        StateT, Object?, Object?>?;
-  }
+      elementOrNull() => _element;
 
   $ClassProviderElement<AnyNotifier<StateT, ValueT>, StateT, Object?, Object?>
       requireElement() {
-    final ref = _ref;
     final element = elementOrNull();
-    if (ref == null || element == null) {
+    if (element == null) {
       throw StateError(uninitializedElementError);
     }
 
@@ -345,7 +339,7 @@ extension ClassBaseX<StateT, ValueT> on AnyNotifier<StateT, ValueT> {
   @internal
   // ignore: library_private_types_in_public_api, not public
   $Ref<StateT> get $ref {
-    final ref = _ref;
+    final ref = _element?.ref;
     if (ref == null) throw StateError(uninitializedElementError);
 
     return ref;
@@ -504,13 +498,13 @@ abstract class $ClassProviderElement< //
     // ignore: library_private_types_in_public_api, not public
     $Ref<StateT> ref,
   ) {
-    final result = classListenable.result = $Result.guard(() {
+    final result = classListenable.result ??= $Result.guard(() {
       final notifier = provider.create();
-      if (notifier._ref != null) {
+      if (notifier._element != null) {
         throw StateError(alreadyInitializedError);
       }
 
-      notifier._ref = ref;
+      notifier._element = this;
       return notifier;
     });
 

--- a/packages/riverpod/test/src/providers/stream_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/stream_notifier_test.dart
@@ -8,8 +8,6 @@ import 'package:riverpod/legacy.dart';
 import 'package:riverpod/misc.dart' show Refreshable, ProviderListenable;
 import 'package:riverpod/riverpod.dart';
 import 'package:riverpod/src/framework.dart' show UnmountedRefException;
-import 'package:riverpod/src/providers/stream_notifier.dart'
-    show $StreamNotifier;
 import 'package:test/test.dart';
 
 import '../../third_party/fake_async.dart';
@@ -835,37 +833,6 @@ void main() {
         final notifier = container.read(provider.notifier);
 
         expect(notifier.future, same(container.read(provider.future)));
-      });
-    });
-
-    group('StreamNotifierProvider.notifier', () {
-      test(
-          'Notifies listeners whenever `build` is re-executed, due to recreating a new notifier.',
-          () async {
-        final notifierListener = Listener<$StreamNotifier<int>>();
-        final dep = StateProvider((ref) => 0);
-        final provider = factory.provider<int>(() {
-          return factory.deferredNotifier(
-            (ref, _) => Stream.value(ref.watch(dep)),
-          );
-        });
-        final container = ProviderContainer.test();
-
-        final sub = container.listen(provider.notifier, notifierListener.call);
-        final initialNotifier = sub.read();
-
-        // Skip the loading
-        await container.read(provider.future);
-        verifyNoMoreInteractions(notifierListener);
-
-        container.refresh(provider);
-        final newNotifier = sub.read();
-
-        expect(newNotifier, isNot(same(initialNotifier)));
-        verifyOnly(
-          notifierListener,
-          notifierListener(initialNotifier, newNotifier),
-        ).called(1);
       });
     });
 

--- a/website/docs/3.0_migration.mdx
+++ b/website/docs/3.0_migration.mdx
@@ -343,64 +343,6 @@ if (value.error is NotFoundException) {
 :::
 
 
-## Notifiers are now recreated when the provider rebuilds
-
-In 2.0, Notifier instances were reused for the lifetime of the provider.
-In 3.0, [a new Notifier is created whenever the provider rebuilds](./whats_new.mdx#when-a-notifier-rebuilds-a-new-instance-of-the-notifier-class-is-created).
-
-This prevents storing state inside the Notifier class itself, as any state outside of the `state` property
-will be lost when the provider rebuilds.  
-To fix this, you will need to move any custom state inside `Notifier.state`.
-
-
-<AutoSnippet
-  language="dart"
-  codegen={`
-  // Before:
-  @riverpod
-  class TodoList extends _$TodoList {
-    int _count = 0;
-  
-    @override
-    List<Todo> build() => [];
-  }
-  
-  // After
-  class TodosState {
-    TodosState._(this.todos, this._count);
-    final List<Todo> todos;
-    int _count;
-  }
-  @riverpod
-  class TodoList extends _$TodoList {
-    @override
-    TodosState build() => TodosState._([], 0);
-  }
-  `}
-  
-  raw={`
-  // Before:
-  class TodoList extends Notifier<List<Todo>> {
-    int _count = 0;
-  
-    @override
-    List<Todo> build() => [];
-  }
-  
-  // After
-  class TodosState {
-    TodosState._(this.todos, this._count);
-    final List<Todo> todos;
-    int _count;
-  }
-  class TodoList extends Notifier<TodosState> {
-    @override
-    TodosState build() => TodosState._([], 0);
-  }
-  `}
-></AutoSnippet>
-
-
 [TickerMode]: https://api.flutter.dev/flutter/widgets/TickerMode-class.html
 [StreamProvider]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/StreamProvider-class.html
 [StreamNotifierProvider]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/StreamNotifierProvider.html

--- a/website/docs/whats_new.mdx
+++ b/website/docs/whats_new.mdx
@@ -912,63 +912,6 @@ resumed
 ... // And so on every second
 ```
 
-### When a Notifier rebuilds, a new instance of the Notifier class is created
-
-In 2.0, `Notifier`s instances were created once, then reused for the lifetime of the provider.  
-This enabled storing custom state in the `Notifier` class. Unfortunately, this also meant
-caused some possible race conditions ; especially when we consider the new "offline persistence" feature.
-
-Offline persistence works by differentiating the first build of a provider
-from the subsequent builds. This is done by checking `Ref.isFirstBuild`. 
-The problem is, if `Notifier` instances are reused and a rebuild occurs
-while `Notifier.build` is still running, this could confuse offline persistence.
-
-Although unfortunate, for 3.0 the decision was made to break the old behavior
-and create a new instance of the `Notifier` class every time the provider rebuilds.
-
-On the upside, it means that you can now safely rely on `late final` variables initialized during `build`:
-
-
-<AutoSnippet
-  language="dart"
-  codegen={`
-    @riverpod
-    class MyNotifier extends _$MyNotifier {
-      late final int _cached;
-      
-      @override
-      int build() {
-        // This is now safe, as a new Notifier instance is created upon rebuild
-        _cached = ref.watch(myProvider);
-        return 0;
-      }
-      
-      void increment() {
-        print(_cached);
-      }
-    }
-  `}
-  
-  raw={`
-    class MyNotifier extends Notifier<int> {
-      late final int _cached;
-      
-      @override
-      int build() {
-        // This is now safe, as a new Notifier instance is created upon rebuild
-        _cached = ref.watch(myProvider);
-        return 0;
-      }
-      
-      void increment() {
-        print(_cached);
-      }
-    }
-    
-    final myNotifierProvider = NotifierProvider<MyNotifier, int>(MyNotifier.new);
-  `}
-></AutoSnippet>
-
 ## New testing utilities
 
 ### `ProviderContainer.test`


### PR DESCRIPTION
fixes #4098

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated changelogs to note that Notifiers are now preserved across provider rebuilds.
  - Removed documentation and migration guide sections describing Notifier recreation on rebuilds, reflecting the reverted behavior.
- **Bug Fixes**
  - Notifiers are once again preserved across provider rebuilds, restoring previous behavior.
- **Tests**
  - Removed tests related to Notifier recreation on provider rebuilds.
  - Added a test to confirm that Notifier instances persist across provider refreshes.
- **Refactor**
  - Simplified internal logic for Notifier element management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->