### PR TITLE
Better `.keepAlive` doc comments

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased build
 
+- Better doc comments on `ref.keepAlive` (thanks to @lucavenir)
 - **Breaking**: ProviderObserver methods have been updated to take a `ProviderObserverContext` parameter.
   This replaces the old `provider`+`container` parameters, and contains extra
   information.

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -39,10 +39,7 @@ Cannot use the Ref of $origin after it has been disposed. This typically happens
 /// {@endtemplate}
 @optionalTypeArgs
 sealed class Ref {
-  Ref._({
-    required this.isFirstBuild,
-    required this.isReload,
-  });
+  Ref._({required this.isFirstBuild, required this.isReload});
 
   ProviderElement<Object?> get _element;
   List<KeepAliveLink>? _keepAliveLinks;
@@ -73,24 +70,21 @@ sealed class Ref {
     final origin = _element.origin;
     final provider = _element.provider;
 
-    assert(
-      dependency != origin,
-      'A provider cannot depend on itself',
-    );
+    assert(dependency != origin, 'A provider cannot depend on itself');
 
     final dependencies = origin.from?.dependencies ?? origin.dependencies ?? [];
     final targetDependencies =
         dependency.from?.dependencies ?? dependency.dependencies;
 
     if (
-        // If the target has a null "dependencies", it should never be scoped.
-        !(targetDependencies == null ||
-            // Ignore dependency check if from an override
-            provider != origin ||
-            // Families are allowed to depend on themselves with different parameters.
-            (origin.from != null && dependency.from == origin.from) ||
-            dependencies.contains(dependency.from) ||
-            dependencies.contains(dependency))) {
+    // If the target has a null "dependencies", it should never be scoped.
+    !(targetDependencies == null ||
+        // Ignore dependency check if from an override
+        provider != origin ||
+        // Families are allowed to depend on themselves with different parameters.
+        (origin.from != null && dependency.from == origin.from) ||
+        dependencies.contains(dependency.from) ||
+        dependencies.contains(dependency))) {
       throw StateError('''
 The provider `$origin` depends on `$dependency`, which may be scoped.
 Yet `$dependency` is not part of `$origin`'s `dependencies` list.
@@ -138,6 +132,9 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   ///
   /// If [keepAlive] is invoked multiple times, all [KeepAliveLink] will have
   /// to be closed for the provider to dispose itself when all listeners are removed.
+  ///
+  /// Finally, keep in mind that [keepAlive] doesn't mark a provider immune to rebuilds or invalidations.
+  /// Indeed, when a provider disposes, **all** its associated [KeepAliveLink]s will be closed.
   KeepAliveLink keepAlive() {
     _throwIfInvalidUsage();
 
@@ -602,11 +599,8 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
 @internal
 class $Ref<StateT> extends Ref {
   /// {@macro riverpod.provider_ref_base}
-  $Ref(
-    this._element, {
-    required super.isFirstBuild,
-    required super.isReload,
-  }) : super._();
+  $Ref(this._element, {required super.isFirstBuild, required super.isReload})
+    : super._();
 
   ProviderElement<StateT> get element => _element;
 

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -138,6 +138,9 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   ///
   /// If [keepAlive] is invoked multiple times, all [KeepAliveLink] will have
   /// to be closed for the provider to dispose itself when all listeners are removed.
+  ///
+  /// Finally, keep in mind that [keepAlive] doesn't mark a provider immune to rebuilds or invalidations.
+  /// Indeed, when a provider disposes, **all** its associated [KeepAliveLink]s will be closed.
   KeepAliveLink keepAlive() {
     _throwIfInvalidUsage();
 

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -139,8 +139,19 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   /// If [keepAlive] is invoked multiple times, all [KeepAliveLink] will have
   /// to be closed for the provider to dispose itself when all listeners are removed.
   ///
-  /// Finally, keep in mind that [keepAlive] doesn't mark a provider immune to rebuilds or invalidations.
-  /// Indeed, when a provider disposes, **all** its associated [KeepAliveLink]s will be closed.
+  /// Keep in mind that [keepAlive] doesn't mark a provider immune to rebuilds or invalidations.
+  /// Indeed, [keepAlive] has no effect on disposal through [watch] or [invalidate].
+  ///
+  /// Furthermore, when a provider disposes, all its associated [KeepAliveLink]s will be closed.
+  ///
+  /// The most extreme scenario is a provider with no active listeners,
+  /// which rebuilds for whatever reason, causing it to dispose
+  /// and to close any active [KeepAliveLink]:
+  /// in such scenario, the provider won't recompute at all.
+  ///
+  /// In other words, without listeners, it might be that
+  /// a provider gets disposed just like every other,
+  /// despite previously being kept alive.
   KeepAliveLink keepAlive() {
     _throwIfInvalidUsage();
 

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -140,9 +140,12 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   /// to be closed for the provider to dispose itself when all listeners are removed.
   ///
   /// **Note:**
+  /// You do not need to call [KeepAliveLink.close].
+  /// When a provider rebuilds, previously created links are automatically closed.
+  ///
+  /// **Note:**
   /// [keepAlive] only affects [auto dispose](https://riverpod.dev/docs/essentials/auto_dispose),
   /// and does not prevent a provider from rebuilding, such as when using [watch]/[invalidate].
-  /// Indeed, when a provider disposes, all its associated [KeepAliveLink]s will be closed.
   KeepAliveLink keepAlive() {
     _throwIfInvalidUsage();
 

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -39,7 +39,10 @@ Cannot use the Ref of $origin after it has been disposed. This typically happens
 /// {@endtemplate}
 @optionalTypeArgs
 sealed class Ref {
-  Ref._({required this.isFirstBuild, required this.isReload});
+  Ref._({
+    required this.isFirstBuild,
+    required this.isReload,
+  });
 
   ProviderElement<Object?> get _element;
   List<KeepAliveLink>? _keepAliveLinks;
@@ -70,21 +73,24 @@ sealed class Ref {
     final origin = _element.origin;
     final provider = _element.provider;
 
-    assert(dependency != origin, 'A provider cannot depend on itself');
+    assert(
+      dependency != origin,
+      'A provider cannot depend on itself',
+    );
 
     final dependencies = origin.from?.dependencies ?? origin.dependencies ?? [];
     final targetDependencies =
         dependency.from?.dependencies ?? dependency.dependencies;
 
     if (
-    // If the target has a null "dependencies", it should never be scoped.
-    !(targetDependencies == null ||
-        // Ignore dependency check if from an override
-        provider != origin ||
-        // Families are allowed to depend on themselves with different parameters.
-        (origin.from != null && dependency.from == origin.from) ||
-        dependencies.contains(dependency.from) ||
-        dependencies.contains(dependency))) {
+        // If the target has a null "dependencies", it should never be scoped.
+        !(targetDependencies == null ||
+            // Ignore dependency check if from an override
+            provider != origin ||
+            // Families are allowed to depend on themselves with different parameters.
+            (origin.from != null && dependency.from == origin.from) ||
+            dependencies.contains(dependency.from) ||
+            dependencies.contains(dependency))) {
       throw StateError('''
 The provider `$origin` depends on `$dependency`, which may be scoped.
 Yet `$dependency` is not part of `$origin`'s `dependencies` list.
@@ -132,9 +138,6 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   ///
   /// If [keepAlive] is invoked multiple times, all [KeepAliveLink] will have
   /// to be closed for the provider to dispose itself when all listeners are removed.
-  ///
-  /// Finally, keep in mind that [keepAlive] doesn't mark a provider immune to rebuilds or invalidations.
-  /// Indeed, when a provider disposes, **all** its associated [KeepAliveLink]s will be closed.
   KeepAliveLink keepAlive() {
     _throwIfInvalidUsage();
 
@@ -599,8 +602,11 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
 @internal
 class $Ref<StateT> extends Ref {
   /// {@macro riverpod.provider_ref_base}
-  $Ref(this._element, {required super.isFirstBuild, required super.isReload})
-    : super._();
+  $Ref(
+    this._element, {
+    required super.isFirstBuild,
+    required super.isReload,
+  }) : super._();
 
   ProviderElement<StateT> get element => _element;
 

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -139,19 +139,10 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   /// If [keepAlive] is invoked multiple times, all [KeepAliveLink] will have
   /// to be closed for the provider to dispose itself when all listeners are removed.
   ///
-  /// Keep in mind that [keepAlive] doesn't mark a provider immune to rebuilds or invalidations.
-  /// Indeed, [keepAlive] has no effect on disposal through [watch] or [invalidate].
-  ///
-  /// Furthermore, when a provider disposes, all its associated [KeepAliveLink]s will be closed.
-  ///
-  /// The most extreme scenario is a provider with no active listeners,
-  /// which rebuilds for whatever reason, causing it to dispose
-  /// and to close any active [KeepAliveLink]:
-  /// in such scenario, the provider won't recompute at all.
-  ///
-  /// In other words, without listeners, it might be that
-  /// a provider gets disposed just like every other,
-  /// despite previously being kept alive.
+  /// **Note:**
+  /// [keepAlive] only affects [auto dispose](https://riverpod.dev/docs/essentials/auto_dispose),
+  /// and does not prevent a provider from rebuilding, such as when using [watch]/[invalidate].
+  /// Indeed, when a provider disposes, all its associated [KeepAliveLink]s will be closed.
   KeepAliveLink keepAlive() {
     _throwIfInvalidUsage();
 


### PR DESCRIPTION
## Related Issues

fixes #4088

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [X] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new sealed `$Result` type for value/error handling.
  - Added comprehensive internal builder classes for provider creation with unified APIs and retry support.
  - Added new legacy entrypoints (`legacy.dart`) for accessing legacy providers.
  - Added new test suites and improved test container management for more reliable testing.
  - Added a new internal code generator package (`lint_visitor_generator`) with supporting files.

- **Breaking Changes**
  - Major refactor of provider builder APIs; many old builder classes were removed and replaced with internal, unified builders.
  - Deprecated and removed several internal and public classes related to async notifiers and change notifier providers.
  - Moved `StateProvider`, `StateNotifierProvider`, and `ChangeNotifierProvider` to legacy imports.
  - `AsyncValue.valueOrNull` and all `Ref` subclasses removed; use `.value` and `Ref` directly.
  - `ProviderObserver` methods now require a `ProviderObserverContext` parameter.
  - Provider exports have been reorganized and internal APIs further hidden.

- **Enhancements**
  - Provider containers now support a `retry` mechanism for automatic error recovery.
  - Improved visibility and lifecycle management for provider listeners in Flutter widgets.
  - Updated code generation for Riverpod providers to use more explicit, type-safe patterns.
  - Dependency and environment constraints updated for Dart 3.6.0+ across all packages and examples.

- **Bug Fixes**
  - Fixed issues with provider container disposal, listener management, and circular dependency detection.
  - Improved error reporting and handling in provider lifecycle and observer methods.
  - Addressed timer-related issues in widget tests.

- **Documentation**
  - Changelogs updated with detailed migration and breaking change notes.
  - Updated Discord invite links and improved documentation comments.
  - Added new README and LICENSE files for internal tooling.

- **Chores**
  - Removed all local path dependency overrides and Melos configuration.
  - Cleaned up and standardized analysis/lint configurations.
  - Extensive code formatting and style improvements in generated and source files.

This release contains significant breaking changes and internal refactoring. Please review migration guides and changelogs before upgrading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->