### PR TITLE
Make all providers internaly rely on AsyncValue

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,8 +4,8 @@ analyzer:
     strict-casts: true
     strict-inference: true
     strict-raw-types: true
-  plugins:
-    - custom_lint
+  # plugins:
+  #   - custom_lint
   errors:
     # Otherwise cause the import of all_lint_rules to warn because of some rules conflicts.
     # We explicitly enabled even conflicting rules and are fixing the conflict

--- a/examples/counter/lib/main.g.dart
+++ b/examples/counter/lib/main.g.dart
@@ -50,7 +50,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -63,7 +63,7 @@ abstract class _$Counter extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/examples/pub/lib/detail.g.dart
+++ b/examples/pub/lib/detail.g.dart
@@ -12,7 +12,7 @@ part of 'detail.dart';
 const fetchPackageDetailsProvider = FetchPackageDetailsFamily._();
 
 final class FetchPackageDetailsProvider
-    extends $FunctionalProvider<AsyncValue<Package>, FutureOr<Package>>
+    extends $FunctionalProvider<AsyncValue<Package>, Package, FutureOr<Package>>
     with $FutureModifier<Package>, $FutureProvider<Package> {
   const FetchPackageDetailsProvider._(
       {required FetchPackageDetailsFamily super.from,
@@ -87,7 +87,7 @@ final class FetchPackageDetailsFamily extends $Family
 const likedPackagesProvider = LikedPackagesProvider._();
 
 final class LikedPackagesProvider extends $FunctionalProvider<
-        AsyncValue<List<String>>, FutureOr<List<String>>>
+        AsyncValue<List<String>>, List<String>, FutureOr<List<String>>>
     with $FutureModifier<List<String>>, $FutureProvider<List<String>> {
   const LikedPackagesProvider._()
       : super(
@@ -121,7 +121,7 @@ String _$likedPackagesHash() => r'8debee8d8fa48334d1de21fa9bbf03224265d29d';
 const pubRepositoryProvider = PubRepositoryProvider._();
 
 final class PubRepositoryProvider
-    extends $FunctionalProvider<PubRepository, PubRepository>
+    extends $FunctionalProvider<PubRepository, PubRepository, PubRepository>
     with $Provider<PubRepository> {
   const PubRepositoryProvider._()
       : super(
@@ -151,7 +151,7 @@ final class PubRepositoryProvider
   Override overrideWithValue(PubRepository value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<PubRepository>(value),
+      providerOverride: $ValueProvider<PubRepository, PubRepository>(value),
     );
   }
 }
@@ -267,7 +267,8 @@ abstract class _$PackageMetrics extends $AsyncNotifier<PackageMetricsScore> {
     final created = build(
       packageName: _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<PackageMetricsScore>>;
+    final ref =
+        this.ref as $Ref<AsyncValue<PackageMetricsScore>, PackageMetricsScore>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<PackageMetricsScore>, PackageMetricsScore>,
         AsyncValue<PackageMetricsScore>,

--- a/examples/pub/lib/search.g.dart
+++ b/examples/pub/lib/search.g.dart
@@ -12,7 +12,7 @@ part of 'search.dart';
 const fetchPackagesProvider = FetchPackagesFamily._();
 
 final class FetchPackagesProvider extends $FunctionalProvider<
-        AsyncValue<List<Package>>, FutureOr<List<Package>>>
+        AsyncValue<List<Package>>, List<Package>, FutureOr<List<Package>>>
     with $FutureModifier<List<Package>>, $FutureProvider<List<Package>> {
   const FetchPackagesProvider._(
       {required FetchPackagesFamily super.from,

--- a/examples/stackoverflow/lib/common.g.dart
+++ b/examples/stackoverflow/lib/common.g.dart
@@ -19,7 +19,8 @@ const themeProvider = ThemeProvider._();
 ///
 /// This is unimplemented by default, and will be overridden inside [MaterialApp]
 /// with the current theme obtained using a [BuildContext].
-final class ThemeProvider extends $FunctionalProvider<ThemeData, ThemeData>
+final class ThemeProvider
+    extends $FunctionalProvider<ThemeData, ThemeData, ThemeData>
     with $Provider<ThemeData> {
   /// A Provider that exposes the current theme.
   ///
@@ -53,7 +54,7 @@ final class ThemeProvider extends $FunctionalProvider<ThemeData, ThemeData>
   Override overrideWithValue(ThemeData value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<ThemeData>(value),
+      providerOverride: $ValueProvider<ThemeData, ThemeData>(value),
     );
   }
 }

--- a/examples/stackoverflow/lib/question.g.dart
+++ b/examples/stackoverflow/lib/question.g.dart
@@ -63,7 +63,7 @@ Map<String, dynamic> _$QuestionToJson(_Question instance) => <String, dynamic>{
 const questionThemeProvider = QuestionThemeProvider._();
 
 final class QuestionThemeProvider
-    extends $FunctionalProvider<QuestionTheme, QuestionTheme>
+    extends $FunctionalProvider<QuestionTheme, QuestionTheme, QuestionTheme>
     with $Provider<QuestionTheme> {
   const QuestionThemeProvider._()
       : super(
@@ -93,7 +93,7 @@ final class QuestionThemeProvider
   Override overrideWithValue(QuestionTheme value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<QuestionTheme>(value),
+      providerOverride: $ValueProvider<QuestionTheme, QuestionTheme>(value),
     );
   }
 }
@@ -127,9 +127,10 @@ const currentQuestionProvider = CurrentQuestionProvider._();
 ///
 /// This is an optional step. Since scoping is a fairly advanced mechanism,
 /// it's entirely fine to simply pass the [Question] to [QuestionItem] directly.
-final class CurrentQuestionProvider
-    extends $FunctionalProvider<AsyncValue<Question>, AsyncValue<Question>>
-    with $Provider<AsyncValue<Question>> {
+final class CurrentQuestionProvider extends $FunctionalProvider<
+    AsyncValue<Question>,
+    AsyncValue<Question>,
+    AsyncValue<Question>> with $Provider<AsyncValue<Question>> {
   /// A scoped provider, exposing the current question used by [QuestionItem].
   ///
   /// This is used as a performance optimization to pass a [Question] to
@@ -171,7 +172,8 @@ final class CurrentQuestionProvider
   Override overrideWithValue(AsyncValue<Question> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<AsyncValue<Question>>(value),
+      providerOverride:
+          $ValueProvider<AsyncValue<Question>, AsyncValue<Question>>(value),
     );
   }
 }

--- a/examples/stackoverflow/lib/tag.g.dart
+++ b/examples/stackoverflow/lib/tag.g.dart
@@ -11,7 +11,8 @@ part of 'tag.dart';
 @ProviderFor(tagTheme)
 const tagThemeProvider = TagThemeProvider._();
 
-final class TagThemeProvider extends $FunctionalProvider<TagTheme, TagTheme>
+final class TagThemeProvider
+    extends $FunctionalProvider<TagTheme, TagTheme, TagTheme>
     with $Provider<TagTheme> {
   const TagThemeProvider._()
       : super(
@@ -45,7 +46,7 @@ final class TagThemeProvider extends $FunctionalProvider<TagTheme, TagTheme>
   Override overrideWithValue(TagTheme value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<TagTheme>(value),
+      providerOverride: $ValueProvider<TagTheme, TagTheme>(value),
     );
   }
 }

--- a/packages/flutter_riverpod/lib/src/core/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/core/consumer.dart
@@ -504,7 +504,7 @@ base class ConsumerStatefulElement extends StatefulElement
   }
 
   @override
-  bool exists(ProviderBase<Object?> provider) {
+  bool exists(ProviderBase<Object?, Object?> provider) {
     _assertNotDisposed();
     return ProviderScope.containerOf(this, listen: false).exists(provider);
   }
@@ -516,7 +516,7 @@ base class ConsumerStatefulElement extends StatefulElement
   }
 
   @override
-  StateT refresh<StateT>(Refreshable<StateT> provider) {
+  ValueT refresh<ValueT>(Refreshable<ValueT> provider) {
     _assertNotDisposed();
     return ProviderScope.containerOf(this, listen: false).refresh(provider);
   }
@@ -531,9 +531,9 @@ base class ConsumerStatefulElement extends StatefulElement
   }
 
   @override
-  ProviderSubscription<T> listenManual<T>(
-    ProviderListenable<T> provider,
-    void Function(T? previous, T next) listener, {
+  ProviderSubscription<ValueT> listenManual<ValueT>(
+    ProviderListenable<ValueT> provider,
+    void Function(ValueT? previous, ValueT next) listener, {
     void Function(Object error, StackTrace stackTrace)? onError,
     bool fireImmediately = false,
   }) {
@@ -544,17 +544,17 @@ base class ConsumerStatefulElement extends StatefulElement
     // be used inside initState.
     final container = ProviderScope.containerOf(this, listen: false);
 
-    final innerSubscription = container.listen<T>(
+    final innerSubscription = container.listen<ValueT>(
       provider,
       listener,
       onError: onError,
       fireImmediately: fireImmediately,
       // ignore: invalid_use_of_internal_member, from riverpod
-    ) as ProviderSubscriptionWithOrigin<T, Object?>;
+    ) as ProviderSubscriptionWithOrigin<ValueT, Object?, Object?>;
 
     // ignore: invalid_use_of_internal_member, from riverpod
-    late final ProviderSubscriptionView<T, Object?> sub;
-    sub = ProviderSubscriptionView<T, Object?>(
+    late final ProviderSubscriptionView<ValueT, Object?, Object?> sub;
+    sub = ProviderSubscriptionView<ValueT, Object?, Object?>(
       innerSubscription: innerSubscription,
       listener: (prev, next) {},
       onError: (error, stackTrace) {},

--- a/packages/flutter_riverpod/lib/src/core/widget_ref.dart
+++ b/packages/flutter_riverpod/lib/src/core/widget_ref.dart
@@ -143,7 +143,7 @@ abstract final class WidgetRef {
   ///   return Item.fromJson(json);
   /// });
   /// ```
-  bool exists(ProviderBase<Object?> provider);
+  bool exists(ProviderBase<Object?, Object?> provider);
 
   /// Listen to a provider and call `listener` whenever its value changes,
   /// without having to take care of removing the listener.

--- a/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
+++ b/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
@@ -69,8 +69,8 @@ import '../../builders.dart';
 /// {@endtemplate}
 @publicInLegacy
 final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
-    extends $FunctionalProvider<NotifierT, NotifierT>
-    with LegacyProviderMixin<NotifierT> {
+    extends $FunctionalProvider<NotifierT, NotifierT, NotifierT>
+    with LegacyProviderMixin<NotifierT, NotifierT> {
   /// {@macro riverpod.change_notifier_provider}
   ChangeNotifierProvider(
     this._createFn, {
@@ -121,7 +121,7 @@ final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
   /// This may happen if the provider is refreshed or one of its dependencies
   /// has changes.
   Refreshable<NotifierT> get notifier =>
-      ProviderElementProxy<NotifierT, NotifierT>(
+      ProviderElementProxy<NotifierT, NotifierT, NotifierT>(
         this,
         (element) {
           return (element as _ChangeNotifierProviderElement<NotifierT>)
@@ -146,7 +146,7 @@ final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
 
 /// The element of [ChangeNotifierProvider].
 class _ChangeNotifierProviderElement<NotifierT extends ChangeNotifier?>
-    extends $FunctionalProviderElement<NotifierT, NotifierT> {
+    extends $FunctionalProviderElement<NotifierT, NotifierT, NotifierT> {
   _ChangeNotifierProviderElement._(super.pointer);
 
   final _notifierNotifier = $ElementLense<NotifierT>();
@@ -197,8 +197,9 @@ class _ChangeNotifierProviderElement<NotifierT extends ChangeNotifier?>
 
 /// The [Family] of [ChangeNotifierProvider].
 @publicInMisc
-final class ChangeNotifierProviderFamily<NotifierT extends ChangeNotifier?, Arg>
-    extends FunctionalFamily<NotifierT, Arg, NotifierT,
+final class ChangeNotifierProviderFamily<NotifierT extends ChangeNotifier?,
+        ArgT>
+    extends FunctionalFamily<NotifierT, NotifierT, ArgT, NotifierT,
         ChangeNotifierProvider<NotifierT>> {
   /// The [Family] of [ChangeNotifierProvider].
   /// @nodoc

--- a/packages/riverpod/lib/src/core/async_value.dart
+++ b/packages/riverpod/lib/src/core/async_value.dart
@@ -7,7 +7,7 @@ import '../providers/future_provider.dart' show FutureProvider;
 import '../providers/stream_provider.dart' show StreamProvider;
 
 @internal
-extension AsyncTransition<StateT> on AsyncValue<StateT> {
+extension AsyncTransition<ValueT> on AsyncValue<ValueT> {
   AsyncValue<T> cast<T>() => _cast<T>();
 }
 
@@ -64,14 +64,14 @@ extension AsyncTransition<StateT> on AsyncValue<StateT> {
 @sealed
 @immutable
 @publicInRiverpodAndCodegen
-sealed class AsyncValue<StateT> {
+sealed class AsyncValue<ValueT> {
   const AsyncValue._();
 
   /// {@template async_value.data}
   /// Creates an [AsyncValue] with a data.
   /// {@endtemplate}
   // coverage:ignore-start
-  const factory AsyncValue.data(StateT value) = AsyncData<StateT>;
+  const factory AsyncValue.data(ValueT value) = AsyncData<ValueT>;
   // coverage:ignore-end
 
   /// {@template async_value.loading}
@@ -80,7 +80,7 @@ sealed class AsyncValue<StateT> {
   /// Prefer always using this constructor with the `const` keyword.
   /// {@endtemplate}
   // coverage:ignore-start
-  const factory AsyncValue.loading({num progress}) = AsyncLoading<StateT>;
+  const factory AsyncValue.loading({num progress}) = AsyncLoading<ValueT>;
   // coverage:ignore-end
 
   /// {@template async_value.error_ctor}
@@ -95,7 +95,7 @@ sealed class AsyncValue<StateT> {
   /// {@endtemplate}
   // coverage:ignore-start
   const factory AsyncValue.error(Object error, StackTrace stackTrace) =
-      AsyncError<StateT>;
+      AsyncError<ValueT>;
   // coverage:ignore-end
 
   /// Transforms a [Future] that may fail into something that is safe to read.
@@ -210,7 +210,7 @@ sealed class AsyncValue<StateT> {
   /// ```dart
   /// ref.watch(provider).unwrapPrevious().value;
   /// ```
-  StateT? get value;
+  ValueT? get value;
 
   /// The [error].
   Object? get error;
@@ -225,8 +225,8 @@ sealed class AsyncValue<StateT> {
   /// Finally if in loading state, throws a [StateError].
   ///
   /// This is typically used for when the UI assumes that [value] is always present.
-  StateT get requireValue {
-    if (hasValue) return value as StateT;
+  ValueT get requireValue {
+    if (hasValue) return value as ValueT;
     if (hasError) {
       throwProviderException(error!, stackTrace!);
     }
@@ -271,7 +271,7 @@ sealed class AsyncValue<StateT> {
   ///
   /// Note that an [AsyncData] may still be in loading/error state, such
   /// as during a pull-to-refresh.
-  AsyncData<StateT>? get asData {
+  AsyncData<ValueT>? get asData {
     return map(
       data: (d) => d,
       error: (e) => null,
@@ -284,7 +284,7 @@ sealed class AsyncValue<StateT> {
   ///
   /// Note that an [AsyncError] may still be in loading state, such
   /// as during a pull-to-refresh.
-  AsyncError<StateT>? get asError => map(
+  AsyncError<ValueT>? get asError => map(
         data: (_) => null,
         error: (e) => e,
         loading: (_) => null,
@@ -295,9 +295,9 @@ sealed class AsyncValue<StateT> {
   /// This allows reading the content of an [AsyncValue] in a type-safe way,
   /// without potentially ignoring to handle a case.
   R map<R>({
-    required R Function(AsyncData<StateT> data) data,
-    required R Function(AsyncError<StateT> error) error,
-    required R Function(AsyncLoading<StateT> loading) loading,
+    required R Function(AsyncData<ValueT> data) data,
+    required R Function(AsyncError<ValueT> error) error,
+    required R Function(AsyncLoading<ValueT> loading) loading,
   });
 
   /// Casts the [AsyncValue] to a different type.
@@ -307,7 +307,7 @@ sealed class AsyncValue<StateT> {
   ///
   /// For loading/error cases, creates a new [AsyncValue] with the corresponding
   /// generic type while preserving the error/stacktrace.
-  AsyncValue<R> whenData<R>(R Function(StateT value) cb) {
+  AsyncValue<R> whenData<R>(R Function(ValueT value) cb) {
     return map(
       data: (d) {
         try {
@@ -352,7 +352,7 @@ sealed class AsyncValue<StateT> {
     bool skipLoadingOnReload = false,
     bool skipLoadingOnRefresh = true,
     bool skipError = false,
-    R Function(StateT data)? data,
+    R Function(ValueT data)? data,
     R Function(Object error, StackTrace stackTrace)? error,
     R Function()? loading,
     required R Function() orElse,
@@ -398,7 +398,7 @@ sealed class AsyncValue<StateT> {
     bool skipLoadingOnReload = false,
     bool skipLoadingOnRefresh = true,
     bool skipError = false,
-    required R Function(StateT data) data,
+    required R Function(ValueT data) data,
     required R Function(Object error, StackTrace stackTrace) error,
     required R Function() loading,
   }) {
@@ -431,7 +431,7 @@ sealed class AsyncValue<StateT> {
     bool skipLoadingOnReload = false,
     bool skipLoadingOnRefresh = true,
     bool skipError = false,
-    R? Function(StateT data)? data,
+    R? Function(ValueT data)? data,
     R? Function(Object error, StackTrace stackTrace)? error,
     R? Function()? loading,
   }) {
@@ -448,9 +448,9 @@ sealed class AsyncValue<StateT> {
   /// Perform some actions based on the state of the [AsyncValue], or call orElse
   /// if the current state was not tested.
   R maybeMap<R>({
-    R Function(AsyncData<StateT> data)? data,
-    R Function(AsyncError<StateT> error)? error,
-    R Function(AsyncLoading<StateT> loading)? loading,
+    R Function(AsyncData<ValueT> data)? data,
+    R Function(AsyncError<ValueT> error)? error,
+    R Function(AsyncLoading<ValueT> loading)? loading,
     required R Function() orElse,
   }) {
     return map(
@@ -472,9 +472,9 @@ sealed class AsyncValue<StateT> {
   /// Perform some actions based on the state of the [AsyncValue], or return null
   /// if the current state wasn't tested.
   R? mapOrNull<R>({
-    R? Function(AsyncData<StateT> data)? data,
-    R? Function(AsyncError<StateT> error)? error,
-    R? Function(AsyncLoading<StateT> loading)? loading,
+    R? Function(AsyncData<ValueT> data)? data,
+    R? Function(AsyncError<ValueT> error)? error,
+    R? Function(AsyncLoading<ValueT> loading)? loading,
   }) {
     return map(
       data: (d) => data?.call(d),
@@ -495,24 +495,24 @@ sealed class AsyncValue<StateT> {
   /// or instead by [Ref.watch] (if false).
   /// This changes the default behavior of [when] and sets the [isReloading]/
   /// [isRefreshing] flags accordingly.
-  AsyncValue<StateT> copyWithPrevious(
-    AsyncValue<StateT> previous, {
+  AsyncValue<ValueT> copyWithPrevious(
+    AsyncValue<ValueT> previous, {
     bool isRefresh = true,
   });
 
   /// The opposite of [copyWithPrevious], reverting to the raw [AsyncValue]
   /// with no information on the previous state.
-  AsyncValue<StateT> unwrapPrevious() {
+  AsyncValue<ValueT> unwrapPrevious() {
     return map(
       data: (d) {
-        if (d.isLoading) return AsyncLoading<StateT>(progress: progress);
+        if (d.isLoading) return AsyncLoading<ValueT>(progress: progress);
         return AsyncData(d.value);
       },
       error: (e) {
-        if (e.isLoading) return AsyncLoading<StateT>(progress: progress);
+        if (e.isLoading) return AsyncLoading<ValueT>(progress: progress);
         return AsyncError(e.error, e.stackTrace);
       },
-      loading: (l) => AsyncLoading<StateT>(progress: progress),
+      loading: (l) => AsyncLoading<ValueT>(progress: progress),
     );
   }
 
@@ -529,13 +529,13 @@ sealed class AsyncValue<StateT> {
       if (isFromCache) 'isFromCache: $isFromCache',
     ].join(', ');
 
-    return '$_displayString<$StateT>($content)';
+    return '$_displayString<$ValueT>($content)';
   }
 
   @override
   bool operator ==(Object other) {
     return runtimeType == other.runtimeType &&
-        other is AsyncValue<StateT> &&
+        other is AsyncValue<ValueT> &&
         other.isLoading == isLoading &&
         other.hasValue == hasValue &&
         other.error == error &&
@@ -561,10 +561,10 @@ sealed class AsyncValue<StateT> {
 /// {@macro async_value.data}
 /// {@category Core}
 @publicInRiverpodAndCodegen
-final class AsyncData<StateT> extends AsyncValue<StateT> {
+final class AsyncData<ValueT> extends AsyncValue<ValueT> {
   /// {@macro async_value.data}
   const AsyncData(
-    StateT value, {
+    ValueT value, {
     /// @nodoc
     bool isFromCache = false,
   }) : this._(
@@ -598,7 +598,7 @@ final class AsyncData<StateT> extends AsyncValue<StateT> {
   final num? progress;
 
   @override
-  final StateT value;
+  final ValueT value;
 
   @override
   @override
@@ -612,16 +612,16 @@ final class AsyncData<StateT> extends AsyncValue<StateT> {
 
   @override
   R map<R>({
-    required R Function(AsyncData<StateT> data) data,
-    required R Function(AsyncError<StateT> error) error,
-    required R Function(AsyncLoading<StateT> loading) loading,
+    required R Function(AsyncData<ValueT> data) data,
+    required R Function(AsyncError<ValueT> error) error,
+    required R Function(AsyncLoading<ValueT> loading) loading,
   }) {
     return data(this);
   }
 
   @override
-  AsyncData<StateT> copyWithPrevious(
-    AsyncValue<StateT> previous, {
+  AsyncData<ValueT> copyWithPrevious(
+    AsyncValue<ValueT> previous, {
     bool isRefresh = true,
   }) {
     return this;
@@ -629,7 +629,7 @@ final class AsyncData<StateT> extends AsyncValue<StateT> {
 
   @override
   AsyncValue<R> _cast<R>() {
-    if (StateT == R) return this as AsyncValue<R>;
+    if (ValueT == R) return this as AsyncValue<R>;
     return AsyncData<R>._(
       value as R,
       isLoading: isLoading,
@@ -644,7 +644,7 @@ final class AsyncData<StateT> extends AsyncValue<StateT> {
 /// {@macro async_value.loading}
 /// {@category Core}
 @publicInRiverpodAndCodegen
-final class AsyncLoading<StateT> extends AsyncValue<StateT> {
+final class AsyncLoading<ValueT> extends AsyncValue<ValueT> {
   /// {@macro async_value.loading}
   const AsyncLoading({this.progress})
       : hasValue = false,
@@ -683,7 +683,7 @@ final class AsyncLoading<StateT> extends AsyncValue<StateT> {
   final num? progress;
 
   @override
-  final StateT? value;
+  final ValueT? value;
 
   @override
   final Object? error;
@@ -693,7 +693,7 @@ final class AsyncLoading<StateT> extends AsyncValue<StateT> {
 
   @override
   AsyncValue<R> _cast<R>() {
-    if (StateT == R) return this as AsyncValue<R>;
+    if (ValueT == R) return this as AsyncValue<R>;
     return AsyncLoading<R>._(
       hasValue: hasValue,
       value: value as R?,
@@ -706,16 +706,16 @@ final class AsyncLoading<StateT> extends AsyncValue<StateT> {
 
   @override
   R map<R>({
-    required R Function(AsyncData<StateT> data) data,
-    required R Function(AsyncError<StateT> error) error,
-    required R Function(AsyncLoading<StateT> loading) loading,
+    required R Function(AsyncData<ValueT> data) data,
+    required R Function(AsyncError<ValueT> error) error,
+    required R Function(AsyncLoading<ValueT> loading) loading,
   }) {
     return loading(this);
   }
 
   @override
-  AsyncValue<StateT> copyWithPrevious(
-    AsyncValue<StateT> previous, {
+  AsyncValue<ValueT> copyWithPrevious(
+    AsyncValue<ValueT> previous, {
     bool isRefresh = true,
   }) {
     if (isRefresh) {
@@ -772,7 +772,7 @@ final class AsyncLoading<StateT> extends AsyncValue<StateT> {
 /// {@macro async_value.error_ctor}
 /// {@category Core}
 @publicInRiverpodAndCodegen
-final class AsyncError<StateT> extends AsyncValue<StateT> {
+final class AsyncError<ValueT> extends AsyncValue<ValueT> {
   /// {@macro async_value.error_ctor}
   const AsyncError(Object error, StackTrace stackTrace)
       : this._(
@@ -809,7 +809,7 @@ final class AsyncError<StateT> extends AsyncValue<StateT> {
   final bool hasValue;
 
   @override
-  final StateT? value;
+  final ValueT? value;
 
   @override
   final Object error;
@@ -819,7 +819,7 @@ final class AsyncError<StateT> extends AsyncValue<StateT> {
 
   @override
   AsyncValue<R> _cast<R>() {
-    if (StateT == R) return this as AsyncValue<R>;
+    if (ValueT == R) return this as AsyncValue<R>;
     return AsyncError<R>._(
       error,
       stackTrace: stackTrace,
@@ -832,16 +832,16 @@ final class AsyncError<StateT> extends AsyncValue<StateT> {
 
   @override
   R map<R>({
-    required R Function(AsyncData<StateT> data) data,
-    required R Function(AsyncError<StateT> error) error,
-    required R Function(AsyncLoading<StateT> loading) loading,
+    required R Function(AsyncData<ValueT> data) data,
+    required R Function(AsyncError<ValueT> error) error,
+    required R Function(AsyncLoading<ValueT> loading) loading,
   }) {
     return error(this);
   }
 
   @override
-  AsyncError<StateT> copyWithPrevious(
-    AsyncValue<StateT> previous, {
+  AsyncError<ValueT> copyWithPrevious(
+    AsyncValue<ValueT> previous, {
     bool isRefresh = true,
   }) {
     return AsyncError._(

--- a/packages/riverpod/lib/src/core/family.dart
+++ b/packages/riverpod/lib/src/core/family.dart
@@ -80,8 +80,8 @@ base class $Family extends Family {
 typedef SetupFamilyOverride<Arg> = void Function(
   Arg argument,
   void Function({
-    required ProviderBase<Object?> origin,
-    required ProviderBase<Object?> override,
+    required ProviderBase<Object?, Object?> origin,
+    required ProviderBase<Object?, Object?> override,
   }),
 );
 
@@ -96,7 +96,7 @@ base mixin $FunctionalFamilyOverride<CreatedT, ArgT> on Family {
       from: this,
       createElement: (pointer) {
         final provider =
-            pointer.origin as $FunctionalProvider<Object?, CreatedT>;
+            pointer.origin as $FunctionalProvider<Object?, Object?, CreatedT>;
 
         return provider
             .$view(create: (ref) => create(ref, provider.argument as ArgT))
@@ -114,10 +114,11 @@ base mixin $FunctionalFamilyOverride<CreatedT, ArgT> on Family {
 @reopen
 base class FunctionalFamily< //
         StateT,
+        ValueT,
         ArgT,
         CreatedT,
-        ProviderT extends $FunctionalProvider<StateT, CreatedT>> extends Family
-    with $FunctionalFamilyOverride<CreatedT, ArgT> {
+        ProviderT extends $FunctionalProvider<StateT, ValueT, CreatedT>>
+    extends Family with $FunctionalFamilyOverride<CreatedT, ArgT> {
   /// A base implementation for [Family], used by the various providers to
   /// help them define a [Family].
   ///

--- a/packages/riverpod/lib/src/core/foundation.dart
+++ b/packages/riverpod/lib/src/core/foundation.dart
@@ -119,7 +119,7 @@ sealed class ProviderOrFamily implements ProviderListenableOrFamily {
 }
 
 extension on ProviderListenableOrFamily {
-  ProviderBase<Object?>? get debugListenedProvider {
+  ProviderBase<Object?, Object?>? get debugListenedProvider {
     final that = this;
     return switch (that) {
       ProviderBase() => that,
@@ -178,10 +178,10 @@ String shortHash(Object? object) {
 }
 
 @internal
-base mixin ProviderListenableWithOrigin<OutT, OriginT>
+base mixin ProviderListenableWithOrigin<OutT, OriginStateT, OriginValueT>
     on ProviderListenable<OutT> {
   @override
-  ProviderSubscriptionWithOrigin<OutT, OriginT> _addListener(
+  ProviderSubscriptionWithOrigin<OutT, OriginStateT, OriginValueT> _addListener(
     Node source,
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -194,7 +194,7 @@ base mixin ProviderListenableWithOrigin<OutT, OriginT>
   ProviderListenable<Selected> select<Selected>(
     Selected Function(OutT value) selector,
   ) {
-    return _ProviderSelector<OutT, Selected, OriginT>(
+    return _ProviderSelector<OutT, Selected, OriginStateT, OriginValueT>(
       provider: this,
       selector: selector,
     );

--- a/packages/riverpod/lib/src/core/modifiers/future.dart
+++ b/packages/riverpod/lib/src/core/modifiers/future.dart
@@ -16,17 +16,17 @@ typedef AsyncSubscription = ({
 /// Do not use.
 @internal
 @publicInCodegen
-mixin $AsyncClassModifier<StateT, CreatedT, ValueT>
-    on AnyNotifier<AsyncValue<StateT>, ValueT> {
+mixin $AsyncClassModifier<ValueT, CreatedT>
+    on AnyNotifier<AsyncValue<ValueT>, ValueT> {
   @visibleForTesting
   @protected
   @override
-  AsyncValue<StateT> get state;
+  AsyncValue<ValueT> get state;
 
   @visibleForTesting
   @protected
   @override
-  set state(AsyncValue<StateT> newState);
+  set state(AsyncValue<ValueT> newState);
 
   /// {@template riverpod.async_notifier.future}
   /// Obtains a [Future] that resolves with the first [state] value that is not
@@ -41,11 +41,11 @@ mixin $AsyncClassModifier<StateT, CreatedT, ValueT>
   /// {@endtemplate}
   @visibleForTesting
   @protected
-  Future<StateT> get future {
+  Future<ValueT> get future {
     final element = requireElement();
 
     element.flush();
-    return (element as FutureModifierElement<StateT>).futureNotifier.value;
+    return (element as FutureModifierElement<ValueT>).futureNotifier.value;
   }
 
   /// A function to update [state] from its previous value, while
@@ -64,12 +64,12 @@ mixin $AsyncClassModifier<StateT, CreatedT, ValueT>
   /// - [AsyncValue.guard], and alternate way to perform asynchronous operations.
   @visibleForTesting
   @protected
-  Future<StateT> update(
-    FutureOr<StateT> Function(StateT previousState) cb, {
-    FutureOr<StateT> Function(Object err, StackTrace stackTrace)? onError,
+  Future<ValueT> update(
+    FutureOr<ValueT> Function(ValueT previousState) cb, {
+    FutureOr<ValueT> Function(Object err, StackTrace stackTrace)? onError,
   }) async {
     final newState = await future.then(cb, onError: onError);
-    state = AsyncData<StateT>(newState);
+    state = AsyncData<ValueT>(newState);
     return newState;
   }
 }
@@ -78,7 +78,7 @@ mixin $AsyncClassModifier<StateT, CreatedT, ValueT>
 /// Do not use.
 @internal
 @publicInCodegen
-base mixin $FutureModifier<StateT> on ProviderBase<AsyncValue<StateT>> {
+base mixin $FutureModifier<ValueT> on ProviderBase<AsyncValue<ValueT>, ValueT> {
   /// Obtains the [Future] representing this provider.
   ///
   /// The instance of [Future] obtained may change over time. This typically
@@ -99,13 +99,13 @@ base mixin $FutureModifier<StateT> on ProviderBase<AsyncValue<StateT>> {
   ///   return await http.get('${configs.host}/products');
   /// });
   /// ```
-  Refreshable<Future<StateT>> get future => _future;
+  Refreshable<Future<ValueT>> get future => _future;
 
-  _ProviderRefreshable<Future<StateT>, AsyncValue<StateT>> get _future {
-    return ProviderElementProxy<Future<StateT>, AsyncValue<StateT>>(
+  _ProviderRefreshable<Future<ValueT>, AsyncValue<ValueT>, ValueT> get _future {
+    return ProviderElementProxy<Future<ValueT>, AsyncValue<ValueT>, ValueT>(
       this,
       (element) {
-        element as FutureModifierElement<StateT>;
+        element as FutureModifierElement<ValueT>;
 
         return element.futureNotifier;
       },
@@ -142,9 +142,9 @@ base mixin $FutureModifier<StateT> on ProviderBase<AsyncValue<StateT>> {
   /// ```
   /// {@endtemplate}
   ProviderListenable<Future<Output>> selectAsync<Output>(
-    Output Function(StateT data) selector,
+    Output Function(ValueT data) selector,
   ) {
-    return _AsyncSelector<StateT, Output, AsyncValue<StateT>>(
+    return _AsyncSelector<ValueT, Output, AsyncValue<ValueT>, ValueT>(
       selector: selector,
       provider: this,
       future: _future,
@@ -154,12 +154,12 @@ base mixin $FutureModifier<StateT> on ProviderBase<AsyncValue<StateT>> {
 
 @internal
 mixin FutureModifierClassElement<
-        NotifierT extends AnyNotifier<AsyncValue<StateT>, StateT>,
-        StateT,
+        NotifierT extends AnyNotifier<AsyncValue<ValueT>, ValueT>,
+        ValueT,
         CreatedT>
     on
-        FutureModifierElement<StateT>,
-        $ClassProviderElement<NotifierT, AsyncValue<StateT>, StateT, CreatedT> {
+        FutureModifierElement<ValueT>,
+        $ClassProviderElement<NotifierT, AsyncValue<ValueT>, ValueT, CreatedT> {
   @override
   void handleError(Ref ref, Object error, StackTrace stackTrace) {
     triggerRetry(error);
@@ -170,22 +170,23 @@ mixin FutureModifierClassElement<
 /// Mixin to help implement logic for listening to [Future]s/[Stream]s and setup
 /// `provider.future` + convert the object into an [AsyncValue].
 @internal
-mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
+mixin FutureModifierElement<ValueT>
+    on ProviderElement<AsyncValue<ValueT>, ValueT> {
   /// An observable for [FutureProvider.future].
   @internal
-  final futureNotifier = $ElementLense<Future<StateT>>();
-  Completer<StateT>? _futureCompleter;
-  Future<StateT>? _lastFuture;
+  final futureNotifier = $ElementLense<Future<ValueT>>();
+  Completer<ValueT>? _futureCompleter;
+  Future<ValueT>? _lastFuture;
   AsyncSubscription? _cancelSubscription;
 
   @override
   void initState(Ref ref) {
-    onLoading(AsyncLoading<StateT>(), seamless: !ref.isReload);
+    onLoading(AsyncLoading<ValueT>(), seamless: !ref.isReload);
   }
 
   @override
   void mount() {
-    _stateResult = $ResultData(AsyncLoading<StateT>());
+    _stateResult = $ResultData(AsyncLoading<ValueT>());
     super.mount();
   }
 
@@ -195,7 +196,7 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
   /// - seamless:true => import previous state and skip loading
   /// - seamless:false => import previous state and prefer loading
   void asyncTransition(
-    AsyncValue<StateT> newState, {
+    AsyncValue<ValueT> newState, {
     required bool seamless,
   }) {
     final previous = stateResult?.requireState;
@@ -206,7 +207,7 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
       super.setStateResult(
         $ResultData(
           newState
-              .cast<StateT>()
+              .cast<ValueT>()
               .copyWithPrevious(previous, isRefresh: seamless),
         ),
       );
@@ -215,7 +216,7 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
 
   @override
   @protected
-  void setStateResult($Result<AsyncValue<StateT>> newState) {
+  void setStateResult($Result<AsyncValue<ValueT>> newState) {
     newState.requireState.map(
       loading: onLoading,
       error: onError,
@@ -224,7 +225,7 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
   }
 
   @internal
-  void onLoading(AsyncLoading<StateT> value, {bool seamless = false}) {
+  void onLoading(AsyncLoading<ValueT> value, {bool seamless = false}) {
     asyncTransition(value, seamless: seamless);
     if (_futureCompleter == null) {
       final completer = _futureCompleter = Completer();
@@ -237,7 +238,7 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
   /// Might be invoked after the element is disposed in the case where `provider.future`
   /// has yet to complete.
   @internal
-  void onError(AsyncError<StateT> value, {bool seamless = false}) {
+  void onError(AsyncError<ValueT> value, {bool seamless = false}) {
     asyncTransition(value, seamless: seamless);
 
     for (final observer in container.observers) {
@@ -273,7 +274,7 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
   /// Might be invoked after the element is disposed in the case where `provider.future`
   /// has yet to complete.
   @internal
-  void onData(AsyncData<StateT> value, {bool seamless = false}) {
+  void onData(AsyncData<ValueT> value, {bool seamless = false}) {
     asyncTransition(value, seamless: seamless);
 
     final completer = _futureCompleter;
@@ -288,7 +289,7 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
   /// Listens to a [Stream] and convert it into an [AsyncValue].
   @preferInline
   @internal
-  WhenComplete handleStream(Ref ref, Stream<StateT> Function() create) {
+  WhenComplete handleStream(Ref ref, Stream<ValueT> Function() create) {
     return _handleAsync(ref, ({
       required data,
       required done,
@@ -297,7 +298,7 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
     }) {
       final stream = create();
 
-      late StreamSubscription<StateT> subscription;
+      late StreamSubscription<ValueT> subscription;
       subscription = stream.listen(data, onError: error, onDone: done);
 
       final asyncSub = (
@@ -337,7 +338,7 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
   @internal
   WhenComplete handleFuture(
     Ref ref,
-    FutureOr<StateT> Function() create,
+    FutureOr<ValueT> Function() create,
   ) {
     return _handleAsync(ref, ({
       required data,
@@ -346,7 +347,7 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
       required last,
     }) {
       final futureOr = create();
-      if (futureOr is! Future<StateT>) {
+      if (futureOr is! Future<ValueT>) {
         data(futureOr);
         done();
         return null;
@@ -389,10 +390,10 @@ mixin FutureModifierElement<StateT> on ProviderElement<AsyncValue<StateT>> {
   WhenComplete _handleAsync(
     Ref ref,
     AsyncSubscription? Function({
-      required void Function(StateT) data,
+      required void Function(ValueT) data,
       required void Function(Object, StackTrace) error,
       required void Function() done,
-      required void Function(Future<StateT>) last,
+      required void Function(Future<ValueT>) last,
     }) listen,
   ) {
     void callOnError(Object error, StackTrace stackTrace) {

--- a/packages/riverpod/lib/src/core/modifiers/select.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select.dart
@@ -1,10 +1,10 @@
 part of '../../framework.dart';
 
 /// An internal class for `ProviderBase.select`.
-final class _ProviderSelector<InputT, OutputT, OriginT>
+final class _ProviderSelector<InputT, OutputT, OriginStateT, OriginValueT>
     with
         ProviderListenable<OutputT>,
-        ProviderListenableWithOrigin<OutputT, OriginT> {
+        ProviderListenableWithOrigin<OutputT, OriginStateT, OriginValueT> {
   /// An internal class for `ProviderBase.select`.
   _ProviderSelector({
     required this.provider,
@@ -12,7 +12,8 @@ final class _ProviderSelector<InputT, OutputT, OriginT>
   });
 
   /// The provider that was selected
-  final ProviderListenableWithOrigin<InputT, OriginT> provider;
+  final ProviderListenableWithOrigin<InputT, OriginStateT, OriginValueT>
+      provider;
 
   /// The selector applied
   final OutputT Function(InputT) selector;
@@ -56,7 +57,8 @@ final class _ProviderSelector<InputT, OutputT, OriginT>
   }
 
   @override
-  ProviderSubscriptionWithOrigin<OutputT, OriginT> _addListener(
+  ProviderSubscriptionWithOrigin<OutputT, OriginStateT, OriginValueT>
+      _addListener(
     Node node,
     void Function(OutputT? previous, OutputT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -64,7 +66,8 @@ final class _ProviderSelector<InputT, OutputT, OriginT>
     required bool fireImmediately,
     required bool weak,
   }) {
-    late final ProviderSubscriptionView<OutputT, OriginT> providerSub;
+    late final ProviderSubscriptionView<OutputT, OriginStateT, OriginValueT>
+        providerSub;
     $Result<OutputT>? lastSelectedValue;
     final sub = provider._addListener(
       node,
@@ -96,7 +99,7 @@ final class _ProviderSelector<InputT, OutputT, OriginT>
       );
     }
 
-    providerSub = ProviderSubscriptionView<OutputT, OriginT>(
+    providerSub = ProviderSubscriptionView<OutputT, OriginStateT, OriginValueT>(
       innerSubscription: sub,
       listener: listener,
       onError: onError,

--- a/packages/riverpod/lib/src/core/modifiers/select_async.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select_async.dart
@@ -1,10 +1,11 @@
 part of '../../framework.dart';
 
 /// An internal class for `ProviderBase.selectAsync`.
-final class _AsyncSelector<InputT, OutputT, OriginT>
+final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
     with
         ProviderListenable<Future<OutputT>>,
-        ProviderListenableWithOrigin<Future<OutputT>, OriginT> {
+        ProviderListenableWithOrigin<Future<OutputT>, OriginStateT,
+            OriginValueT> {
   /// An internal class for `ProviderBase.select`.
   _AsyncSelector({
     required this.provider,
@@ -13,10 +14,12 @@ final class _AsyncSelector<InputT, OutputT, OriginT>
   });
 
   /// The provider that was selected
-  final ProviderListenableWithOrigin<AsyncValue<InputT>, OriginT> provider;
+  final ProviderListenableWithOrigin<AsyncValue<InputT>, OriginStateT,
+      OriginValueT> provider;
 
   /// The future associated to the listened provider
-  final ProviderListenableWithOrigin<Future<InputT>, OriginT> future;
+  final ProviderListenableWithOrigin<Future<InputT>, OriginStateT, OriginValueT>
+      future;
 
   /// The selector applied
   final OutputT Function(InputT) selector;
@@ -34,7 +37,8 @@ final class _AsyncSelector<InputT, OutputT, OriginT>
   }
 
   @override
-  ProviderSubscriptionWithOrigin<Future<OutputT>, OriginT> _addListener(
+  ProviderSubscriptionWithOrigin<Future<OutputT>, OriginStateT, OriginValueT>
+      _addListener(
     Node node,
     void Function(Future<OutputT>? previous, Future<OutputT> next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -42,7 +46,8 @@ final class _AsyncSelector<InputT, OutputT, OriginT>
     required bool fireImmediately,
     required bool weak,
   }) {
-    late final ProviderSubscriptionView<Future<OutputT>, OriginT> providerSub;
+    late final ProviderSubscriptionView<Future<OutputT>, OriginStateT,
+        OriginValueT> providerSub;
 
     $Result<OutputT>? lastSelectedValue;
     Completer<OutputT>? selectedCompleter;
@@ -155,7 +160,8 @@ final class _AsyncSelector<InputT, OutputT, OriginT>
       listener(null, selectedFuture!);
     }
 
-    return providerSub = ProviderSubscriptionView<Future<OutputT>, OriginT>(
+    return providerSub =
+        ProviderSubscriptionView<Future<OutputT>, OriginStateT, OriginValueT>(
       innerSubscription: sub,
       listener: listener,
       onError: onError,

--- a/packages/riverpod/lib/src/core/override.dart
+++ b/packages/riverpod/lib/src/core/override.dart
@@ -12,7 +12,7 @@ sealed class _ProviderOverride implements Override {}
 
 extension on _ProviderOverride {
   /// The provider that is overridden.
-  ProviderBase<Object?> get origin {
+  ProviderBase<Object?, Object?> get origin {
     final that = this;
     return switch (that) {
       ProviderBase() => that,
@@ -21,7 +21,7 @@ extension on _ProviderOverride {
   }
 
   /// The new provider behavior.
-  ProviderBase<Object?> get providerOverride {
+  ProviderBase<Object?, Object?> get providerOverride {
     final that = this;
     return switch (that) {
       ProviderBase() => that,
@@ -61,10 +61,10 @@ class $ProviderOverride implements _ProviderOverride {
   });
 
   /// The provider that is overridden.
-  final ProviderBase<Object?> origin;
+  final ProviderBase<Object?, Object?> origin;
 
   /// The new provider behavior.
-  final ProviderBase<Object?> providerOverride;
+  final ProviderBase<Object?, Object?> providerOverride;
 
   @mustBeOverridden
   @override
@@ -84,10 +84,10 @@ class TransitiveProviderOverride implements $ProviderOverride {
   TransitiveProviderOverride(this.origin);
 
   @override
-  final ProviderBase<Object?> origin;
+  final ProviderBase<Object?, Object?> origin;
 
   @override
-  ProviderBase<Object?> get providerOverride => origin;
+  ProviderBase<Object?, Object?> get providerOverride => origin;
 
   @override
   String toString() => '$origin';

--- a/packages/riverpod/lib/src/core/override_with_value.dart
+++ b/packages/riverpod/lib/src/core/override_with_value.dart
@@ -4,8 +4,8 @@ part of '../framework.dart';
 ///
 /// This is an implementation detail of `overrideWithValue`.
 @publicInCodegen
-final class $ValueProvider<StateT> extends ProviderBase<StateT>
-    with LegacyProviderMixin<StateT> {
+final class $ValueProvider<StateT, ValueT> extends ProviderBase<StateT, ValueT>
+    with LegacyProviderMixin<StateT, ValueT> {
   /// Creates a [$ValueProvider].
   const $ValueProvider(this._value)
       : super(
@@ -30,13 +30,16 @@ final class $ValueProvider<StateT> extends ProviderBase<StateT>
   @internal
   @override
   // ignore: library_private_types_in_public_api, not public API
-  _ValueProviderElement<StateT> $createElement($ProviderPointer pointer) {
+  _ValueProviderElement<StateT, ValueT> $createElement(
+    $ProviderPointer pointer,
+  ) {
     return _ValueProviderElement(this, pointer);
   }
 }
 
 /// The [ProviderElement] of a [$ValueProvider]
-class _ValueProviderElement<StateT> extends ProviderElement<StateT> {
+class _ValueProviderElement<StateT, ValueT>
+    extends ProviderElement<StateT, ValueT> {
   /// The [ProviderElement] of a [$ValueProvider]
   _ValueProviderElement(this.provider, super.pointer);
 
@@ -45,10 +48,10 @@ class _ValueProviderElement<StateT> extends ProviderElement<StateT> {
   void Function(StateT value)? onChange;
 
   @override
-  $ValueProvider<StateT> provider;
+  $ValueProvider<StateT, ValueT> provider;
 
   @override
-  void update(covariant $ValueProvider<StateT> newProvider) {
+  void update(covariant $ValueProvider<StateT, ValueT> newProvider) {
     super.update(newProvider);
     provider = newProvider;
     final newValue = provider._value;
@@ -82,28 +85,28 @@ class _ValueProviderElement<StateT> extends ProviderElement<StateT> {
 }
 
 @internal
-final class $AsyncValueProvider<StateT>
-    extends $ValueProvider<AsyncValue<StateT>> {
+final class $AsyncValueProvider<ValueT>
+    extends $ValueProvider<AsyncValue<ValueT>, ValueT> {
   const $AsyncValueProvider(super._value);
 
   /// @nodoc
   @internal
   @override
   // ignore: library_private_types_in_public_api, not public API
-  _AsyncValueProviderElement<StateT> $createElement(
+  _AsyncValueProviderElement<ValueT> $createElement(
     $ProviderPointer pointer,
   ) {
     return _AsyncValueProviderElement(this, pointer);
   }
 }
 
-class _AsyncValueProviderElement<StateT>
-    extends _ValueProviderElement<AsyncValue<StateT>>
-    with FutureModifierElement<StateT> {
+class _AsyncValueProviderElement<ValueT>
+    extends _ValueProviderElement<AsyncValue<ValueT>, ValueT>
+    with FutureModifierElement<ValueT> {
   _AsyncValueProviderElement(super.provider, super.pointer);
 
   @override
-  void _setValue(AsyncValue<StateT> value) {
+  void _setValue(AsyncValue<ValueT> value) {
     switch (value) {
       case AsyncData():
         onData(value, seamless: true);

--- a/packages/riverpod/lib/src/core/provider/functional_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/functional_provider.dart
@@ -7,8 +7,9 @@ part of '../../framework.dart';
 @publicInCodegen
 abstract base class $FunctionalProvider< //
         StateT,
+        ValueT,
         CreatedT> //
-    extends ProviderBase<StateT> {
+    extends ProviderBase<StateT, ValueT> {
   /// Implementation detail of `riverpod_generator`.
   /// Do not use, as this can be removed at any time.
   const $FunctionalProvider({
@@ -23,10 +24,10 @@ abstract base class $FunctionalProvider< //
 
   /// @nodoc
   @internal
-  $FunctionalProvider<StateT, CreatedT> $view({
+  $FunctionalProvider<StateT, ValueT, CreatedT> $view({
     required Create<CreatedT> create,
   }) {
-    return _FunctionalProviderView.$FunctionalView(this, create);
+    return _FunctionalProviderView(this, create);
   }
 
   /// {@template riverpod.override_with}
@@ -77,16 +78,16 @@ abstract base class $FunctionalProvider< //
   /// @nodoc
   @internal
   @override
-  $FunctionalProviderElement<StateT, CreatedT> $createElement(
+  $FunctionalProviderElement<StateT, ValueT, CreatedT> $createElement(
     $ProviderPointer pointer,
   );
 }
 
-final class _FunctionalProviderView<StateT, CreatedT> //
-    extends $FunctionalProvider<StateT, CreatedT> {
+final class _FunctionalProviderView<StateT, ValueT, CreatedT> //
+    extends $FunctionalProvider<StateT, ValueT, CreatedT> {
   /// Implementation detail of `riverpod_generator`.
   /// Do not use, as this can be removed at any time.
-  _FunctionalProviderView.$FunctionalView(
+  _FunctionalProviderView(
     this._inner,
     this._createOverride,
   ) : super(
@@ -99,7 +100,7 @@ final class _FunctionalProviderView<StateT, CreatedT> //
           retry: _inner.retry,
         );
 
-  final $FunctionalProvider<StateT, CreatedT> _inner;
+  final $FunctionalProvider<StateT, ValueT, CreatedT> _inner;
   final Create<CreatedT> _createOverride;
 
   @override
@@ -108,7 +109,7 @@ final class _FunctionalProviderView<StateT, CreatedT> //
   /// @nodoc
   @internal
   @override
-  $FunctionalProviderElement<StateT, CreatedT> $createElement(
+  $FunctionalProviderElement<StateT, ValueT, CreatedT> $createElement(
     $ProviderPointer pointer,
   ) {
     return _inner.$createElement(pointer)..provider = this;
@@ -119,13 +120,14 @@ final class _FunctionalProviderView<StateT, CreatedT> //
 }
 
 @internal
-abstract class $FunctionalProviderElement<StateT, CreatedT>
-    extends ProviderElement<StateT> {
+abstract class $FunctionalProviderElement<StateT, ValueT, CreatedT>
+    extends ProviderElement<StateT, ValueT> {
   /// Implementation detail of `riverpod_generator`.
   /// Do not use, as this can be removed at any time.
   $FunctionalProviderElement(super.pointer)
-      : provider = pointer.origin as $FunctionalProvider<StateT, CreatedT>;
+      : provider =
+            pointer.origin as $FunctionalProvider<StateT, ValueT, CreatedT>;
 
   @override
-  $FunctionalProvider<StateT, CreatedT> provider;
+  $FunctionalProvider<StateT, ValueT, CreatedT> provider;
 }

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -303,15 +303,15 @@ abstract class $AsyncNotifierBase<ValueT>
 }
 
 @internal
-abstract class $SyncNotifierBase<StateT> with AnyNotifier<StateT, StateT> {
+abstract class $SyncNotifierBase<ValueT> with AnyNotifier<ValueT, ValueT> {
   @override
-  void _setStateFromValue(StateT value) => state = value;
+  void _setStateFromValue(ValueT value) => state = value;
 
   @override
   FutureOr<void> _callEncode<KeyT, EncodedT>(
     FutureOr<Storage<KeyT, EncodedT>> storage,
     KeyT key,
-    EncodedT Function(StateT state) encode,
+    EncodedT Function(ValueT state) encode,
     StorageOptions options,
   ) {
     return storage
@@ -338,7 +338,7 @@ extension ClassBaseX<StateT, ValueT> on AnyNotifier<StateT, ValueT> {
 
   @internal
   // ignore: library_private_types_in_public_api, not public
-  $Ref<StateT> get $ref {
+  $Ref<StateT, ValueT> get $ref {
     final ref = _element?.ref;
     if (ref == null) throw StateError(uninitializedElementError);
 
@@ -355,7 +355,7 @@ abstract base class $ClassProvider< //
     NotifierT extends AnyNotifier<StateT, ValueT>,
     StateT,
     ValueT,
-    CreatedT> extends ProviderBase<StateT> {
+    CreatedT> extends ProviderBase<StateT, ValueT> {
   const $ClassProvider({
     required super.name,
     required super.from,
@@ -367,7 +367,7 @@ abstract base class $ClassProvider< //
   });
 
   Refreshable<NotifierT> get notifier {
-    return ProviderElementProxy<NotifierT, StateT>(
+    return ProviderElementProxy<NotifierT, StateT, ValueT>(
       this,
       (element) => (element
               as $ClassProviderElement<NotifierT, StateT, ValueT, CreatedT>)
@@ -481,7 +481,7 @@ abstract class $ClassProviderElement< //
         StateT,
         ValueT,
         CreatedT> //
-    extends ProviderElement<StateT> {
+    extends ProviderElement<StateT, ValueT> {
   $ClassProviderElement(super.pointer)
       : provider = pointer.origin
             as $ClassProvider<NotifierT, StateT, ValueT, CreatedT>;
@@ -496,7 +496,7 @@ abstract class $ClassProviderElement< //
   @override
   WhenComplete create(
     // ignore: library_private_types_in_public_api, not public
-    $Ref<StateT> ref,
+    $Ref<StateT, ValueT> ref,
   ) {
     final result = classListenable.result ??= $Result.guard(() {
       final notifier = provider.create();

--- a/packages/riverpod/lib/src/core/provider/provider.dart
+++ b/packages/riverpod/lib/src/core/provider/provider.dart
@@ -22,10 +22,10 @@ typedef OnError = void Function(Object error, StackTrace stackTrace);
 /// A base class for _all_ providers.
 @immutable
 @publicInMisc
-abstract final class ProviderBase<StateT> extends ProviderOrFamily
+abstract final class ProviderBase<StateT, ValueT> extends ProviderOrFamily
     with
         ProviderListenable<StateT>,
-        ProviderListenableWithOrigin<StateT, StateT>
+        ProviderListenableWithOrigin<StateT, StateT, ValueT>
     implements Refreshable<StateT>, _ProviderOverride {
   /// A base class for _all_ providers.
   const ProviderBase({
@@ -52,7 +52,7 @@ abstract final class ProviderBase<StateT> extends ProviderOrFamily
   final Object? argument;
 
   @override
-  ProviderSubscriptionWithOrigin<StateT, StateT> _addListener(
+  ProviderSubscriptionWithOrigin<StateT, StateT, ValueT> _addListener(
     Node source,
     void Function(StateT? previous, StateT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -78,7 +78,7 @@ abstract final class ProviderBase<StateT> extends ProviderOrFamily
       );
     }
 
-    return ProviderStateSubscription<StateT>(
+    return ProviderStateSubscription<StateT, ValueT>(
       source: source,
       listenedElement: element,
       weak: weak,
@@ -90,7 +90,7 @@ abstract final class ProviderBase<StateT> extends ProviderOrFamily
   /// An internal method that defines how a provider behaves.
   /// @nodoc
   @visibleForOverriding
-  ProviderElement<StateT> $createElement($ProviderPointer pointer);
+  ProviderElement<StateT, ValueT> $createElement($ProviderPointer pointer);
 
   /// A debug-only function for obtaining a hash of the source code of the
   /// initialization function.
@@ -125,7 +125,7 @@ abstract final class ProviderBase<StateT> extends ProviderOrFamily
 
 /// A mixin that implements some methods for non-generic providers.
 @internal
-base mixin LegacyProviderMixin<StateT> on ProviderBase<StateT> {
+base mixin LegacyProviderMixin<StateT, ValueT> on ProviderBase<StateT, ValueT> {
   @override
   int get hashCode {
     if (from == null) return super.hashCode;
@@ -138,7 +138,7 @@ base mixin LegacyProviderMixin<StateT> on ProviderBase<StateT> {
     if (from == null) return identical(other, this);
 
     return other.runtimeType == runtimeType &&
-        other is ProviderBase<StateT> &&
+        other is ProviderBase<StateT, ValueT> &&
         other.from == from &&
         other.argument == argument;
   }

--- a/packages/riverpod/lib/src/core/provider_subscription.dart
+++ b/packages/riverpod/lib/src/core/provider_subscription.dart
@@ -52,10 +52,10 @@ sealed class ProviderSubscription<OutT> {
 }
 
 @internal
-sealed class ProviderSubscriptionWithOrigin<OutT, StateT>
+sealed class ProviderSubscriptionWithOrigin<OutT, StateT, ValueT>
     extends ProviderSubscription<OutT> implements Pausable {
-  ProviderBase<StateT> get origin;
-  ProviderElement<StateT> get _listenedElement;
+  ProviderBase<StateT, ValueT> get origin;
+  ProviderElement<StateT, ValueT> get _listenedElement;
 
   void _onOriginData(StateT? prev, StateT next);
   void _onOriginError(Object error, StackTrace stackTrace);
@@ -77,8 +77,9 @@ sealed class ProviderSubscriptionWithOrigin<OutT, StateT>
 }
 
 @internal
-abstract base class ProviderSubscriptionImpl<OutT, OriginT>
-    extends ProviderSubscriptionWithOrigin<OutT, OriginT> with _OnPauseMixin {
+abstract base class ProviderSubscriptionImpl<OutT, OriginT, ValueT>
+    extends ProviderSubscriptionWithOrigin<OutT, OriginT, ValueT>
+    with _OnPauseMixin {
   @override
   bool get isPaused => _isPaused;
 
@@ -195,8 +196,8 @@ mixin _OnPauseMixin on Pausable {
 }
 
 @internal
-base class ProviderSubscriptionView<OutT, OriginT>
-    extends ProviderSubscriptionImpl<OutT, OriginT> {
+base class ProviderSubscriptionView<OutT, OriginStateT, OriginValueT>
+    extends ProviderSubscriptionImpl<OutT, OriginStateT, OriginValueT> {
   ProviderSubscriptionView({
     required this.innerSubscription,
     required OutT Function() read,
@@ -209,7 +210,8 @@ base class ProviderSubscriptionView<OutT, OriginT>
         _errorListener = onError ??
             innerSubscription._listenedElement.container.defaultOnError;
 
-  final ProviderSubscriptionWithOrigin<Object?, OriginT> innerSubscription;
+  final ProviderSubscriptionWithOrigin<Object?, OriginStateT, OriginValueT>
+      innerSubscription;
   final OutT Function() _read;
   final void Function()? _onClose;
 
@@ -220,10 +222,11 @@ base class ProviderSubscriptionView<OutT, OriginT>
   final void Function(OutT? prev, OutT next) _listener;
 
   @override
-  ProviderBase<OriginT> get origin => innerSubscription.origin;
+  ProviderBase<OriginStateT, OriginValueT> get origin =>
+      innerSubscription.origin;
 
   @override
-  ProviderElement<OriginT> get _listenedElement =>
+  ProviderElement<OriginStateT, OriginValueT> get _listenedElement =>
       innerSubscription._listenedElement;
 
   @override
@@ -233,7 +236,7 @@ base class ProviderSubscriptionView<OutT, OriginT>
   Node get source => innerSubscription.source;
 
   @override
-  void _onOriginData(OriginT? prev, OriginT next) {
+  void _onOriginData(OriginStateT? prev, OriginStateT next) {
     innerSubscription._onOriginData(prev, next);
   }
 
@@ -274,16 +277,17 @@ base class ProviderSubscriptionView<OutT, OriginT>
 }
 
 @internal
-final class DelegatingProviderSubscription<OutT, InT, OriginT>
-    extends ProviderSubscriptionImpl<OutT, OriginT> {
+final class DelegatingProviderSubscription<OutT, InT, OriginStateT,
+        OriginValueT>
+    extends ProviderSubscriptionImpl<OutT, OriginStateT, OriginValueT> {
   DelegatingProviderSubscription({
     required this.origin,
     required this.source,
     required this.weak,
     required OnError? errorListener,
-    required ProviderElement<OriginT> listenedElement,
+    required ProviderElement<OriginStateT, OriginValueT> listenedElement,
     required void Function(OutT? prev, OutT next) listener,
-    void Function(OriginT? prev, OriginT next)? onOriginData,
+    void Function(OriginStateT? prev, OriginStateT next)? onOriginData,
     void Function(Object error, StackTrace stackTrace)? onOriginError,
     required OutT Function() read,
     required void Function()? onClose,
@@ -296,7 +300,7 @@ final class DelegatingProviderSubscription<OutT, InT, OriginT>
         _onCloseCb = onClose;
 
   @override
-  final ProviderBase<OriginT> origin;
+  final ProviderBase<OriginStateT, OriginValueT> origin;
   @override
   final Node source;
   @override
@@ -304,16 +308,16 @@ final class DelegatingProviderSubscription<OutT, InT, OriginT>
   @override
   final OnError _errorListener;
   @override
-  final ProviderElement<OriginT> _listenedElement;
+  final ProviderElement<OriginStateT, OriginValueT> _listenedElement;
   @override
   final void Function(OutT? prev, OutT next) _listener;
-  final void Function(OriginT? prev, OriginT next)? _onOriginDataCb;
+  final void Function(OriginStateT? prev, OriginStateT next)? _onOriginDataCb;
   final void Function(Object error, StackTrace stackTrace)? _onOriginErrorCb;
   final OutT Function() _readCb;
   final void Function()? _onCloseCb;
 
   @override
-  void _onOriginData(OriginT? prev, OriginT next) =>
+  void _onOriginData(OriginStateT? prev, OriginStateT next) =>
       _onOriginDataCb?.call(prev, next);
 
   @override
@@ -334,12 +338,12 @@ final class DelegatingProviderSubscription<OutT, InT, OriginT>
 
 /// When a provider listens to another provider using `listen`
 @internal
-final class ProviderStateSubscription<StateT>
-    extends ProviderSubscriptionImpl<StateT, StateT> {
+final class ProviderStateSubscription<StateT, ValueT>
+    extends ProviderSubscriptionImpl<StateT, StateT, ValueT> {
   ProviderStateSubscription({
     required this.source,
     required this.weak,
-    required ProviderElement<StateT> listenedElement,
+    required ProviderElement<StateT, ValueT> listenedElement,
     required void Function(StateT? prev, StateT next) listener,
     required OnError onError,
   })  : _listenedElement = listenedElement,
@@ -347,12 +351,12 @@ final class ProviderStateSubscription<StateT>
         _errorListener = onError;
 
   @override
-  ProviderBase<StateT> get origin => _listenedElement.origin;
+  ProviderBase<StateT, ValueT> get origin => _listenedElement.origin;
 
   @override
   final Node source;
   @override
-  final ProviderElement<StateT> _listenedElement;
+  final ProviderElement<StateT, ValueT> _listenedElement;
   @override
   final bool weak;
 

--- a/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
+++ b/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
@@ -2,17 +2,19 @@ part of '../framework.dart';
 
 @internal
 @publicInCodegen
-final class $LazyProxyListenable<OutT, OriginT>
-    with ProviderListenable<OutT>, ProviderListenableWithOrigin<OutT, OriginT> {
+final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
+    with
+        ProviderListenable<OutT>,
+        ProviderListenableWithOrigin<OutT, OriginStateT, OriginValueT> {
   $LazyProxyListenable(this.provider, this._lense);
 
-  final ProviderBase<OriginT> provider;
+  final ProviderBase<OriginStateT, OriginValueT> provider;
   final $ElementLense<OutT> Function(
-    ProviderElement<OriginT> element,
+    ProviderElement<OriginStateT, OriginValueT> element,
   ) _lense;
 
   @override
-  ProviderSubscriptionWithOrigin<OutT, OriginT> _addListener(
+  ProviderSubscriptionWithOrigin<OutT, OriginStateT, OriginValueT> _addListener(
     Node source,
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -35,14 +37,15 @@ final class $LazyProxyListenable<OutT, OriginT>
       }
     }
 
-    late final ProviderSubscriptionImpl<OutT, OriginT> sub;
+    late final ProviderSubscriptionImpl<OutT, OriginStateT, OriginValueT> sub;
     final removeListener = listenable.addListener(
       (a, b) => sub._notifyData(a, b),
       onError: onError,
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
     );
 
-    return sub = DelegatingProviderSubscription<OutT, OriginT, OriginT>(
+    return sub = DelegatingProviderSubscription<OutT, OriginStateT,
+        OriginStateT, OriginValueT>(
       listenedElement: element,
       source: source,
       weak: weak,
@@ -71,11 +74,11 @@ final class $LazyProxyListenable<OutT, OriginT>
 ///
 /// This API is not meant for public consumption.
 @internal
-final class ProviderElementProxy<OutT, OriginT>
+final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
     with
         ProviderListenable<OutT>,
-        ProviderListenableWithOrigin<OutT, OriginT>,
-        _ProviderRefreshable<OutT, OriginT> {
+        ProviderListenableWithOrigin<OutT, OriginStateT, OriginValueT>,
+        _ProviderRefreshable<OutT, OriginStateT, OriginValueT> {
   /// An internal utility for reading alternate values of a provider.
   ///
   /// For example, this is used by [FutureProvider] to differentiate:
@@ -100,13 +103,13 @@ final class ProviderElementProxy<OutT, OriginT>
   final bool flushElement;
 
   @override
-  final ProviderBase<OriginT> provider;
+  final ProviderBase<OriginStateT, OriginValueT> provider;
   final $ElementLense<OutT> Function(
-    ProviderElement<OriginT> element,
+    ProviderElement<OriginStateT, OriginValueT> element,
   ) _lense;
 
   @override
-  ProviderSubscriptionWithOrigin<OutT, OriginT> _addListener(
+  ProviderSubscriptionWithOrigin<OutT, OriginStateT, OriginValueT> _addListener(
     Node source,
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -144,14 +147,14 @@ final class ProviderElementProxy<OutT, OriginT>
       }
     }
 
-    late ProviderSubscriptionView<OutT, OriginT> sub;
+    late ProviderSubscriptionView<OutT, OriginStateT, OriginValueT> sub;
     final removeListener = notifier.addListener(
       (prev, next) => sub._notifyData(prev, next),
       onError: onError,
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
     );
 
-    return sub = ProviderSubscriptionView<OutT, OriginT>(
+    return sub = ProviderSubscriptionView<OutT, OriginStateT, OriginValueT>(
       innerSubscription: innerSub,
       onClose: removeListener,
       listener: listener,
@@ -168,7 +171,7 @@ final class ProviderElementProxy<OutT, OriginT>
 
   @override
   bool operator ==(Object other) =>
-      other is ProviderElementProxy<OutT, OriginT> &&
+      other is ProviderElementProxy<OutT, OriginStateT, OriginValueT> &&
       other.provider == provider;
 
   @override

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -14,7 +14,7 @@ extension $RefArg on Ref {
 class UnmountedRefException implements Exception {
   UnmountedRefException(this.origin);
 
-  final ProviderBase<Object?> origin;
+  final ProviderBase<Object?, Object?> origin;
 
   @override
   String toString() {
@@ -47,7 +47,7 @@ sealed class Ref {
     required this.isReload,
   });
 
-  ProviderElement<Object?> get _element;
+  ProviderElement<Object?, Object?> get _element;
   List<KeepAliveLink>? _keepAliveLinks;
   List<void Function()>? _onDisposeListeners;
   List<void Function()>? _onResumeListeners;
@@ -527,7 +527,7 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   /// });
   /// ```
   /// {@endtemplate}
-  bool exists(ProviderBase<Object?> provider) {
+  bool exists(ProviderBase<Object?, Object?> provider) {
     _throwIfInvalidUsage();
 
     final result = container.exists(provider);
@@ -677,7 +677,7 @@ void _runCallbacks(
 
 @internal
 @publicInCodegen
-class $Ref<StateT> extends Ref {
+class $Ref<StateT, ValueT> extends Ref {
   /// {@macro riverpod.provider_ref_base}
   $Ref(
     this._element, {
@@ -685,10 +685,10 @@ class $Ref<StateT> extends Ref {
     required super.isReload,
   }) : super._();
 
-  ProviderElement<StateT> get element => _element;
+  ProviderElement<StateT, ValueT> get element => _element;
 
   @override
-  final ProviderElement<StateT> _element;
+  final ProviderElement<StateT, ValueT> _element;
 
   List<void Function(StateT?, StateT)>? _onChangeSelfListeners;
   List<OnError>? _onErrorSelfListeners;

--- a/packages/riverpod/lib/src/providers/async_notifier.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier.dart
@@ -15,22 +15,22 @@ part 'async_notifier/family.dart';
 /// Implementation detail of `riverpod_generator`.
 /// Do not use.
 @publicInCodegen
-abstract class $AsyncNotifier<StateT> extends $AsyncNotifierBase<StateT>
-    with $AsyncClassModifier<StateT, FutureOr<StateT>, StateT> {}
+abstract class $AsyncNotifier<ValueT> extends $AsyncNotifierBase<ValueT>
+    with $AsyncClassModifier<ValueT, FutureOr<ValueT>> {}
 
 /// Implementation detail of `riverpod_generator`.
 /// Do not use.
 @publicInCodegen
 abstract base class $AsyncNotifierProvider< //
-        NotifierT extends $AsyncNotifier<StateT>,
-        StateT> //
+        NotifierT extends $AsyncNotifier<ValueT>,
+        ValueT> //
     extends $ClassProvider< //
         NotifierT,
-        AsyncValue<StateT>,
-        StateT,
-        FutureOr<StateT>> //
+        AsyncValue<ValueT>,
+        ValueT,
+        FutureOr<ValueT>> //
     with
-        $FutureModifier<StateT> {
+        $FutureModifier<ValueT> {
   /// Implementation detail of `riverpod_generator`.
   /// Do not use.
   const $AsyncNotifierProvider({
@@ -46,7 +46,7 @@ abstract base class $AsyncNotifierProvider< //
   /// @nodoc
   @internal
   @override
-  $AsyncNotifierProviderElement<NotifierT, StateT> $createElement(
+  $AsyncNotifierProviderElement<NotifierT, ValueT> $createElement(
     $ProviderPointer pointer,
   ) {
     return $AsyncNotifierProviderElement(pointer);
@@ -62,22 +62,22 @@ abstract base class $AsyncNotifierProvider< //
 @internal
 @publicInCodegen
 class $AsyncNotifierProviderElement< //
-        NotifierT extends $AsyncNotifier<StateT>,
-        StateT> //
+        NotifierT extends $AsyncNotifier<ValueT>,
+        ValueT> //
     extends $ClassProviderElement< //
         NotifierT,
-        AsyncValue<StateT>,
-        StateT,
-        FutureOr<StateT>> //
+        AsyncValue<ValueT>,
+        ValueT,
+        FutureOr<ValueT>> //
     with
-        FutureModifierElement<StateT>,
-        FutureModifierClassElement<NotifierT, StateT, FutureOr<StateT>> {
+        FutureModifierElement<ValueT>,
+        FutureModifierClassElement<NotifierT, ValueT, FutureOr<ValueT>> {
   /// Implementation detail of `riverpod_generator`.
   /// Do not use.
   $AsyncNotifierProviderElement(super.pointer);
 
   @override
-  void handleValue(Ref ref, FutureOr<StateT> created) {
+  void handleValue(Ref ref, FutureOr<ValueT> created) {
     handleFuture(ref, () => created);
   }
 }

--- a/packages/riverpod/lib/src/providers/async_notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/family.dart
@@ -34,16 +34,16 @@ abstract class FamilyAsyncNotifier<StateT, ArgT>
 /// @nodoc
 @publicInMisc
 final class AsyncNotifierProviderFamily< //
-        NotifierT extends FamilyAsyncNotifier<StateT, ArgT>,
-        StateT,
+        NotifierT extends FamilyAsyncNotifier<ValueT, ArgT>,
+        ValueT,
         ArgT> //
     extends ClassFamily< //
         NotifierT,
-        AsyncValue<StateT>,
-        StateT,
+        AsyncValue<ValueT>,
+        ValueT,
         ArgT,
-        FutureOr<StateT>,
-        FamilyAsyncNotifierProvider<NotifierT, StateT, ArgT>> {
+        FutureOr<ValueT>,
+        FamilyAsyncNotifierProvider<NotifierT, ValueT, ArgT>> {
   /// The [Family] of [AsyncNotifierProvider].
   /// @nodoc
   @internal
@@ -63,11 +63,11 @@ final class AsyncNotifierProviderFamily< //
 /// The provider returned by [AsyncNotifierProviderFamily].
 @publicInMisc
 final class FamilyAsyncNotifierProvider< //
-        NotifierT extends FamilyAsyncNotifier<StateT, ArgT>,
-        StateT,
+        NotifierT extends FamilyAsyncNotifier<ValueT, ArgT>,
+        ValueT,
         ArgT> //
-    extends $AsyncNotifierProvider<NotifierT, StateT>
-    with LegacyProviderMixin<AsyncValue<StateT>> {
+    extends $AsyncNotifierProvider<NotifierT, ValueT>
+    with LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
   /// An implementation detail of Riverpod
   const FamilyAsyncNotifierProvider._(
     this._createNotifier, {

--- a/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
@@ -60,10 +60,10 @@ abstract class AsyncNotifier<StateT> extends $AsyncNotifier<StateT> {
 /// {@endtemplate}
 /// {@category Providers}
 final class AsyncNotifierProvider< //
-        NotifierT extends AsyncNotifier<StateT>,
-        StateT> //
-    extends $AsyncNotifierProvider<NotifierT, StateT>
-    with LegacyProviderMixin<AsyncValue<StateT>> {
+        NotifierT extends AsyncNotifier<ValueT>,
+        ValueT> //
+    extends $AsyncNotifierProvider<NotifierT, ValueT>
+    with LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
   /// {@macro riverpod.async_notifier_provider}
   ///
   /// {@macro riverpod.async_notifier_provider_modifier}

--- a/packages/riverpod/lib/src/providers/future_provider.dart
+++ b/packages/riverpod/lib/src/providers/future_provider.dart
@@ -14,13 +14,13 @@ import 'stream_provider.dart' show StreamProvider;
 /// Do not use, as this may be removed at any time.
 @internal
 @publicInCodegen
-base mixin $FutureProvider<StateT>
-    on $FunctionalProvider<AsyncValue<StateT>, FutureOr<StateT>> {
+base mixin $FutureProvider<ValueT>
+    on $FunctionalProvider<AsyncValue<ValueT>, ValueT, FutureOr<ValueT>> {
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<StateT> value) {
+  Override overrideWithValue(AsyncValue<ValueT> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $AsyncValueProvider<StateT>(value),
+      providerOverride: $AsyncValueProvider<ValueT>(value),
     );
   }
 }
@@ -94,12 +94,12 @@ base mixin $FutureProvider<StateT>
 /// - [FutureProvider.autoDispose], to destroy the state of a [FutureProvider] when no longer needed.
 /// {@endtemplate}
 /// {@category Providers}
-final class FutureProvider<StateT>
-    extends $FunctionalProvider<AsyncValue<StateT>, FutureOr<StateT>>
+final class FutureProvider<ValueT>
+    extends $FunctionalProvider<AsyncValue<ValueT>, ValueT, FutureOr<ValueT>>
     with
-        $FutureModifier<StateT>,
-        $FutureProvider<StateT>,
-        LegacyProviderMixin<AsyncValue<StateT>> {
+        $FutureModifier<ValueT>,
+        $FutureProvider<ValueT>,
+        LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
   /// {@macro riverpod.future_provider}
   FutureProvider(
     this._create, {
@@ -134,17 +134,17 @@ final class FutureProvider<StateT>
   /// {@macro riverpod.family}
   static const family = FutureProviderFamilyBuilder();
 
-  final Create<FutureOr<StateT>> _create;
+  final Create<FutureOr<ValueT>> _create;
 
   /// @nodoc
   @internal
   @override
-  FutureOr<StateT> create(Ref ref) => _create(ref);
+  FutureOr<ValueT> create(Ref ref) => _create(ref);
 
   /// @nodoc
   @internal
   @override
-  $FutureProviderElement<StateT> $createElement($ProviderPointer pointer) {
+  $FutureProviderElement<ValueT> $createElement($ProviderPointer pointer) {
     return $FutureProviderElement(pointer);
   }
 }
@@ -154,9 +154,10 @@ final class FutureProvider<StateT>
 /// @nodoc
 @internal
 @publicInCodegen
-class $FutureProviderElement<StateT>
-    extends $FunctionalProviderElement<AsyncValue<StateT>, FutureOr<StateT>>
-    with FutureModifierElement<StateT> {
+class $FutureProviderElement<ValueT> extends $FunctionalProviderElement<
+    AsyncValue<ValueT>,
+    ValueT,
+    FutureOr<ValueT>> with FutureModifierElement<ValueT> {
   /// The element of a [FutureProvider]
   /// Implementation detail of `riverpod_generator`. Do not use.
   $FutureProviderElement(super.pointer);
@@ -169,8 +170,12 @@ class $FutureProviderElement<StateT>
 
 /// The [Family] of a [FutureProvider]
 @publicInMisc
-final class FutureProviderFamily<StateT, ArgT> extends FunctionalFamily<
-    AsyncValue<StateT>, ArgT, FutureOr<StateT>, FutureProvider<StateT>> {
+final class FutureProviderFamily<ValueT, ArgT> extends FunctionalFamily<
+    AsyncValue<ValueT>,
+    ValueT,
+    ArgT,
+    FutureOr<ValueT>,
+    FutureProvider<ValueT>> {
   /// The [Family] of a [FutureProvider]
   /// @nodoc
   @internal
@@ -181,7 +186,7 @@ final class FutureProviderFamily<StateT, ArgT> extends FunctionalFamily<
     super.isAutoDispose = false,
     super.retry,
   }) : super(
-          providerFactory: FutureProvider<StateT>.internal,
+          providerFactory: FutureProvider<ValueT>.internal,
           $allTransitiveDependencies:
               computeAllTransitiveDependencies(dependencies),
         );
@@ -196,5 +201,5 @@ final class FutureProviderFamily<StateT, ArgT> extends FunctionalFamily<
     required super.$allTransitiveDependencies,
     required super.isAutoDispose,
     required super.retry,
-  }) : super(providerFactory: FutureProvider<StateT>.internal);
+  }) : super(providerFactory: FutureProvider<ValueT>.internal);
 }

--- a/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
@@ -68,11 +68,12 @@ import '../../internals.dart';
 /// {@endtemplate}
 @publicInLegacy
 final class StateNotifierProvider< //
-        NotifierT extends StateNotifier<StateT>,
-        StateT> //
+        NotifierT extends StateNotifier<ValueT>,
+        ValueT> //
     extends $FunctionalProvider< //
-        StateT,
-        NotifierT> with LegacyProviderMixin<StateT> {
+        ValueT,
+        ValueT,
+        NotifierT> with LegacyProviderMixin<ValueT, ValueT> {
   /// {@macro riverpod.state_notifier_provider}
   StateNotifierProvider(
     this._create, {
@@ -127,10 +128,10 @@ final class StateNotifierProvider< //
   /// This may happen if the provider is refreshed or one of its dependencies
   /// has changes.
   Refreshable<NotifierT> get notifier =>
-      ProviderElementProxy<NotifierT, StateT>(
+      ProviderElementProxy<NotifierT, ValueT, ValueT>(
         this,
         (element) {
-          return (element as _StateNotifierProviderElement<NotifierT, StateT>)
+          return (element as _StateNotifierProviderElement<NotifierT, ValueT>)
               ._notifierNotifier;
         },
       );
@@ -139,7 +140,7 @@ final class StateNotifierProvider< //
   @internal
   @override
   // ignore: library_private_types_in_public_api, not public API
-  _StateNotifierProviderElement<NotifierT, StateT> $createElement(
+  _StateNotifierProviderElement<NotifierT, ValueT> $createElement(
     $ProviderPointer pointer,
   ) {
     return _StateNotifierProviderElement._(pointer);
@@ -148,7 +149,7 @@ final class StateNotifierProvider< //
 
 /// The element of [StateNotifierProvider].
 class _StateNotifierProviderElement<NotifierT extends StateNotifier<StateT>,
-    StateT> extends $FunctionalProviderElement<StateT, NotifierT> {
+    StateT> extends $FunctionalProviderElement<StateT, StateT, NotifierT> {
   _StateNotifierProviderElement._(super.pointer);
 
   final _notifierNotifier = $ElementLense<NotifierT>();
@@ -156,7 +157,7 @@ class _StateNotifierProviderElement<NotifierT extends StateNotifier<StateT>,
   void Function()? _removeListener;
 
   @override
-  WhenComplete create($Ref<StateT> ref) {
+  WhenComplete create(Ref ref) {
     final notifier = _notifierNotifier.result = $Result.guard(
       () => provider.create(ref),
     );
@@ -201,10 +202,10 @@ class _StateNotifierProviderElement<NotifierT extends StateNotifier<StateT>,
 
 /// The [Family] of [StateNotifierProvider].
 @publicInLegacy
-final class StateNotifierProviderFamily<NotifierT extends StateNotifier<T>, T,
-        Arg>
-    extends FunctionalFamily<T, Arg, NotifierT,
-        StateNotifierProvider<NotifierT, T>> {
+final class StateNotifierProviderFamily<NotifierT extends StateNotifier<ValueT>,
+        ValueT, Arg>
+    extends FunctionalFamily<ValueT, ValueT, Arg, NotifierT,
+        StateNotifierProvider<NotifierT, ValueT>> {
   /// The [Family] of [StateNotifierProvider].
   /// @nodoc
   @internal

--- a/packages/riverpod/lib/src/providers/legacy/state_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_provider.dart
@@ -36,8 +36,9 @@ import '../../internals.dart';
 /// ```
 /// {@endtemplate}
 @publicInLegacy
-final class StateProvider<StateT> extends $FunctionalProvider<StateT, StateT>
-    with LegacyProviderMixin<StateT> {
+final class StateProvider<ValueT>
+    extends $FunctionalProvider<ValueT, ValueT, ValueT>
+    with LegacyProviderMixin<ValueT, ValueT> {
   /// {@macro riverpod.state_provider}
   StateProvider(
     this._createFn, {
@@ -72,19 +73,19 @@ final class StateProvider<StateT> extends $FunctionalProvider<StateT, StateT>
   /// {@macro riverpod.family}
   static const family = StateProviderFamilyBuilder();
 
-  final StateT Function(Ref ref) _createFn;
+  final ValueT Function(Ref ref) _createFn;
   @override
-  StateT create(Ref ref) => _createFn(ref);
+  ValueT create(Ref ref) => _createFn(ref);
 
   /// Obtains the [StateController] of this provider.
   ///
   /// The value obtained may change if the provider is refreshed (such as using
   /// [Ref.watch] or [Ref.refresh]).
-  Refreshable<StateController<StateT>> get notifier =>
-      ProviderElementProxy<StateController<StateT>, StateT>(
+  Refreshable<StateController<ValueT>> get notifier =>
+      ProviderElementProxy<StateController<ValueT>, ValueT, ValueT>(
         this,
         (element) {
-          return (element as _StateProviderElement<StateT>)._controllerNotifier;
+          return (element as _StateProviderElement<ValueT>)._controllerNotifier;
         },
       );
 
@@ -92,7 +93,7 @@ final class StateProvider<StateT> extends $FunctionalProvider<StateT, StateT>
   @internal
   @override
   // ignore: library_private_types_in_public_api, not public
-  _StateProviderElement<StateT> $createElement(
+  _StateProviderElement<ValueT> $createElement(
     $ProviderPointer pointer,
   ) {
     return _StateProviderElement._(pointer);
@@ -100,17 +101,18 @@ final class StateProvider<StateT> extends $FunctionalProvider<StateT, StateT>
 }
 
 /// The element of [StateProvider].
-class _StateProviderElement<T> extends $FunctionalProviderElement<T, T> {
+class _StateProviderElement<ValueT>
+    extends $FunctionalProviderElement<ValueT, ValueT, ValueT> {
   _StateProviderElement._(super.pointer);
 
-  final _controllerNotifier = $ElementLense<StateController<T>>();
+  final _controllerNotifier = $ElementLense<StateController<ValueT>>();
 
-  final _stateNotifier = $ElementLense<StateController<T>>();
+  final _stateNotifier = $ElementLense<StateController<ValueT>>();
 
   void Function()? _removeListener;
 
   @override
-  WhenComplete create($Ref<T> ref) {
+  WhenComplete create(Ref ref) {
     final initialState = provider.create(ref);
 
     final controller = StateController(initialState);
@@ -150,11 +152,12 @@ class _StateProviderElement<T> extends $FunctionalProviderElement<T, T> {
 
 /// The [Family] of [StateProvider].
 @publicInLegacy
-final class StateProviderFamily<StateT, Arg> extends FunctionalFamily< //
-    StateT,
+final class StateProviderFamily<ValueT, Arg> extends FunctionalFamily< //
+    ValueT,
+    ValueT,
     Arg,
-    StateT,
-    StateProvider<StateT>> {
+    ValueT,
+    StateProvider<ValueT>> {
   /// The [Family] of [StateProvider].
   /// @nodoc
   @internal

--- a/packages/riverpod/lib/src/providers/notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/notifier/family.dart
@@ -3,13 +3,13 @@ part of '../notifier.dart';
 /// {@macro riverpod.notifier}
 ///
 /// {@macro riverpod.notifier_provider_modifier}
-abstract class FamilyNotifier<StateT, ArgT> extends $Notifier<StateT> {
+abstract class FamilyNotifier<ValueT, ArgT> extends $Notifier<ValueT> {
   /// {@macro riverpod.notifier.family_arg}
   late final ArgT arg = ref.$arg as ArgT;
 
   /// {@macro riverpod.async_notifier.build}
   @visibleForOverriding
-  StateT build(ArgT arg);
+  ValueT build(ArgT arg);
 
   @mustCallSuper
   @override
@@ -22,9 +22,9 @@ abstract class FamilyNotifier<StateT, ArgT> extends $Notifier<StateT> {
 /// The [NotifierProvider] that can be used with a [Family].
 @publicInMisc
 final class FamilyNotifierProvider //
-    <NotifierT extends $Notifier<StateT>, StateT, ArgT>
-    extends $NotifierProvider<NotifierT, StateT>
-    with LegacyProviderMixin<StateT> {
+    <NotifierT extends $Notifier<ValueT>, ValueT, ArgT>
+    extends $NotifierProvider<NotifierT, ValueT>
+    with LegacyProviderMixin<ValueT, ValueT> {
   /// An implementation detail of Riverpod
   const FamilyNotifierProvider._(
     this._createNotifier, {

--- a/packages/riverpod/lib/src/providers/notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/notifier/orphan.dart
@@ -53,7 +53,7 @@ part of '../notifier.dart';
 /// Instead of extending [Notifier], you should extend [FamilyNotifier].
 /// {@endtemplate}
 /// {@category Notifiers}
-abstract class Notifier<StateT> extends $Notifier<StateT> {
+abstract class Notifier<ValueT> extends $Notifier<ValueT> {
   /// {@template riverpod.notifier.build}
   /// Initialize a [Notifier].
   ///
@@ -67,7 +67,7 @@ abstract class Notifier<StateT> extends $Notifier<StateT> {
   /// If this method throws, reading this provider will rethrow the error.
   /// {@endtemplate}
   @visibleForOverriding
-  StateT build();
+  ValueT build();
 
   @mustCallSuper
   @override
@@ -83,9 +83,9 @@ abstract class Notifier<StateT> extends $Notifier<StateT> {
 /// [NotifierProvider] can be considered as a mutable [Provider].
 /// {@endtemplate}
 /// {@category Providers}
-final class NotifierProvider<NotifierT extends Notifier<StateT>, StateT>
-    extends $NotifierProvider<NotifierT, StateT>
-    with LegacyProviderMixin<StateT> {
+final class NotifierProvider<NotifierT extends Notifier<ValueT>, ValueT>
+    extends $NotifierProvider<NotifierT, ValueT>
+    with LegacyProviderMixin<ValueT, ValueT> {
   /// {@macro riverpod.notifier_provider}
   ///
   /// {@macro riverpod.notifier_provider_modifier}

--- a/packages/riverpod/lib/src/providers/provider.dart
+++ b/packages/riverpod/lib/src/providers/provider.dart
@@ -11,12 +11,12 @@ import 'stream_provider.dart' show StreamProvider;
 /// Do not use, as this may be removed at any time.
 @internal
 @publicInCodegen
-base mixin $Provider<StateT> on $FunctionalProvider<StateT, StateT> {}
+base mixin $Provider<ValueT> on $FunctionalProvider<ValueT, ValueT, ValueT> {}
 
 /// {@macro riverpod.provider}
 /// {@category Providers}
-final class Provider<StateT> extends $FunctionalProvider<StateT, StateT>
-    with $Provider<StateT>, LegacyProviderMixin<StateT> {
+final class Provider<ValueT> extends $FunctionalProvider<ValueT, ValueT, ValueT>
+    with $Provider<ValueT>, LegacyProviderMixin<ValueT, ValueT> {
   /// {@macro riverpod.provider}
   Provider(
     this._create, {
@@ -51,17 +51,17 @@ final class Provider<StateT> extends $FunctionalProvider<StateT, StateT>
   /// {@macro riverpod.family}
   static const family = ProviderFamilyBuilder();
 
-  final Create<StateT> _create;
+  final Create<ValueT> _create;
 
   /// @nodoc
   @internal
   @override
-  StateT create(Ref ref) => _create(ref);
+  ValueT create(Ref ref) => _create(ref);
 
   /// @nodoc
   @internal
   @override
-  $ProviderElement<StateT> $createElement($ProviderPointer pointer) {
+  $ProviderElement<ValueT> $createElement($ProviderPointer pointer) {
     return $ProviderElement(pointer);
   }
 
@@ -111,10 +111,10 @@ final class Provider<StateT> extends $FunctionalProvider<StateT, StateT>
   /// The benefit of using [overrideWithValue] over [overrideWith] in this scenario
   /// is that if the theme ever changes, then `themeProvider` will be updated.
   /// {@endtemplate}
-  Override overrideWithValue(StateT value) {
+  Override overrideWithValue(ValueT value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<StateT>(value),
+      providerOverride: $ValueProvider<ValueT, ValueT>(value),
     );
   }
 }
@@ -333,7 +333,7 @@ final class Provider<StateT> extends $FunctionalProvider<StateT, StateT>
 @internal
 @publicInCodegen
 class $ProviderElement<StateT>
-    extends $FunctionalProviderElement<StateT, StateT> {
+    extends $FunctionalProviderElement<StateT, StateT, StateT> {
   /// A [ProviderElement] for [Provider]
   $ProviderElement(super.pointer);
 
@@ -351,7 +351,7 @@ class $ProviderElement<StateT>
 /// The [Family] of [Provider]
 @publicInMisc
 final class ProviderFamily<StateT, ArgT>
-    extends FunctionalFamily<StateT, ArgT, StateT, Provider<StateT>> {
+    extends FunctionalFamily<StateT, StateT, ArgT, StateT, Provider<StateT>> {
   /// The [Family] of [Provider]
   /// @nodoc
   @internal

--- a/packages/riverpod/lib/src/providers/stream_notifier.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier.dart
@@ -16,22 +16,22 @@ part 'stream_notifier/orphan.dart';
 /// Implementation detail of `riverpod_generator`.
 /// Do not use.
 @publicInCodegen
-abstract class $StreamNotifier<StateT> extends $AsyncNotifierBase<StateT>
-    with $AsyncClassModifier<StateT, Stream<StateT>, StateT> {}
+abstract class $StreamNotifier<ValueT> extends $AsyncNotifierBase<ValueT>
+    with $AsyncClassModifier<ValueT, Stream<ValueT>> {}
 
 /// Implementation detail of `riverpod_generator`.
 /// Do not use.
 @publicInCodegen
 abstract base class $StreamNotifierProvider<
-        NotifierT extends $StreamNotifier<StateT>, //
-        StateT> //
+        NotifierT extends $StreamNotifier<ValueT>, //
+        ValueT> //
     extends $ClassProvider< //
         NotifierT,
-        AsyncValue<StateT>,
-        StateT,
-        Stream<StateT>> //
+        AsyncValue<ValueT>,
+        ValueT,
+        Stream<ValueT>> //
     with
-        $FutureModifier<StateT> {
+        $FutureModifier<ValueT> {
   /// Implementation detail of `riverpod_generator`.
   /// Do not use.
   const $StreamNotifierProvider({
@@ -47,7 +47,7 @@ abstract base class $StreamNotifierProvider<
   /// @nodoc
   @internal
   @override
-  $StreamNotifierProviderElement<NotifierT, StateT> $createElement(
+  $StreamNotifierProviderElement<NotifierT, ValueT> $createElement(
     $ProviderPointer pointer,
   ) {
     return $StreamNotifierProviderElement(pointer);
@@ -59,22 +59,22 @@ abstract base class $StreamNotifierProvider<
 @internal
 @publicInCodegen
 class $StreamNotifierProviderElement< //
-        NotifierT extends $StreamNotifier<StateT>,
-        StateT> //
+        NotifierT extends $StreamNotifier<ValueT>,
+        ValueT> //
     extends $ClassProviderElement< //
         NotifierT,
-        AsyncValue<StateT>,
-        StateT,
-        Stream<StateT>> //
+        AsyncValue<ValueT>,
+        ValueT,
+        Stream<ValueT>> //
     with
-        FutureModifierElement<StateT>,
-        FutureModifierClassElement<NotifierT, StateT, Stream<StateT>> {
+        FutureModifierElement<ValueT>,
+        FutureModifierClassElement<NotifierT, ValueT, Stream<ValueT>> {
   /// Implementation detail of `riverpod_generator`.
   /// Do not use.
   $StreamNotifierProviderElement(super.pointer);
 
   @override
-  void handleValue(Ref ref, Stream<StateT> created) {
+  void handleValue(Ref ref, Stream<ValueT> created) {
     handleStream(ref, () => created);
   }
 }

--- a/packages/riverpod/lib/src/providers/stream_notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier/family.dart
@@ -33,11 +33,11 @@ abstract class FamilyStreamNotifier<StateT, ArgT>
 /// An implementation detail of Riverpod
 @publicInMisc
 final class FamilyStreamNotifierProvider< //
-        NotifierT extends FamilyStreamNotifier<StateT, ArgT>,
-        StateT,
+        NotifierT extends FamilyStreamNotifier<ValueT, ArgT>,
+        ValueT,
         ArgT> //
-    extends $StreamNotifierProvider<NotifierT, StateT>
-    with LegacyProviderMixin<AsyncValue<StateT>> {
+    extends $StreamNotifierProvider<NotifierT, ValueT>
+    with LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
   /// An implementation detail of Riverpod
   const FamilyStreamNotifierProvider._(
     this._createNotifier, {
@@ -61,16 +61,16 @@ final class FamilyStreamNotifierProvider< //
 /// The [Family] of [StreamNotifierProvider].
 @publicInMisc
 final class StreamNotifierProviderFamily< //
-        NotifierT extends FamilyStreamNotifier<StateT, ArgT>,
-        StateT,
+        NotifierT extends FamilyStreamNotifier<ValueT, ArgT>,
+        ValueT,
         ArgT> //
     extends ClassFamily< //
         NotifierT,
-        AsyncValue<StateT>,
-        StateT,
+        AsyncValue<ValueT>,
+        ValueT,
         ArgT,
-        Stream<StateT>,
-        FamilyStreamNotifierProvider<NotifierT, StateT, ArgT>> {
+        Stream<ValueT>,
+        FamilyStreamNotifierProvider<NotifierT, ValueT, ArgT>> {
   /// The [Family] of [FamilyStreamNotifierProvider].
   /// @nodoc
   @internal

--- a/packages/riverpod/lib/src/providers/stream_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier/orphan.dart
@@ -16,10 +16,10 @@ part of '../stream_notifier.dart';
 /// [StreamNotifier], you should extend [FamilyStreamNotifier].
 /// {@endtemplate}
 /// {@category Notifiers}
-abstract class StreamNotifier<StateT> extends $StreamNotifier<StateT> {
+abstract class StreamNotifier<ValueT> extends $StreamNotifier<ValueT> {
   /// {@macro riverpod.async_notifier.build}
   @visibleForOverriding
-  Stream<StateT> build();
+  Stream<ValueT> build();
 
   @mustCallSuper
   @override
@@ -47,10 +47,10 @@ abstract class StreamNotifier<StateT> extends $StreamNotifier<StateT> {
 /// {@endtemplate}
 /// {@category Providers}
 final class StreamNotifierProvider< //
-        NotifierT extends StreamNotifier<StateT>,
-        StateT> //
-    extends $StreamNotifierProvider<NotifierT, StateT>
-    with LegacyProviderMixin<AsyncValue<StateT>> {
+        NotifierT extends StreamNotifier<ValueT>,
+        ValueT> //
+    extends $StreamNotifierProvider<NotifierT, ValueT>
+    with LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
   /// {@macro riverpod.stream_notifier_provider}
   ///
   /// {@macro riverpod.async_notifier_provider_modifier}

--- a/packages/riverpod/lib/src/providers/stream_provider.dart
+++ b/packages/riverpod/lib/src/providers/stream_provider.dart
@@ -15,13 +15,13 @@ import 'provider.dart' show Provider;
 /// Do not use, as this may be removed at any time.
 @internal
 @publicInCodegen
-base mixin $StreamProvider<StateT>
-    on $FunctionalProvider<AsyncValue<StateT>, Stream<StateT>> {
+base mixin $StreamProvider<ValueT>
+    on $FunctionalProvider<AsyncValue<ValueT>, ValueT, Stream<ValueT>> {
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AsyncValue<StateT> value) {
+  Override overrideWithValue(AsyncValue<ValueT> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $AsyncValueProvider<StateT>(value),
+      providerOverride: $AsyncValueProvider<ValueT>(value),
     );
   }
 }
@@ -83,12 +83,12 @@ base mixin $StreamProvider<StateT>
 /// - [StreamProvider.autoDispose], to destroy the state of a [StreamProvider] when no longer needed.
 /// {@endtemplate}
 /// {@category Providers}
-final class StreamProvider<StateT>
-    extends $FunctionalProvider<AsyncValue<StateT>, Stream<StateT>>
+final class StreamProvider<ValueT>
+    extends $FunctionalProvider<AsyncValue<ValueT>, ValueT, Stream<ValueT>>
     with
-        $FutureModifier<StateT>,
-        $StreamProvider<StateT>,
-        LegacyProviderMixin<AsyncValue<StateT>> {
+        $FutureModifier<ValueT>,
+        $StreamProvider<ValueT>,
+        LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
   /// {@macro riverpod.stream_provider}
   StreamProvider(
     this._create, {
@@ -123,17 +123,17 @@ final class StreamProvider<StateT>
   /// {@macro riverpod.family}
   static const family = StreamProviderFamilyBuilder();
 
-  final Create<Stream<StateT>> _create;
+  final Create<Stream<ValueT>> _create;
 
   /// @nodoc
   @internal
   @override
-  Stream<StateT> create(Ref ref) => _create(ref);
+  Stream<ValueT> create(Ref ref) => _create(ref);
 
   /// @nodoc
   @internal
   @override
-  $StreamProviderElement<StateT> $createElement($ProviderPointer pointer) {
+  $StreamProviderElement<ValueT> $createElement($ProviderPointer pointer) {
     return $StreamProviderElement(pointer);
   }
 }
@@ -141,15 +141,16 @@ final class StreamProvider<StateT>
 /// The element of [StreamProvider].
 @internal
 @publicInCodegen
-class $StreamProviderElement<StateT>
-    extends $FunctionalProviderElement<AsyncValue<StateT>, Stream<StateT>>
-    with FutureModifierElement<StateT> {
+class $StreamProviderElement<ValueT> extends $FunctionalProviderElement<
+    AsyncValue<ValueT>,
+    ValueT,
+    Stream<ValueT>> with FutureModifierElement<ValueT> {
   /// The element of [StreamProvider].
   $StreamProviderElement(super.pointer);
 
-  final _streamNotifier = $ElementLense<Stream<StateT>>();
-  final StreamController<StateT> _streamController =
-      StreamController<StateT>.broadcast();
+  final _streamNotifier = $ElementLense<Stream<ValueT>>();
+  final StreamController<ValueT> _streamController =
+      StreamController<ValueT>.broadcast();
 
   @override
   WhenComplete create(Ref ref) {
@@ -176,7 +177,7 @@ class $StreamProviderElement<StateT>
   }
 
   @override
-  void onData(AsyncData<StateT> value, {bool seamless = false}) {
+  void onData(AsyncData<ValueT> value, {bool seamless = false}) {
     if (!_streamController.isClosed) {
       // The controller might be closed if onData is executed post dispose. Cf onData
       _streamController.add(value.value);
@@ -185,7 +186,7 @@ class $StreamProviderElement<StateT>
   }
 
   @override
-  void onError(AsyncError<StateT> value, {bool seamless = false}) {
+  void onError(AsyncError<ValueT> value, {bool seamless = false}) {
     if (!_streamController.isClosed) {
       // The controller might be closed if onError is executed post dispose. Cf onError
       _streamController.addError(value.error, value.stackTrace);
@@ -196,8 +197,8 @@ class $StreamProviderElement<StateT>
 
 /// The [Family] of a [StreamProvider]
 @publicInMisc
-final class StreamProviderFamily<StateT, ArgT> extends FunctionalFamily<
-    AsyncValue<StateT>, ArgT, Stream<StateT>, StreamProvider<StateT>> {
+final class StreamProviderFamily<ValueT, ArgT> extends FunctionalFamily<
+    AsyncValue<ValueT>, ValueT, ArgT, Stream<ValueT>, StreamProvider<ValueT>> {
   /// The [Family] of a [StreamProvider]
   /// @nodoc
   @internal
@@ -208,7 +209,7 @@ final class StreamProviderFamily<StateT, ArgT> extends FunctionalFamily<
     super.isAutoDispose = false,
     super.retry,
   }) : super(
-          providerFactory: StreamProvider<StateT>.internal,
+          providerFactory: StreamProvider<ValueT>.internal,
           $allTransitiveDependencies:
               computeAllTransitiveDependencies(dependencies),
         );
@@ -223,5 +224,5 @@ final class StreamProviderFamily<StateT, ArgT> extends FunctionalFamily<
     required super.$allTransitiveDependencies,
     required super.isAutoDispose,
     required super.retry,
-  }) : super(providerFactory: StreamProvider<StateT>.internal);
+  }) : super(providerFactory: StreamProvider<ValueT>.internal);
 }

--- a/packages/riverpod/test/feature/offline_test.dart
+++ b/packages/riverpod/test/feature/offline_test.dart
@@ -573,7 +573,7 @@ extension on AnyNotifier<Object?, Object?> {
   Future<Object?> get future {
     final that = this;
     switch (that) {
-      case $AsyncClassModifier<Object?, Object?, Object?>():
+      case $AsyncClassModifier<Object?, Object?>():
         return that.future;
       default:
         throw AssertionError('not async');
@@ -607,7 +607,7 @@ extension on TestFactory<Object?> {
     throw AssertionError('unreachable');
   }
 
-  ProviderBase<Object?> simpleProvider(
+  ProviderBase<Object?, Object?> simpleProvider(
     FutureOr<Object?> Function(Ref, AnyNotifier<Object?, Object?> notifier)
         createCb, {
     Storage? storage,

--- a/packages/riverpod/test/feature/visit_states_test.dart
+++ b/packages/riverpod/test/feature/visit_states_test.dart
@@ -307,7 +307,7 @@ void main() {
   });
 }
 
-List<ProviderBase<Object?>> compute(ProviderContainer container) {
+List<ProviderBase<Object?, Object?>> compute(ProviderContainer container) {
   return container
       .getAllProviderElementsInOrder()
       .map((e) => e.provider)

--- a/packages/riverpod/test/old/framework/provider_container_test.dart
+++ b/packages/riverpod/test/old/framework/provider_container_test.dart
@@ -286,7 +286,7 @@ void main() {
 
         expect(
           container.getAllProviderElements(),
-          [isA<ProviderElement<int>>()],
+          [isA<ProviderElement>()],
         );
 
         sub = container.listen(provider, (_, __) {});

--- a/packages/riverpod/test/old/framework/ref_watch_test.dart
+++ b/packages/riverpod/test/old/framework/ref_watch_test.dart
@@ -448,7 +448,7 @@ void main() {
 
   test('Provider.family', () async {
     final computed =
-        Provider.family<String, ProviderBase<int>>((ref, provider) {
+        Provider.family<String, ProviderBase<int, int>>((ref, provider) {
       return ref.watch(provider).toString();
     });
     final notifier = Counter();

--- a/packages/riverpod/test/old/legacy_providers/scoped_provider/scoped_provider_test.dart
+++ b/packages/riverpod/test/old/legacy_providers/scoped_provider/scoped_provider_test.dart
@@ -41,7 +41,7 @@ void main() {
 
       expect(container.getAllProviderElements(), isEmpty);
       expect(mid.getAllProviderElements(), [
-        isA<ProviderElement<int>>()
+        isA<ProviderElement>()
             .having((e) => e.origin, 'origin', provider)
             .having((e) => e.readSelf(), 'readSelf()', 42),
       ]);

--- a/packages/riverpod/test/old/utils.dart
+++ b/packages/riverpod/test/old/utils.dart
@@ -233,7 +233,7 @@ class ObserverMock extends Mock implements ProviderObserver {
 class CustomObserver extends ProviderObserver {}
 
 TypeMatcher<ProviderObserverContext> isProviderObserverContext(
-  ProviderBase<Object?> provider,
+  ProviderBase<Object?, Object?> provider,
   ProviderContainer container, {
   Object? notifier,
 }) {

--- a/packages/riverpod/test/src/core/ref_test.dart
+++ b/packages/riverpod/test/src/core/ref_test.dart
@@ -10,7 +10,7 @@ import '../matrix.dart';
 import '../utils.dart';
 
 final refMethodsThatDependOnProviders =
-    <String, void Function(Ref ref, ProviderBase<Object?>)>{
+    <String, void Function(Ref ref, ProviderBase<Object?, Object?>)>{
   'watch': (ref, p) => ref.watch(p),
   'read': (ref, p) => ref.read(p),
   'listen': (ref, p) => ref.listen(p, (prev, next) {}),
@@ -933,7 +933,7 @@ void main() {
 
           expect(
             container.pointerManager.orphanPointers.pointers[dep]!.element,
-            isA<ProviderElement<int>>()
+            isA<ProviderElement>()
                 .having((e) => e.stateResult, 'stateResult', null),
           );
         });

--- a/packages/riverpod/test/src/matrix.dart
+++ b/packages/riverpod/test/src/matrix.dart
@@ -40,7 +40,7 @@ typedef ProviderFactory<BaseT, ProviderT> = ProviderT Function([Object? arg])
   Retry? retry,
 });
 
-extension $Modifiers on ProviderBase<Object?> {
+extension $Modifiers on ProviderBase<Object?, Object?> {
   Refreshable<AnyNotifier<Object?, Object?>>? get notifier {
     final that = this;
     return switch (that) {
@@ -166,7 +166,7 @@ final streamProviderFactories =
 ];
 
 final asyncProviderFactory =
-    <ProviderFactory<Object?, ProviderBase<AsyncValue<Object?>>>>[
+    <ProviderFactory<Object?, ProviderBase<AsyncValue<Object?>, Object?>>>[
   for (final factory in futureProviderFactories)
     (create, {name, dependencies, retry}) => factory(
           (ref, arg) async => create(ref, arg),

--- a/packages/riverpod/test/src/matrix/async_notifier_provider.dart
+++ b/packages/riverpod/test/src/matrix/async_notifier_provider.dart
@@ -6,8 +6,8 @@ final asyncNotifierProviderFactory = TestMatrix<AsyncNotifierTestFactory>(
       isAutoDispose: false,
       isFamily: false,
       deferredNotifier: DeferredAsyncNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify, retry}) {
-        return AsyncNotifierProvider<DeferredAsyncNotifier<StateT>, StateT>(
+      deferredProvider: <ValueT>(create, {updateShouldNotify, retry}) {
+        return AsyncNotifierProvider<DeferredAsyncNotifier<ValueT>, ValueT>(
           retry: retry,
           () => DeferredAsyncNotifier(
             create,
@@ -15,9 +15,9 @@ final asyncNotifierProviderFactory = TestMatrix<AsyncNotifierTestFactory>(
           ),
         );
       },
-      provider: <StateT>(create) =>
-          AsyncNotifierProvider<AsyncNotifier<StateT>, StateT>(
-        () => create() as AsyncNotifier<StateT>,
+      provider: <ValueT>(create) =>
+          AsyncNotifierProvider<AsyncNotifier<ValueT>, ValueT>(
+        () => create() as AsyncNotifier<ValueT>,
       ),
       value: (create, {name, dependencies, retry}) => ([arg]) {
         return AsyncNotifierProvider<AsyncNotifier<Object?>, Object?>(
@@ -32,9 +32,9 @@ final asyncNotifierProviderFactory = TestMatrix<AsyncNotifierTestFactory>(
       isAutoDispose: true,
       isFamily: false,
       deferredNotifier: DeferredAsyncNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify, retry}) {
-        return AsyncNotifierProvider.autoDispose<DeferredAsyncNotifier<StateT>,
-            StateT>(
+      deferredProvider: <ValueT>(create, {updateShouldNotify, retry}) {
+        return AsyncNotifierProvider.autoDispose<DeferredAsyncNotifier<ValueT>,
+            ValueT>(
           retry: retry,
           () => DeferredAsyncNotifier(
             create,
@@ -42,9 +42,9 @@ final asyncNotifierProviderFactory = TestMatrix<AsyncNotifierTestFactory>(
           ),
         );
       },
-      provider: <StateT>(create) {
-        return AsyncNotifierProvider.autoDispose<AsyncNotifier<StateT>, StateT>(
-          () => create() as AsyncNotifier<StateT>,
+      provider: <ValueT>(create) {
+        return AsyncNotifierProvider.autoDispose<AsyncNotifier<ValueT>, ValueT>(
+          () => create() as AsyncNotifier<ValueT>,
         );
       },
       value: (create, {name, dependencies, retry}) => ([arg]) {
@@ -61,9 +61,9 @@ final asyncNotifierProviderFactory = TestMatrix<AsyncNotifierTestFactory>(
       isAutoDispose: false,
       isFamily: true,
       deferredNotifier: DeferredFamilyAsyncNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify, retry}) {
-        return AsyncNotifierProvider.family<DeferredFamilyAsyncNotifier<StateT>,
-            StateT, Object?>(
+      deferredProvider: <ValueT>(create, {updateShouldNotify, retry}) {
+        return AsyncNotifierProvider.family<DeferredFamilyAsyncNotifier<ValueT>,
+            ValueT, Object?>(
           retry: retry,
           () => DeferredFamilyAsyncNotifier(
             create,
@@ -71,10 +71,10 @@ final asyncNotifierProviderFactory = TestMatrix<AsyncNotifierTestFactory>(
           ),
         ).call(42);
       },
-      provider: <StateT>(create) {
+      provider: <ValueT>(create) {
         return AsyncNotifierProvider.family<
-            FamilyAsyncNotifier<StateT, Object?>, StateT, Object?>(
-          () => create() as FamilyAsyncNotifier<StateT, Object?>,
+            FamilyAsyncNotifier<ValueT, Object?>, ValueT, Object?>(
+          () => create() as FamilyAsyncNotifier<ValueT, Object?>,
         ).call(42);
       },
       value: (create, {name, dependencies, retry}) => ([arg]) {
@@ -91,9 +91,9 @@ final asyncNotifierProviderFactory = TestMatrix<AsyncNotifierTestFactory>(
       isAutoDispose: true,
       isFamily: true,
       deferredNotifier: DeferredFamilyAsyncNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify, retry}) {
+      deferredProvider: <ValueT>(create, {updateShouldNotify, retry}) {
         return AsyncNotifierProvider.family
-            .autoDispose<DeferredFamilyAsyncNotifier<StateT>, StateT, Object?>(
+            .autoDispose<DeferredFamilyAsyncNotifier<ValueT>, ValueT, Object?>(
               retry: retry,
               () => DeferredFamilyAsyncNotifier(
                 create,
@@ -102,10 +102,10 @@ final asyncNotifierProviderFactory = TestMatrix<AsyncNotifierTestFactory>(
             )
             .call(42);
       },
-      provider: <StateT>(create) {
+      provider: <ValueT>(create) {
         return AsyncNotifierProvider.autoDispose
-            .family<FamilyAsyncNotifier<StateT, Object?>, StateT, Object?>(
-              () => create() as FamilyAsyncNotifier<StateT, Object?>,
+            .family<FamilyAsyncNotifier<ValueT, Object?>, ValueT, Object?>(
+              () => create() as FamilyAsyncNotifier<ValueT, Object?>,
             )
             .call(42);
       },
@@ -122,35 +122,35 @@ final asyncNotifierProviderFactory = TestMatrix<AsyncNotifierTestFactory>(
   },
 );
 
-abstract class TestAsyncNotifier<StateT> implements $AsyncNotifier<StateT> {
+abstract class TestAsyncNotifier<ValueT> implements $AsyncNotifier<ValueT> {
   // Removing protected
   @override
-  AsyncValue<StateT> get state;
+  AsyncValue<ValueT> get state;
 
   @override
-  set state(AsyncValue<StateT> value);
+  set state(AsyncValue<ValueT> value);
 }
 
-class DeferredAsyncNotifier<StateT> extends AsyncNotifier<StateT>
-    implements TestAsyncNotifier<StateT> {
+class DeferredAsyncNotifier<ValueT> extends AsyncNotifier<ValueT>
+    implements TestAsyncNotifier<ValueT> {
   DeferredAsyncNotifier(
     this._create, {
-    bool Function(AsyncValue<StateT>, AsyncValue<StateT>)? updateShouldNotify,
+    bool Function(AsyncValue<ValueT>, AsyncValue<ValueT>)? updateShouldNotify,
   }) : _updateShouldNotify = updateShouldNotify;
 
-  final FutureOr<StateT> Function(Ref ref, DeferredAsyncNotifier<StateT> self)
+  final FutureOr<ValueT> Function(Ref ref, DeferredAsyncNotifier<ValueT> self)
       _create;
   final bool Function(
-    AsyncValue<StateT> previousState,
-    AsyncValue<StateT> newState,
+    AsyncValue<ValueT> previousState,
+    AsyncValue<ValueT> newState,
   )? _updateShouldNotify;
 
   @override
-  FutureOr<StateT> build() => _create(ref, this);
+  FutureOr<ValueT> build() => _create(ref, this);
 
   @override
   RemoveListener listenSelf(
-    void Function(AsyncValue<StateT>? previous, AsyncValue<StateT> next)
+    void Function(AsyncValue<ValueT>? previous, AsyncValue<ValueT> next)
         listener, {
     void Function(Object error, StackTrace stackTrace)? onError,
   }) {
@@ -159,42 +159,42 @@ class DeferredAsyncNotifier<StateT> extends AsyncNotifier<StateT>
 
   @override
   bool updateShouldNotify(
-    AsyncValue<StateT> previousState,
-    AsyncValue<StateT> newState,
+    AsyncValue<ValueT> previousState,
+    AsyncValue<ValueT> newState,
   ) =>
       _updateShouldNotify?.call(previousState, newState) ??
       super.updateShouldNotify(previousState, newState);
 }
 
-class DeferredFamilyAsyncNotifier<StateT>
-    extends FamilyAsyncNotifier<StateT, int>
-    implements TestAsyncNotifier<StateT> {
+class DeferredFamilyAsyncNotifier<ValueT>
+    extends FamilyAsyncNotifier<ValueT, int>
+    implements TestAsyncNotifier<ValueT> {
   DeferredFamilyAsyncNotifier(
     this._create, {
-    bool Function(AsyncValue<StateT>, AsyncValue<StateT>)? updateShouldNotify,
+    bool Function(AsyncValue<ValueT>, AsyncValue<ValueT>)? updateShouldNotify,
   }) : _updateShouldNotify = updateShouldNotify;
 
-  final FutureOr<StateT> Function(Ref ref, $AsyncNotifier<StateT> self) _create;
+  final FutureOr<ValueT> Function(Ref ref, $AsyncNotifier<ValueT> self) _create;
 
   final bool Function(
-    AsyncValue<StateT> previousState,
-    AsyncValue<StateT> newState,
+    AsyncValue<ValueT> previousState,
+    AsyncValue<ValueT> newState,
   )? _updateShouldNotify;
 
   @override
-  FutureOr<StateT> build(int arg) => _create(ref, this);
+  FutureOr<ValueT> build(int arg) => _create(ref, this);
 
   @override
   bool updateShouldNotify(
-    AsyncValue<StateT> previousState,
-    AsyncValue<StateT> newState,
+    AsyncValue<ValueT> previousState,
+    AsyncValue<ValueT> newState,
   ) =>
       _updateShouldNotify?.call(previousState, newState) ??
       super.updateShouldNotify(previousState, newState);
 }
 
 class AsyncNotifierTestFactory extends TestFactory<
-    ProviderFactory<$AsyncNotifier<Object?>, ProviderBase<Object?>>> {
+    ProviderFactory<$AsyncNotifier<Object?>, ProviderBase<Object?, Object?>>> {
   AsyncNotifierTestFactory({
     required super.isAutoDispose,
     required super.isFamily,
@@ -204,28 +204,28 @@ class AsyncNotifierTestFactory extends TestFactory<
     required this.provider,
   });
 
-  final TestAsyncNotifier<StateT> Function<StateT>(
-    FutureOr<StateT> Function(Ref ref, $AsyncNotifier<StateT> self) create,
+  final TestAsyncNotifier<ValueT> Function<ValueT>(
+    FutureOr<ValueT> Function(Ref ref, $AsyncNotifier<ValueT> self) create,
   ) deferredNotifier;
 
-  final $AsyncNotifierProvider<TestAsyncNotifier<StateT>, StateT>
-      Function<StateT>(
-    FutureOr<StateT> Function(Ref ref, $AsyncNotifier<StateT> self) create, {
-    bool Function(AsyncValue<StateT>, AsyncValue<StateT>)? updateShouldNotify,
+  final $AsyncNotifierProvider<TestAsyncNotifier<ValueT>, ValueT>
+      Function<ValueT>(
+    FutureOr<ValueT> Function(Ref ref, $AsyncNotifier<ValueT> self) create, {
+    bool Function(AsyncValue<ValueT>, AsyncValue<ValueT>)? updateShouldNotify,
     Retry? retry,
   }) deferredProvider;
 
-  final $AsyncNotifierProvider<$AsyncNotifier<StateT>, StateT> Function<StateT>(
-    $AsyncNotifier<StateT> Function() create,
+  final $AsyncNotifierProvider<$AsyncNotifier<ValueT>, ValueT> Function<ValueT>(
+    $AsyncNotifier<ValueT> Function() create,
   ) provider;
 
-  $AsyncNotifierProvider<TestAsyncNotifier<StateT>, StateT>
-      simpleTestProvider<StateT>(
-    FutureOr<StateT> Function(Ref ref, $AsyncNotifier<StateT> self) create, {
-    bool Function(AsyncValue<StateT>, AsyncValue<StateT>)? updateShouldNotify,
+  $AsyncNotifierProvider<TestAsyncNotifier<ValueT>, ValueT>
+      simpleTestProvider<ValueT>(
+    FutureOr<ValueT> Function(Ref ref, $AsyncNotifier<ValueT> self) create, {
+    bool Function(AsyncValue<ValueT>, AsyncValue<ValueT>)? updateShouldNotify,
     Retry? retry,
   }) {
-    return deferredProvider<StateT>(
+    return deferredProvider<ValueT>(
       (ref, self) => create(ref, self),
       updateShouldNotify: updateShouldNotify,
       retry: retry,

--- a/packages/riverpod/test/src/matrix/notifier_provider.dart
+++ b/packages/riverpod/test/src/matrix/notifier_provider.dart
@@ -6,16 +6,16 @@ final notifierProviderFactory = TestMatrix<NotifierTestFactory>(
       isAutoDispose: false,
       isFamily: false,
       deferredNotifier: DeferredNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify}) {
-        return NotifierProvider<DeferredNotifier<StateT>, StateT>(
+      deferredProvider: <ValueT>(create, {updateShouldNotify}) {
+        return NotifierProvider<DeferredNotifier<ValueT>, ValueT>(
           () => DeferredNotifier(
             (ref, self) => create(ref, self),
             updateShouldNotify: updateShouldNotify,
           ),
         );
       },
-      provider: <StateT>(create) => NotifierProvider<Notifier<StateT>, StateT>(
-        () => create() as Notifier<StateT>,
+      provider: <ValueT>(create) => NotifierProvider<Notifier<ValueT>, ValueT>(
+        () => create() as Notifier<ValueT>,
       ),
       value: (create, {name, dependencies, retry}) => ([arg]) {
         return NotifierProvider<Notifier<Object?>, Object?>(
@@ -30,17 +30,17 @@ final notifierProviderFactory = TestMatrix<NotifierTestFactory>(
       isAutoDispose: true,
       isFamily: false,
       deferredNotifier: DeferredNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify}) {
-        return NotifierProvider.autoDispose<DeferredNotifier<StateT>, StateT>(
+      deferredProvider: <ValueT>(create, {updateShouldNotify}) {
+        return NotifierProvider.autoDispose<DeferredNotifier<ValueT>, ValueT>(
           () => DeferredNotifier(
             (ref, self) => create(ref, self),
             updateShouldNotify: updateShouldNotify,
           ),
         );
       },
-      provider: <StateT>(create) {
-        return NotifierProvider.autoDispose<Notifier<StateT>, StateT>(
-          () => create() as Notifier<StateT>,
+      provider: <ValueT>(create) {
+        return NotifierProvider.autoDispose<Notifier<ValueT>, ValueT>(
+          () => create() as Notifier<ValueT>,
         );
       },
       value: (create, {name, dependencies, retry}) => ([arg]) {
@@ -56,8 +56,8 @@ final notifierProviderFactory = TestMatrix<NotifierTestFactory>(
       isAutoDispose: false,
       isFamily: true,
       deferredNotifier: DeferredFamilyNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify}) {
-        return NotifierProvider.family<DeferredFamilyNotifier<StateT>, StateT,
+      deferredProvider: <ValueT>(create, {updateShouldNotify}) {
+        return NotifierProvider.family<DeferredFamilyNotifier<ValueT>, ValueT,
             Object?>(
           () => DeferredFamilyNotifier(
             create,
@@ -65,10 +65,10 @@ final notifierProviderFactory = TestMatrix<NotifierTestFactory>(
           ),
         ).call(42);
       },
-      provider: <StateT>(create) {
-        return NotifierProvider.family<FamilyNotifier<StateT, Object?>, StateT,
+      provider: <ValueT>(create) {
+        return NotifierProvider.family<FamilyNotifier<ValueT, Object?>, ValueT,
             Object?>(
-          () => create() as FamilyNotifier<StateT, Object?>,
+          () => create() as FamilyNotifier<ValueT, Object?>,
         ).call(42);
       },
       value: (create, {name, dependencies, retry}) => ([arg]) {
@@ -85,9 +85,9 @@ final notifierProviderFactory = TestMatrix<NotifierTestFactory>(
       isAutoDispose: true,
       isFamily: true,
       deferredNotifier: DeferredFamilyNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify}) {
+      deferredProvider: <ValueT>(create, {updateShouldNotify}) {
         return NotifierProvider.family
-            .autoDispose<DeferredFamilyNotifier<StateT>, StateT, Object?>(
+            .autoDispose<DeferredFamilyNotifier<ValueT>, ValueT, Object?>(
               () => DeferredFamilyNotifier(
                 create,
                 updateShouldNotify: updateShouldNotify,
@@ -95,10 +95,10 @@ final notifierProviderFactory = TestMatrix<NotifierTestFactory>(
             )
             .call(42);
       },
-      provider: <StateT>(create) {
+      provider: <ValueT>(create) {
         return NotifierProvider.autoDispose
-            .family<FamilyNotifier<StateT, Object?>, StateT, Object?>(
-              () => create() as FamilyNotifier<StateT, Object?>,
+            .family<FamilyNotifier<ValueT, Object?>, ValueT, Object?>(
+              () => create() as FamilyNotifier<ValueT, Object?>,
             )
             .call(42);
       },
@@ -115,32 +115,32 @@ final notifierProviderFactory = TestMatrix<NotifierTestFactory>(
   },
 );
 
-abstract class TestNotifier<StateT> implements $Notifier<StateT> {
+abstract class TestNotifier<ValueT> implements $Notifier<ValueT> {
   // Removing protected
   @override
-  StateT get state;
+  ValueT get state;
 
   @override
-  set state(StateT value);
+  set state(ValueT value);
 
   @override
   RemoveListener listenSelf(
-    void Function(StateT? previous, StateT next) listener, {
+    void Function(ValueT? previous, ValueT next) listener, {
     void Function(Object error, StackTrace stackTrace)? onError,
   });
 }
 
-class DeferredNotifier<StateT> extends Notifier<StateT>
-    implements TestNotifier<StateT> {
+class DeferredNotifier<ValueT> extends Notifier<ValueT>
+    implements TestNotifier<ValueT> {
   DeferredNotifier(
     this._create, {
-    bool Function(StateT, StateT)? updateShouldNotify,
+    bool Function(ValueT, ValueT)? updateShouldNotify,
   }) : _updateShouldNotify = updateShouldNotify;
 
-  final StateT Function(Ref ref, DeferredNotifier<StateT> self) _create;
+  final ValueT Function(Ref ref, DeferredNotifier<ValueT> self) _create;
   final bool Function(
-    StateT previousState,
-    StateT newState,
+    ValueT previousState,
+    ValueT newState,
   )? _updateShouldNotify;
 
   @override
@@ -148,47 +148,47 @@ class DeferredNotifier<StateT> extends Notifier<StateT>
 
   @override
   RemoveListener listenSelf(
-    void Function(StateT? previous, StateT next) listener, {
+    void Function(ValueT? previous, ValueT next) listener, {
     void Function(Object error, StackTrace stackTrace)? onError,
   });
 
   @override
-  StateT build() => _create(ref, this);
+  ValueT build() => _create(ref, this);
 
   @override
-  bool updateShouldNotify(StateT previousState, StateT newState) =>
+  bool updateShouldNotify(ValueT previousState, ValueT newState) =>
       _updateShouldNotify?.call(previousState, newState) ??
       super.updateShouldNotify(previousState, newState);
 }
 
-class DeferredFamilyNotifier<StateT> extends FamilyNotifier<StateT, int>
-    implements TestNotifier<StateT> {
+class DeferredFamilyNotifier<ValueT> extends FamilyNotifier<ValueT, int>
+    implements TestNotifier<ValueT> {
   DeferredFamilyNotifier(
     this._create, {
-    bool Function(StateT, StateT)? updateShouldNotify,
+    bool Function(ValueT, ValueT)? updateShouldNotify,
   }) : _updateShouldNotify = updateShouldNotify;
 
-  final StateT Function(Ref ref, DeferredFamilyNotifier<StateT> self) _create;
+  final ValueT Function(Ref ref, DeferredFamilyNotifier<ValueT> self) _create;
 
   final bool Function(
-    StateT previousState,
-    StateT newState,
+    ValueT previousState,
+    ValueT newState,
   )? _updateShouldNotify;
 
   @override
-  StateT build(int arg) => _create(ref, this);
+  ValueT build(int arg) => _create(ref, this);
 
   @override
   bool updateShouldNotify(
-    StateT previousState,
-    StateT newState,
+    ValueT previousState,
+    ValueT newState,
   ) =>
       _updateShouldNotify?.call(previousState, newState) ??
       super.updateShouldNotify(previousState, newState);
 }
 
 class NotifierTestFactory extends TestFactory<
-    ProviderFactory<$Notifier<Object?>, ProviderBase<Object?>>> {
+    ProviderFactory<$Notifier<Object?>, ProviderBase<Object?, Object?>>> {
   NotifierTestFactory({
     required super.isAutoDispose,
     required super.isFamily,
@@ -198,24 +198,24 @@ class NotifierTestFactory extends TestFactory<
     required this.provider,
   });
 
-  final TestNotifier<StateT> Function<StateT>(
-    StateT Function(Ref ref, $Notifier<StateT> self) create,
+  final TestNotifier<ValueT> Function<ValueT>(
+    ValueT Function(Ref ref, $Notifier<ValueT> self) create,
   ) deferredNotifier;
 
-  final $NotifierProvider<TestNotifier<StateT>, StateT> Function<StateT>(
-    StateT Function(Ref ref, $Notifier<StateT> self) create, {
-    bool Function(StateT, StateT)? updateShouldNotify,
+  final $NotifierProvider<TestNotifier<ValueT>, ValueT> Function<ValueT>(
+    ValueT Function(Ref ref, $Notifier<ValueT> self) create, {
+    bool Function(ValueT, ValueT)? updateShouldNotify,
   }) deferredProvider;
 
-  final $NotifierProvider<$Notifier<StateT>, StateT> Function<StateT>(
-    $Notifier<StateT> Function() create,
+  final $NotifierProvider<$Notifier<ValueT>, ValueT> Function<ValueT>(
+    $Notifier<ValueT> Function() create,
   ) provider;
 
-  $NotifierProvider<TestNotifier<StateT>, StateT> simpleTestProvider<StateT>(
-    StateT Function(Ref ref, $Notifier<StateT> self) create, {
-    bool Function(StateT, StateT)? updateShouldNotify,
+  $NotifierProvider<TestNotifier<ValueT>, ValueT> simpleTestProvider<ValueT>(
+    ValueT Function(Ref ref, $Notifier<ValueT> self) create, {
+    bool Function(ValueT, ValueT)? updateShouldNotify,
   }) {
-    return deferredProvider<StateT>(
+    return deferredProvider<ValueT>(
       (ref, self) => create(ref, self),
       updateShouldNotify: updateShouldNotify,
     );

--- a/packages/riverpod/test/src/matrix/stream_notifier_provider.dart
+++ b/packages/riverpod/test/src/matrix/stream_notifier_provider.dart
@@ -6,8 +6,8 @@ final streamNotifierProviderFactory = TestMatrix<StreamNotifierTestFactory>(
       isAutoDispose: false,
       isFamily: false,
       deferredNotifier: DeferredStreamNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify, retry}) {
-        return StreamNotifierProvider<DeferredStreamNotifier<StateT>, StateT>(
+      deferredProvider: <ValueT>(create, {updateShouldNotify, retry}) {
+        return StreamNotifierProvider<DeferredStreamNotifier<ValueT>, ValueT>(
           retry: retry,
           () => DeferredStreamNotifier(
             create,
@@ -15,9 +15,9 @@ final streamNotifierProviderFactory = TestMatrix<StreamNotifierTestFactory>(
           ),
         );
       },
-      provider: <StateT>(create) =>
-          StreamNotifierProvider<StreamNotifier<StateT>, StateT>(
-        () => create() as StreamNotifier<StateT>,
+      provider: <ValueT>(create) =>
+          StreamNotifierProvider<StreamNotifier<ValueT>, ValueT>(
+        () => create() as StreamNotifier<ValueT>,
       ),
       value: (create, {name, dependencies, retry}) => ([arg]) {
         return StreamNotifierProvider<StreamNotifier<Object?>, Object?>(
@@ -32,9 +32,9 @@ final streamNotifierProviderFactory = TestMatrix<StreamNotifierTestFactory>(
       isAutoDispose: true,
       isFamily: false,
       deferredNotifier: DeferredStreamNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify, retry}) {
+      deferredProvider: <ValueT>(create, {updateShouldNotify, retry}) {
         return StreamNotifierProvider.autoDispose<
-            DeferredStreamNotifier<StateT>, StateT>(
+            DeferredStreamNotifier<ValueT>, ValueT>(
           retry: retry,
           () => DeferredStreamNotifier(
             create,
@@ -42,10 +42,10 @@ final streamNotifierProviderFactory = TestMatrix<StreamNotifierTestFactory>(
           ),
         );
       },
-      provider: <StateT>(create) {
-        return StreamNotifierProvider.autoDispose<StreamNotifier<StateT>,
-            StateT>(
-          () => create() as StreamNotifier<StateT>,
+      provider: <ValueT>(create) {
+        return StreamNotifierProvider.autoDispose<StreamNotifier<ValueT>,
+            ValueT>(
+          () => create() as StreamNotifier<ValueT>,
         );
       },
       value: (create, {name, dependencies, retry}) => ([arg]) {
@@ -62,9 +62,9 @@ final streamNotifierProviderFactory = TestMatrix<StreamNotifierTestFactory>(
       isAutoDispose: false,
       isFamily: true,
       deferredNotifier: DeferredFamilyStreamNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify, retry}) {
+      deferredProvider: <ValueT>(create, {updateShouldNotify, retry}) {
         return StreamNotifierProvider.family<
-            DeferredFamilyStreamNotifier<StateT>, StateT, Object?>(
+            DeferredFamilyStreamNotifier<ValueT>, ValueT, Object?>(
           retry: retry,
           () => DeferredFamilyStreamNotifier(
             create,
@@ -72,10 +72,10 @@ final streamNotifierProviderFactory = TestMatrix<StreamNotifierTestFactory>(
           ),
         ).call(42);
       },
-      provider: <StateT>(create) {
+      provider: <ValueT>(create) {
         return StreamNotifierProvider.family<
-            FamilyStreamNotifier<StateT, Object?>, StateT, Object?>(
-          () => create() as FamilyStreamNotifier<StateT, Object?>,
+            FamilyStreamNotifier<ValueT, Object?>, ValueT, Object?>(
+          () => create() as FamilyStreamNotifier<ValueT, Object?>,
         ).call(42);
       },
       value: (create, {name, dependencies, retry}) => ([arg]) {
@@ -92,9 +92,9 @@ final streamNotifierProviderFactory = TestMatrix<StreamNotifierTestFactory>(
       isAutoDispose: true,
       isFamily: true,
       deferredNotifier: DeferredFamilyStreamNotifier.new,
-      deferredProvider: <StateT>(create, {updateShouldNotify, retry}) {
+      deferredProvider: <ValueT>(create, {updateShouldNotify, retry}) {
         return StreamNotifierProvider.family
-            .autoDispose<DeferredFamilyStreamNotifier<StateT>, StateT, Object?>(
+            .autoDispose<DeferredFamilyStreamNotifier<ValueT>, ValueT, Object?>(
               retry: retry,
               () => DeferredFamilyStreamNotifier(
                 create,
@@ -103,10 +103,10 @@ final streamNotifierProviderFactory = TestMatrix<StreamNotifierTestFactory>(
             )
             .call(42);
       },
-      provider: <StateT>(create) {
+      provider: <ValueT>(create) {
         return StreamNotifierProvider.autoDispose
-            .family<FamilyStreamNotifier<StateT, Object?>, StateT, Object?>(
-              () => create() as FamilyStreamNotifier<StateT, Object?>,
+            .family<FamilyStreamNotifier<ValueT, Object?>, ValueT, Object?>(
+              () => create() as FamilyStreamNotifier<ValueT, Object?>,
             )
             .call(42);
       },
@@ -123,37 +123,37 @@ final streamNotifierProviderFactory = TestMatrix<StreamNotifierTestFactory>(
   },
 );
 
-abstract class TestStreamNotifier<StateT> implements $StreamNotifier<StateT> {
+abstract class TestStreamNotifier<ValueT> implements $StreamNotifier<ValueT> {
   // Removing protected
   @override
-  AsyncValue<StateT> get state;
+  AsyncValue<ValueT> get state;
 
   @override
-  set state(AsyncValue<StateT> value);
+  set state(AsyncValue<ValueT> value);
 }
 
-class DeferredStreamNotifier<StateT> extends StreamNotifier<StateT>
-    implements TestStreamNotifier<StateT> {
+class DeferredStreamNotifier<ValueT> extends StreamNotifier<ValueT>
+    implements TestStreamNotifier<ValueT> {
   DeferredStreamNotifier(
     this._create, {
-    bool Function(AsyncValue<StateT>, AsyncValue<StateT>)? updateShouldNotify,
+    bool Function(AsyncValue<ValueT>, AsyncValue<ValueT>)? updateShouldNotify,
   }) : _updateShouldNotify = updateShouldNotify;
 
-  final Stream<StateT> Function(
+  final Stream<ValueT> Function(
     Ref ref,
-    DeferredStreamNotifier<StateT> self,
+    DeferredStreamNotifier<ValueT> self,
   ) _create;
   final bool Function(
-    AsyncValue<StateT> previousState,
-    AsyncValue<StateT> newState,
+    AsyncValue<ValueT> previousState,
+    AsyncValue<ValueT> newState,
   )? _updateShouldNotify;
 
   @override
-  Stream<StateT> build() => _create(ref, this);
+  Stream<ValueT> build() => _create(ref, this);
 
   @override
   RemoveListener listenSelf(
-    void Function(AsyncValue<StateT>? previous, AsyncValue<StateT> next)
+    void Function(AsyncValue<ValueT>? previous, AsyncValue<ValueT> next)
         listener, {
     void Function(Object error, StackTrace stackTrace)? onError,
   }) {
@@ -162,45 +162,45 @@ class DeferredStreamNotifier<StateT> extends StreamNotifier<StateT>
 
   @override
   bool updateShouldNotify(
-    AsyncValue<StateT> previousState,
-    AsyncValue<StateT> newState,
+    AsyncValue<ValueT> previousState,
+    AsyncValue<ValueT> newState,
   ) =>
       _updateShouldNotify?.call(previousState, newState) ??
       super.updateShouldNotify(previousState, newState);
 }
 
-class DeferredFamilyStreamNotifier<StateT>
-    extends FamilyStreamNotifier<StateT, int>
-    implements TestStreamNotifier<StateT> {
+class DeferredFamilyStreamNotifier<ValueT>
+    extends FamilyStreamNotifier<ValueT, int>
+    implements TestStreamNotifier<ValueT> {
   DeferredFamilyStreamNotifier(
     this._create, {
-    bool Function(AsyncValue<StateT>, AsyncValue<StateT>)? updateShouldNotify,
+    bool Function(AsyncValue<ValueT>, AsyncValue<ValueT>)? updateShouldNotify,
   }) : _updateShouldNotify = updateShouldNotify;
 
-  final Stream<StateT> Function(
+  final Stream<ValueT> Function(
     Ref ref,
-    DeferredFamilyStreamNotifier<StateT> self,
+    DeferredFamilyStreamNotifier<ValueT> self,
   ) _create;
 
   final bool Function(
-    AsyncValue<StateT> previousState,
-    AsyncValue<StateT> newState,
+    AsyncValue<ValueT> previousState,
+    AsyncValue<ValueT> newState,
   )? _updateShouldNotify;
 
   @override
-  Stream<StateT> build(int arg) => _create(ref, this);
+  Stream<ValueT> build(int arg) => _create(ref, this);
 
   @override
   bool updateShouldNotify(
-    AsyncValue<StateT> previousState,
-    AsyncValue<StateT> newState,
+    AsyncValue<ValueT> previousState,
+    AsyncValue<ValueT> newState,
   ) =>
       _updateShouldNotify?.call(previousState, newState) ??
       super.updateShouldNotify(previousState, newState);
 }
 
 class StreamNotifierTestFactory extends TestFactory<
-    ProviderFactory<$StreamNotifier<Object?>, ProviderBase<Object?>>> {
+    ProviderFactory<$StreamNotifier<Object?>, ProviderBase<Object?, Object?>>> {
   StreamNotifierTestFactory({
     required super.isAutoDispose,
     required super.isFamily,
@@ -210,29 +210,29 @@ class StreamNotifierTestFactory extends TestFactory<
     required this.provider,
   });
 
-  final TestStreamNotifier<StateT> Function<StateT>(
-    Stream<StateT> Function(Ref ref, $StreamNotifier<StateT> self) create,
+  final TestStreamNotifier<ValueT> Function<ValueT>(
+    Stream<ValueT> Function(Ref ref, $StreamNotifier<ValueT> self) create,
   ) deferredNotifier;
 
-  final $StreamNotifierProvider<TestStreamNotifier<StateT>, StateT>
-      Function<StateT>(
-    Stream<StateT> Function(Ref ref, $StreamNotifier<StateT> self) create, {
-    bool Function(AsyncValue<StateT>, AsyncValue<StateT>)? updateShouldNotify,
+  final $StreamNotifierProvider<TestStreamNotifier<ValueT>, ValueT>
+      Function<ValueT>(
+    Stream<ValueT> Function(Ref ref, $StreamNotifier<ValueT> self) create, {
+    bool Function(AsyncValue<ValueT>, AsyncValue<ValueT>)? updateShouldNotify,
     Retry? retry,
   }) deferredProvider;
 
-  final $StreamNotifierProvider<$StreamNotifier<StateT>, StateT>
-      Function<StateT>(
-    $StreamNotifier<StateT> Function() create,
+  final $StreamNotifierProvider<$StreamNotifier<ValueT>, ValueT>
+      Function<ValueT>(
+    $StreamNotifier<ValueT> Function() create,
   ) provider;
 
-  $StreamNotifierProvider<TestStreamNotifier<StateT>, StateT>
-      simpleTestProvider<StateT>(
-    Stream<StateT> Function(Ref ref, $StreamNotifier<StateT> self) create, {
-    bool Function(AsyncValue<StateT>, AsyncValue<StateT>)? updateShouldNotify,
+  $StreamNotifierProvider<TestStreamNotifier<ValueT>, ValueT>
+      simpleTestProvider<ValueT>(
+    Stream<ValueT> Function(Ref ref, $StreamNotifier<ValueT> self) create, {
+    bool Function(AsyncValue<ValueT>, AsyncValue<ValueT>)? updateShouldNotify,
     Retry? retry,
   }) {
-    return deferredProvider<StateT>(
+    return deferredProvider<ValueT>(
       (ref, self) => create(ref, self),
       updateShouldNotify: updateShouldNotify,
       retry: retry,

--- a/packages/riverpod_generator/integration/build_yaml/lib/dependencies.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/dependencies.g.dart
@@ -9,7 +9,7 @@ part of 'dependencies.dart';
 @ProviderFor(calc2)
 const myFamilyCalc2ProviderFamily = Calc2Family._();
 
-final class Calc2Provider extends $FunctionalProvider<int, int>
+final class Calc2Provider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const Calc2Provider._(
       {required Calc2Family super.from, required String super.argument})
@@ -65,7 +65,7 @@ final class Calc2Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
@@ -9,7 +9,7 @@ part of 'main.dart';
 @ProviderFor(count)
 const myCountPod = CountProvider._();
 
-final class CountProvider extends $FunctionalProvider<int, int>
+final class CountProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const CountProvider._()
       : super(
@@ -39,7 +39,7 @@ final class CountProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -50,7 +50,7 @@ String _$countHash() => r'a31bb5cbb0ddb2466df2cc62a306709ea24fae12';
 const myCountFuturePod = CountFutureProvider._();
 
 final class CountFutureProvider
-    extends $FunctionalProvider<AsyncValue<int>, FutureOr<int>>
+    extends $FunctionalProvider<AsyncValue<int>, int, FutureOr<int>>
     with $FutureModifier<int>, $FutureProvider<int> {
   const CountFutureProvider._()
       : super(
@@ -83,7 +83,7 @@ String _$countFutureHash() => r'c292214b486fdd9ec98a61e277812f29fc4b5802';
 const myCountStreamPod = CountStreamProvider._();
 
 final class CountStreamProvider
-    extends $FunctionalProvider<AsyncValue<int>, Stream<int>>
+    extends $FunctionalProvider<AsyncValue<int>, int, Stream<int>>
     with $FutureModifier<int>, $StreamProvider<int> {
   const CountStreamProvider._()
       : super(
@@ -145,7 +145,7 @@ final class CountNotifierProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -158,7 +158,7 @@ abstract class _$CountNotifier extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -204,7 +204,7 @@ abstract class _$CountAsyncNotifier extends $AsyncNotifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -250,7 +250,7 @@ abstract class _$CountStreamNotifier extends $StreamNotifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -260,7 +260,7 @@ abstract class _$CountStreamNotifier extends $StreamNotifier<int> {
 @ProviderFor(count2)
 const myFamilyCount2ProviderFamily = Count2Family._();
 
-final class Count2Provider extends $FunctionalProvider<int, int>
+final class Count2Provider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const Count2Provider._(
       {required Count2Family super.from, required int super.argument})
@@ -300,7 +300,7 @@ final class Count2Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -341,7 +341,7 @@ final class Count2Family extends $Family
 const myFamilyCountFuture2ProviderFamily = CountFuture2Family._();
 
 final class CountFuture2Provider
-    extends $FunctionalProvider<AsyncValue<int>, FutureOr<int>>
+    extends $FunctionalProvider<AsyncValue<int>, int, FutureOr<int>>
     with $FutureModifier<int>, $FutureProvider<int> {
   const CountFuture2Provider._(
       {required CountFuture2Family super.from, required int super.argument})
@@ -414,7 +414,7 @@ final class CountFuture2Family extends $Family
 const myFamilyCountStream2ProviderFamily = CountStream2Family._();
 
 final class CountStream2Provider
-    extends $FunctionalProvider<AsyncValue<int>, Stream<int>>
+    extends $FunctionalProvider<AsyncValue<int>, int, Stream<int>>
     with $FutureModifier<int>, $StreamProvider<int> {
   const CountStream2Provider._(
       {required CountStream2Family super.from, required int super.argument})
@@ -522,7 +522,7 @@ final class CountNotifier2Provider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -572,7 +572,7 @@ abstract class _$CountNotifier2 extends $Notifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -664,7 +664,7 @@ abstract class _$CountAsyncNotifier2 extends $AsyncNotifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -757,7 +757,7 @@ abstract class _$CountStreamNotifier2 extends $StreamNotifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);

--- a/packages/riverpod_generator/lib/src/templates/notifier.dart
+++ b/packages/riverpod_generator/lib/src/templates/notifier.dart
@@ -71,7 +71,7 @@ abstract class $notifierBaseName$genericsDefinition extends $baseClass {
   @override
   void runBuild() {
     ${buildVar}build($paramsPassThrough);
-    final ref = this.ref as \$Ref<${provider.exposedTypeDisplayString}>;
+    final ref = this.ref as \$Ref<${provider.exposedTypeDisplayString}, ${provider.valueTypeDisplayString}>;
     final element = ref.element as \$ClassProviderElement<AnyNotifier<${provider.exposedTypeDisplayString}, ${provider.valueTypeDisplayString}>,
           ${provider.exposedTypeDisplayString}, Object?, Object?>;
     element.handleValue(ref, $buildVarUsage);

--- a/packages/riverpod_generator/lib/src/templates/provider.dart
+++ b/packages/riverpod_generator/lib/src/templates/provider.dart
@@ -56,6 +56,7 @@ class ProviderTemplate extends Template {
 ${provider.doc} final class $name$_genericsDefinition
     extends \$FunctionalProvider<
         $exposedType,
+        $valueType,
         $createdType
       >
     $mixins {
@@ -164,7 +165,7 @@ ${provider.doc} final class $name$_genericsDefinition
         for (final mutation in mutations) {
           buffer.writeln('''
   ProviderListenable<${mutation.generatedMutationInterfaceName}> get ${mutation.name}
-    => \$LazyProxyListenable<${mutation.generatedMutationInterfaceName}, ${provider.exposedTypeDisplayString}>(
+    => \$LazyProxyListenable<${mutation.generatedMutationInterfaceName}, ${provider.exposedTypeDisplayString}, ${provider.valueTypeDisplayString}>(
       this,
       (element) {
         element as ${provider.generatedElementName}$_generics;
@@ -190,7 +191,7 @@ ${provider.doc} final class $name$_genericsDefinition
   Override overrideWithValue(${provider.exposedTypeDisplayString} value) {
     return \$ProviderOverride(
       origin: this,
-      providerOverride: \$ValueProvider<${provider.exposedTypeDisplayString}>(value),
+      providerOverride: \$ValueProvider<${provider.exposedTypeDisplayString}, ${provider.valueTypeDisplayString}>(value),
     );
   }
 ''');

--- a/packages/riverpod_generator/test/async_notifier_test.dart
+++ b/packages/riverpod_generator/test/async_notifier_test.dart
@@ -11,7 +11,8 @@ void main() {
       () {
     final container = ProviderContainer.test();
 
-    const ProviderBase<AsyncValue<String>> provider = publicClassProvider;
+    const ProviderBase<AsyncValue<String>, String> provider =
+        publicClassProvider;
     final AsyncValue<String> result = container.read(publicClassProvider);
 
     expect(result, const AsyncData('Hello world'));
@@ -111,7 +112,7 @@ void main() {
       fifth: const ['x42'],
     );
     // ignore: invalid_use_of_internal_member // Just checking
-    final ProviderBase<AsyncValue<String>> futureProvider = provider;
+    final ProviderBase<AsyncValue<String>, String> futureProvider = provider;
 
     final sub = container.listen(
       familyClassProvider(

--- a/packages/riverpod_generator/test/async_test.dart
+++ b/packages/riverpod_generator/test/async_test.dart
@@ -12,7 +12,7 @@ void main() {
       () {
     final container = ProviderContainer.test();
 
-    const ProviderBase<AsyncValue<String>> provider = publicProvider;
+    const ProviderBase<AsyncValue<String>, String> provider = publicProvider;
     final AsyncValue<String> result = container.read(publicProvider);
 
     expect(result, const AsyncData('Hello world'));
@@ -104,7 +104,7 @@ void main() {
       fourth: false,
       fifth: const ['x42'],
     );
-    final ProviderBase<AsyncValue<String>> futureProvider = provider;
+    final ProviderBase<AsyncValue<String>, String> futureProvider = provider;
 
     final sub = container.listen(
       familyProvider(

--- a/packages/riverpod_generator/test/integration/annotated.g.dart
+++ b/packages/riverpod_generator/test/integration/annotated.g.dart
@@ -12,8 +12,8 @@ part of 'annotated.dart';
 @protected
 const functionalProvider = FunctionalFamily._();
 
-final class FunctionalProvider extends $FunctionalProvider<String, String>
-    with $Provider<String> {
+final class FunctionalProvider
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const FunctionalProvider._(
       {required FunctionalFamily super.from, required int super.argument})
       : super(
@@ -52,7 +52,7 @@ final class FunctionalProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -130,7 +130,7 @@ final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -181,7 +181,7 @@ abstract class _$ClassBased extends $Notifier<String> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -194,7 +194,7 @@ abstract class _$ClassBased extends $Notifier<String> {
 @protected
 const familyProvider = FamilyFamily._();
 
-final class FamilyProvider extends $FunctionalProvider<String, String>
+final class FamilyProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const FamilyProvider._(
       {required FamilyFamily super.from, required int super.argument})
@@ -234,7 +234,7 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -275,7 +275,7 @@ final class FamilyFamily extends $Family
 const notCopiedFunctionalProvider = NotCopiedFunctionalProvider._();
 
 final class NotCopiedFunctionalProvider
-    extends $FunctionalProvider<String, String> with $Provider<String> {
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const NotCopiedFunctionalProvider._()
       : super(
           from: null,
@@ -304,7 +304,7 @@ final class NotCopiedFunctionalProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -345,7 +345,7 @@ final class NotCopiedClassBasedProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -359,7 +359,7 @@ abstract class _$NotCopiedClassBased extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -369,8 +369,8 @@ abstract class _$NotCopiedClassBased extends $Notifier<String> {
 @ProviderFor(notCopiedFamily)
 const notCopiedFamilyProvider = NotCopiedFamilyFamily._();
 
-final class NotCopiedFamilyProvider extends $FunctionalProvider<String, String>
-    with $Provider<String> {
+final class NotCopiedFamilyProvider
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const NotCopiedFamilyProvider._(
       {required NotCopiedFamilyFamily super.from, required int super.argument})
       : super(
@@ -409,7 +409,7 @@ final class NotCopiedFamilyProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/integration/async.g.dart
+++ b/packages/riverpod_generator/test/integration/async.g.dart
@@ -10,7 +10,7 @@ part of 'async.dart';
 const genericProvider = GenericFamily._();
 
 final class GenericProvider<T extends num>
-    extends $FunctionalProvider<AsyncValue<List<T>>, FutureOr<List<T>>>
+    extends $FunctionalProvider<AsyncValue<List<T>>, List<T>, FutureOr<List<T>>>
     with $FutureModifier<List<T>>, $FutureProvider<List<T>> {
   const GenericProvider._({required GenericFamily super.from})
       : super(
@@ -196,7 +196,7 @@ abstract class _$GenericClass<T extends num> extends $AsyncNotifier<List<T>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<T>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<T>>, List<T>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<T>>, List<T>>,
         AsyncValue<List<T>>,
@@ -321,7 +321,7 @@ abstract class _$GenericArg<T extends num> extends $AsyncNotifier<String> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,
@@ -335,7 +335,7 @@ abstract class _$GenericArg<T extends num> extends $AsyncNotifier<String> {
 const publicProvider = PublicProvider._();
 
 final class PublicProvider
-    extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
   const PublicProvider._()
       : super(
@@ -368,7 +368,7 @@ String _$publicHash() => r'19bceccf795e4c3a26ad1e613fd6f41aad949e2b';
 const _privateProvider = _PrivateProvider._();
 
 final class _PrivateProvider
-    extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
   const _PrivateProvider._()
       : super(
@@ -401,7 +401,7 @@ String _$privateHash() => r'7f0d1ff55a21e520b8471bbabc4649b5336221d4';
 const familyOrProvider = FamilyOrFamily._();
 
 final class FamilyOrProvider
-    extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
   const FamilyOrProvider._(
       {required FamilyOrFamily super.from, required int super.argument})
@@ -474,7 +474,7 @@ final class FamilyOrFamily extends $Family
 const familyProvider = FamilyFamily._();
 
 final class FamilyProvider
-    extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
   const FamilyProvider._(
       {required FamilyFamily super.from,
@@ -618,7 +618,7 @@ abstract class _$PublicClass extends $AsyncNotifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,
@@ -666,7 +666,7 @@ abstract class _$PrivateClass extends $AsyncNotifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,
@@ -759,7 +759,7 @@ abstract class _$FamilyOrClass extends $AsyncNotifier<String> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,
@@ -898,7 +898,7 @@ abstract class _$FamilyClass extends $AsyncNotifier<String> {
       fourth: _$args.fourth,
       fifth: _$args.fifth,
     );
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,
@@ -958,7 +958,7 @@ final class Regression3490Provider<Model, Sort, Cursor>
   Override overrideWithValue(void value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<void>(value),
+      providerOverride: $ValueProvider<void, void>(value),
     );
   }
 
@@ -1058,7 +1058,7 @@ abstract class _$Regression3490<Model, Sort, Cursor> extends $Notifier<void> {
       getData: _$args.getData,
       parentId: _$args.parentId,
     );
-    final ref = this.ref as $Ref<void>;
+    final ref = this.ref as $Ref<void, void>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<void, void>, void, Object?, Object?>;
     element.handleValue(ref, null);

--- a/packages/riverpod_generator/test/integration/auto_dispose.g.dart
+++ b/packages/riverpod_generator/test/integration/auto_dispose.g.dart
@@ -9,7 +9,7 @@ part of 'auto_dispose.dart';
 @ProviderFor(keepAlive)
 const keepAliveProvider = KeepAliveProvider._();
 
-final class KeepAliveProvider extends $FunctionalProvider<int, int>
+final class KeepAliveProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const KeepAliveProvider._()
       : super(
@@ -39,7 +39,7 @@ final class KeepAliveProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -49,7 +49,7 @@ String _$keepAliveHash() => r'44af50bf7e6dcfddc61a1f32855855b534a7fe4f';
 @ProviderFor(notKeepAlive)
 const notKeepAliveProvider = NotKeepAliveProvider._();
 
-final class NotKeepAliveProvider extends $FunctionalProvider<int, int>
+final class NotKeepAliveProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const NotKeepAliveProvider._()
       : super(
@@ -79,7 +79,7 @@ final class NotKeepAliveProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -89,7 +89,7 @@ String _$notKeepAliveHash() => r'e60c952d04ffd7548294908c2e1ef472614c284b';
 @ProviderFor(defaultKeepAlive)
 const defaultKeepAliveProvider = DefaultKeepAliveProvider._();
 
-final class DefaultKeepAliveProvider extends $FunctionalProvider<int, int>
+final class DefaultKeepAliveProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const DefaultKeepAliveProvider._()
       : super(
@@ -119,7 +119,7 @@ final class DefaultKeepAliveProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -129,7 +129,7 @@ String _$defaultKeepAliveHash() => r'76485c3c7574c38dcba6dda28c94a59c09b339c0';
 @ProviderFor(keepAliveFamily)
 const keepAliveFamilyProvider = KeepAliveFamilyFamily._();
 
-final class KeepAliveFamilyProvider extends $FunctionalProvider<int, int>
+final class KeepAliveFamilyProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const KeepAliveFamilyProvider._(
       {required KeepAliveFamilyFamily super.from, required int super.argument})
@@ -169,7 +169,7 @@ final class KeepAliveFamilyProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -209,8 +209,8 @@ final class KeepAliveFamilyFamily extends $Family
 @ProviderFor(notKeepAliveFamily)
 const notKeepAliveFamilyProvider = NotKeepAliveFamilyFamily._();
 
-final class NotKeepAliveFamilyProvider extends $FunctionalProvider<int, int>
-    with $Provider<int> {
+final class NotKeepAliveFamilyProvider
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const NotKeepAliveFamilyProvider._(
       {required NotKeepAliveFamilyFamily super.from,
       required int super.argument})
@@ -250,7 +250,7 @@ final class NotKeepAliveFamilyProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -291,8 +291,8 @@ final class NotKeepAliveFamilyFamily extends $Family
 @ProviderFor(defaultKeepAliveFamily)
 const defaultKeepAliveFamilyProvider = DefaultKeepAliveFamilyFamily._();
 
-final class DefaultKeepAliveFamilyProvider extends $FunctionalProvider<int, int>
-    with $Provider<int> {
+final class DefaultKeepAliveFamilyProvider
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const DefaultKeepAliveFamilyProvider._(
       {required DefaultKeepAliveFamilyFamily super.from,
       required int super.argument})
@@ -332,7 +332,7 @@ final class DefaultKeepAliveFamilyProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/integration/dependencies.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies.g.dart
@@ -9,7 +9,7 @@ part of 'dependencies.dart';
 @ProviderFor(dep)
 const depProvider = DepProvider._();
 
-final class DepProvider extends $FunctionalProvider<int, int>
+final class DepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const DepProvider._()
       : super(
@@ -39,7 +39,7 @@ final class DepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -49,7 +49,7 @@ String _$depHash() => r'1b3ec5231cd2328602151de9ceacdcd102a1d2e2';
 @ProviderFor(family)
 const familyProvider = FamilyFamily._();
 
-final class FamilyProvider extends $FunctionalProvider<int, int>
+final class FamilyProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const FamilyProvider._(
       {required FamilyFamily super.from, required int super.argument})
@@ -89,7 +89,7 @@ final class FamilyProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -158,7 +158,7 @@ final class Dep2Provider extends $NotifierProvider<Dep2, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -171,7 +171,7 @@ abstract class _$Dep2 extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -216,7 +216,7 @@ final class Family2Provider extends $NotifierProvider<Family2, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -266,7 +266,7 @@ abstract class _$Family2 extends $Notifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -276,7 +276,7 @@ abstract class _$Family2 extends $Notifier<int> {
 @ProviderFor(provider)
 const providerProvider = ProviderProvider._();
 
-final class ProviderProvider extends $FunctionalProvider<int, int>
+final class ProviderProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const ProviderProvider._()
       : super(
@@ -321,7 +321,7 @@ final class ProviderProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -331,7 +331,7 @@ String _$providerHash() => r'1be7ae7ac2100d39b949af50ec50fce48b26cdd1';
 @ProviderFor(provider2)
 const provider2Provider = Provider2Provider._();
 
-final class Provider2Provider extends $FunctionalProvider<int, int>
+final class Provider2Provider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const Provider2Provider._()
       : super(
@@ -376,7 +376,7 @@ final class Provider2Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -430,7 +430,7 @@ final class Provider3Provider extends $NotifierProvider<Provider3, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -443,7 +443,7 @@ abstract class _$Provider3 extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -493,7 +493,7 @@ final class Provider4Provider extends $NotifierProvider<Provider4, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -553,7 +553,7 @@ abstract class _$Provider4 extends $Notifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -563,8 +563,8 @@ abstract class _$Provider4 extends $Notifier<int> {
 @ProviderFor(transitiveDependencies)
 const transitiveDependenciesProvider = TransitiveDependenciesProvider._();
 
-final class TransitiveDependenciesProvider extends $FunctionalProvider<int, int>
-    with $Provider<int> {
+final class TransitiveDependenciesProvider
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const TransitiveDependenciesProvider._()
       : super(
           from: null,
@@ -609,7 +609,7 @@ final class TransitiveDependenciesProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -622,7 +622,7 @@ const smallTransitiveDependencyCountProvider =
     SmallTransitiveDependencyCountProvider._();
 
 final class SmallTransitiveDependencyCountProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const SmallTransitiveDependencyCountProvider._()
       : super(
           from: null,
@@ -663,7 +663,7 @@ final class SmallTransitiveDependencyCountProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -676,7 +676,7 @@ const emptyDependenciesFunctionalProvider =
     EmptyDependenciesFunctionalProvider._();
 
 final class EmptyDependenciesFunctionalProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const EmptyDependenciesFunctionalProvider._()
       : super(
           from: null,
@@ -705,7 +705,7 @@ final class EmptyDependenciesFunctionalProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -747,7 +747,7 @@ final class EmptyDependenciesClassBasedProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -761,7 +761,7 @@ abstract class _$EmptyDependenciesClassBased extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -772,7 +772,7 @@ abstract class _$EmptyDependenciesClassBased extends $Notifier<int> {
 const providerWithDependenciesProvider = ProviderWithDependenciesProvider._();
 
 final class ProviderWithDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const ProviderWithDependenciesProvider._()
       : super(
           from: null,
@@ -810,7 +810,7 @@ final class ProviderWithDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -821,7 +821,7 @@ String _$providerWithDependenciesHash() =>
 @ProviderFor(_privateDep)
 const _privateDepProvider = _PrivateDepProvider._();
 
-final class _PrivateDepProvider extends $FunctionalProvider<int, int>
+final class _PrivateDepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const _PrivateDepProvider._()
       : super(
@@ -851,7 +851,7 @@ final class _PrivateDepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -861,7 +861,7 @@ String _$privateDepHash() => r'92ff5cc515ecf2455cb04773f1b49f23b17ea2e2';
 @ProviderFor(publicDep)
 const publicDepProvider = PublicDepProvider._();
 
-final class PublicDepProvider extends $FunctionalProvider<int, int>
+final class PublicDepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const PublicDepProvider._()
       : super(
@@ -891,7 +891,7 @@ final class PublicDepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -901,8 +901,8 @@ String _$publicDepHash() => r'a9c461ae174577183ab4c0ff8d8267cc7a64a2c5';
 @ProviderFor(duplicateDependencies)
 const duplicateDependenciesProvider = DuplicateDependenciesProvider._();
 
-final class DuplicateDependenciesProvider extends $FunctionalProvider<int, int>
-    with $Provider<int> {
+final class DuplicateDependenciesProvider
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const DuplicateDependenciesProvider._()
       : super(
           from: null,
@@ -937,7 +937,7 @@ final class DuplicateDependenciesProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -948,8 +948,8 @@ String _$duplicateDependenciesHash() =>
 @ProviderFor(duplicateDependencies2)
 const duplicateDependencies2Provider = DuplicateDependencies2Provider._();
 
-final class DuplicateDependencies2Provider extends $FunctionalProvider<int, int>
-    with $Provider<int> {
+final class DuplicateDependencies2Provider
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const DuplicateDependencies2Provider._()
       : super(
           from: null,
@@ -987,7 +987,7 @@ final class DuplicateDependencies2Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -1000,7 +1000,7 @@ const transitiveDuplicateDependenciesProvider =
     TransitiveDuplicateDependenciesProvider._();
 
 final class TransitiveDuplicateDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const TransitiveDuplicateDependenciesProvider._()
       : super(
           from: null,
@@ -1050,7 +1050,7 @@ final class TransitiveDuplicateDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/packages/riverpod_generator/test/integration/dependencies2.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies2.g.dart
@@ -10,7 +10,7 @@ part of 'dependencies2.dart';
 const providerWithDependencies2Provider = ProviderWithDependencies2Provider._();
 
 final class ProviderWithDependencies2Provider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const ProviderWithDependencies2Provider._()
       : super(
           from: null,
@@ -57,7 +57,7 @@ final class ProviderWithDependencies2Provider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -69,7 +69,7 @@ String _$providerWithDependencies2Hash() =>
 const familyWithDependencies2Provider = FamilyWithDependencies2Family._();
 
 final class FamilyWithDependencies2Provider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const FamilyWithDependencies2Provider._(
       {required FamilyWithDependencies2Family super.from,
       required int? super.argument})
@@ -117,7 +117,7 @@ final class FamilyWithDependencies2Provider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -217,7 +217,7 @@ final class NotifierWithDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -231,7 +231,7 @@ abstract class _$NotifierWithDependencies extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -287,7 +287,7 @@ final class NotifierFamilyWithDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -351,7 +351,7 @@ abstract class _$NotifierFamilyWithDependencies extends $Notifier<int> {
     final created = build(
       id: _$args,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -361,7 +361,7 @@ abstract class _$NotifierFamilyWithDependencies extends $Notifier<int> {
 @ProviderFor(_private2)
 const _private2Provider = _Private2Provider._();
 
-final class _Private2Provider extends $FunctionalProvider<int, int>
+final class _Private2Provider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const _Private2Provider._()
       : super(
@@ -391,7 +391,7 @@ final class _Private2Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -401,7 +401,7 @@ String _$private2Hash() => r'e420875c8fbd9bf33eff945f2b7276b585032a38';
 @ProviderFor(public2)
 const public2Provider = Public2Provider._();
 
-final class Public2Provider extends $FunctionalProvider<int, int>
+final class Public2Provider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const Public2Provider._()
       : super(
@@ -431,7 +431,7 @@ final class Public2Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/packages/riverpod_generator/test/integration/documented.g.dart
+++ b/packages/riverpod_generator/test/integration/documented.g.dart
@@ -13,8 +13,8 @@ const functionalProvider = FunctionalProvider._();
 
 /// Hello world
 // Foo
-final class FunctionalProvider extends $FunctionalProvider<String, String>
-    with $Provider<String> {
+final class FunctionalProvider
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   /// Hello world
 // Foo
   const FunctionalProvider._()
@@ -45,7 +45,7 @@ final class FunctionalProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -90,7 +90,7 @@ final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -103,7 +103,7 @@ abstract class _$ClassBased extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -117,7 +117,7 @@ const familyProvider = FamilyFamily._();
 
 /// Hello world
 // Foo
-final class FamilyProvider extends $FunctionalProvider<String, String>
+final class FamilyProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   /// Hello world
 // Foo
@@ -159,7 +159,7 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -245,7 +245,7 @@ final class ClassFamilyBasedProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -302,7 +302,7 @@ abstract class _$ClassFamilyBased extends $Notifier<String> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);

--- a/packages/riverpod_generator/test/integration/generated.g.dart
+++ b/packages/riverpod_generator/test/integration/generated.g.dart
@@ -9,7 +9,7 @@ part of 'generated.dart';
 @ProviderFor(generated)
 const generatedProvider = GeneratedProvider._();
 
-final class GeneratedProvider extends $FunctionalProvider<_Test, _Test>
+final class GeneratedProvider extends $FunctionalProvider<_Test, _Test, _Test>
     with $Provider<_Test> {
   const GeneratedProvider._()
       : super(
@@ -39,7 +39,7 @@ final class GeneratedProvider extends $FunctionalProvider<_Test, _Test>
   Override overrideWithValue(_Test value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<_Test>(value),
+      providerOverride: $ValueProvider<_Test, _Test>(value),
     );
   }
 }
@@ -49,8 +49,8 @@ String _$generatedHash() => r'0332eb232658688654514ff241ff380edbf4dbf6';
 @ProviderFor(generatedFamily)
 const generatedFamilyProvider = GeneratedFamilyFamily._();
 
-final class GeneratedFamilyProvider extends $FunctionalProvider<_Test, _Test>
-    with $Provider<_Test> {
+final class GeneratedFamilyProvider
+    extends $FunctionalProvider<_Test, _Test, _Test> with $Provider<_Test> {
   const GeneratedFamilyProvider._(
       {required GeneratedFamilyFamily super.from,
       required _Test super.argument})
@@ -90,7 +90,7 @@ final class GeneratedFamilyProvider extends $FunctionalProvider<_Test, _Test>
   Override overrideWithValue(_Test value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<_Test>(value),
+      providerOverride: $ValueProvider<_Test, _Test>(value),
     );
   }
 
@@ -160,7 +160,7 @@ final class GeneratedClassProvider
   Override overrideWithValue(_Test value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<_Test>(value),
+      providerOverride: $ValueProvider<_Test, _Test>(value),
     );
   }
 }
@@ -173,7 +173,7 @@ abstract class _$GeneratedClass extends $Notifier<_Test> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<_Test>;
+    final ref = this.ref as $Ref<_Test, _Test>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<_Test, _Test>, _Test, Object?, Object?>;
     element.handleValue(ref, created);
@@ -220,7 +220,7 @@ final class GeneratedClassFamilyProvider
   Override overrideWithValue(_Test value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<_Test>(value),
+      providerOverride: $ValueProvider<_Test, _Test>(value),
     );
   }
 
@@ -272,7 +272,7 @@ abstract class _$GeneratedClassFamily extends $Notifier<_Test> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<_Test>;
+    final ref = this.ref as $Ref<_Test, _Test>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<_Test, _Test>, _Test, Object?, Object?>;
     element.handleValue(ref, created);
@@ -282,7 +282,8 @@ abstract class _$GeneratedClassFamily extends $Notifier<_Test> {
 @ProviderFor($dynamic)
 const $dynamicProvider = $DynamicProvider._();
 
-final class $DynamicProvider extends $FunctionalProvider<Object?, Object?>
+final class $DynamicProvider
+    extends $FunctionalProvider<Object?, Object?, Object?>
     with $Provider<Object?> {
   const $DynamicProvider._()
       : super(
@@ -312,7 +313,7 @@ final class $DynamicProvider extends $FunctionalProvider<Object?, Object?>
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?>(value),
+      providerOverride: $ValueProvider<Object?, Object?>(value),
     );
   }
 }
@@ -322,7 +323,8 @@ String _$$dynamicHash() => r'17c8e140446da2e3c026ebb51c4b074d2894b7ff';
 @ProviderFor($dynamicFamily)
 const $dynamicFamilyProvider = $DynamicFamilyFamily._();
 
-final class $DynamicFamilyProvider extends $FunctionalProvider<Object?, Object?>
+final class $DynamicFamilyProvider
+    extends $FunctionalProvider<Object?, Object?, Object?>
     with $Provider<Object?> {
   const $DynamicFamilyProvider._(
       {required $DynamicFamilyFamily super.from,
@@ -363,7 +365,7 @@ final class $DynamicFamilyProvider extends $FunctionalProvider<Object?, Object?>
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?>(value),
+      providerOverride: $ValueProvider<Object?, Object?>(value),
     );
   }
 
@@ -433,7 +435,7 @@ final class $DynamicClassProvider
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?>(value),
+      providerOverride: $ValueProvider<Object?, Object?>(value),
     );
   }
 }
@@ -446,7 +448,7 @@ abstract class _$$DynamicClass extends $Notifier<Object?> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<Object?>;
+    final ref = this.ref as $Ref<Object?, Object?>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<Object?, Object?>, Object?, Object?, Object?>;
     element.handleValue(ref, created);
@@ -493,7 +495,7 @@ final class $DynamicClassFamilyProvider
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?>(value),
+      providerOverride: $ValueProvider<Object?, Object?>(value),
     );
   }
 
@@ -546,7 +548,7 @@ abstract class _$$DynamicClassFamily extends $Notifier<Object?> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<Object?>;
+    final ref = this.ref as $Ref<Object?, Object?>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<Object?, Object?>, Object?, Object?, Object?>;
     element.handleValue(ref, created);
@@ -556,7 +558,8 @@ abstract class _$$DynamicClassFamily extends $Notifier<Object?> {
 @ProviderFor(_dynamic)
 const _dynamicProvider = _DynamicFamily._();
 
-final class _DynamicProvider extends $FunctionalProvider<Object?, Object?>
+final class _DynamicProvider
+    extends $FunctionalProvider<Object?, Object?, Object?>
     with $Provider<Object?> {
   const _DynamicProvider._(
       {required _DynamicFamily super.from, required dynamic super.argument})
@@ -596,7 +599,7 @@ final class _DynamicProvider extends $FunctionalProvider<Object?, Object?>
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?>(value),
+      providerOverride: $ValueProvider<Object?, Object?>(value),
     );
   }
 
@@ -636,9 +639,8 @@ final class _DynamicFamily extends $Family
 @ProviderFor(alias)
 const aliasProvider = AliasProvider._();
 
-final class AliasProvider
-    extends $FunctionalProvider<AsyncValue<int>, AsyncValue<int>>
-    with $Provider<AsyncValue<int>> {
+final class AliasProvider extends $FunctionalProvider<AsyncValue<int>,
+    AsyncValue<int>, AsyncValue<int>> with $Provider<AsyncValue<int>> {
   const AliasProvider._()
       : super(
           from: null,
@@ -667,7 +669,7 @@ final class AliasProvider
   Override overrideWithValue(AsyncValue<int> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+      providerOverride: $ValueProvider<AsyncValue<int>, AsyncValue<int>>(value),
     );
   }
 }
@@ -677,9 +679,8 @@ String _$aliasHash() => r'3feb548aa9a314142b5c5e3c9c7664a316a10d11';
 @ProviderFor(aliasFamily)
 const aliasFamilyProvider = AliasFamilyFamily._();
 
-final class AliasFamilyProvider
-    extends $FunctionalProvider<AsyncValue<int>, AsyncValue<int>>
-    with $Provider<AsyncValue<int>> {
+final class AliasFamilyProvider extends $FunctionalProvider<AsyncValue<int>,
+    AsyncValue<int>, AsyncValue<int>> with $Provider<AsyncValue<int>> {
   const AliasFamilyProvider._(
       {required AliasFamilyFamily super.from,
       required AsyncValue<int> super.argument})
@@ -719,7 +720,7 @@ final class AliasFamilyProvider
   Override overrideWithValue(AsyncValue<int> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+      providerOverride: $ValueProvider<AsyncValue<int>, AsyncValue<int>>(value),
     );
   }
 
@@ -789,7 +790,7 @@ final class AliasClassProvider
   Override overrideWithValue(AsyncValue<int> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+      providerOverride: $ValueProvider<AsyncValue<int>, AsyncValue<int>>(value),
     );
   }
 }
@@ -802,7 +803,7 @@ abstract class _$AliasClass extends $Notifier<AsyncValue<int>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, AsyncValue<int>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, AsyncValue<int>>,
         AsyncValue<int>,
@@ -852,7 +853,7 @@ final class AliasClassFamilyProvider
   Override overrideWithValue(AsyncValue<int> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>>(value),
+      providerOverride: $ValueProvider<AsyncValue<int>, AsyncValue<int>>(value),
     );
   }
 
@@ -904,7 +905,7 @@ abstract class _$AliasClassFamily extends $Notifier<AsyncValue<int>> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, AsyncValue<int>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, AsyncValue<int>>,
         AsyncValue<int>,

--- a/packages/riverpod_generator/test/integration/hash/hash1.g.dart
+++ b/packages/riverpod_generator/test/integration/hash/hash1.g.dart
@@ -9,7 +9,7 @@ part of 'hash1.dart';
 @ProviderFor(simple)
 const simpleProvider = SimpleProvider._();
 
-final class SimpleProvider extends $FunctionalProvider<String, String>
+final class SimpleProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const SimpleProvider._()
       : super(
@@ -39,7 +39,7 @@ final class SimpleProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -49,7 +49,7 @@ String _$simpleHash() => r'f916b37e39d654e9acfc9c2bd7a244902197b306';
 @ProviderFor(simple2)
 const simple2Provider = Simple2Provider._();
 
-final class Simple2Provider extends $FunctionalProvider<String, String>
+final class Simple2Provider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const Simple2Provider._()
       : super(
@@ -79,7 +79,7 @@ final class Simple2Provider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -118,7 +118,7 @@ final class SimpleClassProvider extends $NotifierProvider<SimpleClass, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -131,7 +131,7 @@ abstract class _$SimpleClass extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);

--- a/packages/riverpod_generator/test/integration/hash/retry.g.dart
+++ b/packages/riverpod_generator/test/integration/hash/retry.g.dart
@@ -9,7 +9,7 @@ part of 'retry.dart';
 @ProviderFor(a)
 const aProvider = AProvider._();
 
-final class AProvider extends $FunctionalProvider<String, String>
+final class AProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const AProvider._()
       : super(
@@ -39,7 +39,7 @@ final class AProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -49,7 +49,7 @@ String _$aHash() => r'83a9516d10f85dc72ca773837e042bfc6e36c1f1';
 @ProviderFor(b)
 const bProvider = BFamily._();
 
-final class BProvider extends $FunctionalProvider<String, String>
+final class BProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const BProvider._({required BFamily super.from, required int super.argument})
       : super(
@@ -88,7 +88,7 @@ final class BProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/integration/mutation.g.dart
+++ b/packages/riverpod_generator/test/integration/mutation.g.dart
@@ -35,7 +35,7 @@ final class SyncTodoListProvider
       _$SyncTodoListElement(pointer);
 
   ProviderListenable<SyncTodoList$AddSync> get addSync =>
-      $LazyProxyListenable<SyncTodoList$AddSync, List<Todo>>(
+      $LazyProxyListenable<SyncTodoList$AddSync, List<Todo>, List<Todo>>(
         this,
         (element) {
           element as _$SyncTodoListElement;
@@ -45,7 +45,7 @@ final class SyncTodoListProvider
       );
 
   ProviderListenable<SyncTodoList$AddAsync> get addAsync =>
-      $LazyProxyListenable<SyncTodoList$AddAsync, List<Todo>>(
+      $LazyProxyListenable<SyncTodoList$AddAsync, List<Todo>, List<Todo>>(
         this,
         (element) {
           element as _$SyncTodoListElement;
@@ -58,7 +58,7 @@ final class SyncTodoListProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }
@@ -71,7 +71,7 @@ abstract class _$SyncTodoList extends $Notifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<List<Todo>>;
+    final ref = this.ref as $Ref<List<Todo>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<List<Todo>, List<Todo>>, List<Todo>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -226,8 +226,8 @@ final class AsyncTodoListProvider
   _$AsyncTodoListElement $createElement($ProviderPointer pointer) =>
       _$AsyncTodoListElement(pointer);
 
-  ProviderListenable<AsyncTodoList$AddSync> get addSync =>
-      $LazyProxyListenable<AsyncTodoList$AddSync, AsyncValue<List<Todo>>>(
+  ProviderListenable<AsyncTodoList$AddSync> get addSync => $LazyProxyListenable<
+          AsyncTodoList$AddSync, AsyncValue<List<Todo>>, List<Todo>>(
         this,
         (element) {
           element as _$AsyncTodoListElement;
@@ -237,7 +237,8 @@ final class AsyncTodoListProvider
       );
 
   ProviderListenable<AsyncTodoList$AddAsync> get addAsync =>
-      $LazyProxyListenable<AsyncTodoList$AddAsync, AsyncValue<List<Todo>>>(
+      $LazyProxyListenable<AsyncTodoList$AddAsync, AsyncValue<List<Todo>>,
+          List<Todo>>(
         this,
         (element) {
           element as _$AsyncTodoListElement;
@@ -255,7 +256,7 @@ abstract class _$AsyncTodoList extends $AsyncNotifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<Todo>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<Todo>>, List<Todo>>,
         AsyncValue<List<Todo>>,
@@ -413,7 +414,7 @@ final class SimpleProvider extends $NotifierProvider<Simple, int> {
       _$SimpleElement(pointer);
 
   ProviderListenable<Simple$Increment> get increment =>
-      $LazyProxyListenable<Simple$Increment, int>(
+      $LazyProxyListenable<Simple$Increment, int, int>(
         this,
         (element) {
           element as _$SimpleElement;
@@ -423,7 +424,7 @@ final class SimpleProvider extends $NotifierProvider<Simple, int> {
       );
 
   ProviderListenable<Simple$IncrementOr> get incrementOr =>
-      $LazyProxyListenable<Simple$IncrementOr, int>(
+      $LazyProxyListenable<Simple$IncrementOr, int, int>(
         this,
         (element) {
           element as _$SimpleElement;
@@ -433,7 +434,7 @@ final class SimpleProvider extends $NotifierProvider<Simple, int> {
       );
 
   ProviderListenable<Simple$Delegated> get delegated =>
-      $LazyProxyListenable<Simple$Delegated, int>(
+      $LazyProxyListenable<Simple$Delegated, int, int>(
         this,
         (element) {
           element as _$SimpleElement;
@@ -446,7 +447,7 @@ final class SimpleProvider extends $NotifierProvider<Simple, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -459,7 +460,7 @@ abstract class _$Simple extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -668,7 +669,7 @@ final class SimpleFamilyProvider extends $NotifierProvider<SimpleFamily, int> {
       _$SimpleFamilyElement(pointer);
 
   ProviderListenable<SimpleFamily$Increment> get increment =>
-      $LazyProxyListenable<SimpleFamily$Increment, int>(
+      $LazyProxyListenable<SimpleFamily$Increment, int, int>(
         this,
         (element) {
           element as _$SimpleFamilyElement;
@@ -678,7 +679,7 @@ final class SimpleFamilyProvider extends $NotifierProvider<SimpleFamily, int> {
       );
 
   ProviderListenable<SimpleFamily$IncrementOr> get incrementOr =>
-      $LazyProxyListenable<SimpleFamily$IncrementOr, int>(
+      $LazyProxyListenable<SimpleFamily$IncrementOr, int, int>(
         this,
         (element) {
           element as _$SimpleFamilyElement;
@@ -691,7 +692,7 @@ final class SimpleFamilyProvider extends $NotifierProvider<SimpleFamily, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -741,7 +742,7 @@ abstract class _$SimpleFamily extends $Notifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -897,7 +898,7 @@ final class SimpleAsyncProvider
       _$SimpleAsyncElement(pointer);
 
   ProviderListenable<SimpleAsync$Increment> get increment =>
-      $LazyProxyListenable<SimpleAsync$Increment, AsyncValue<int>>(
+      $LazyProxyListenable<SimpleAsync$Increment, AsyncValue<int>, int>(
         this,
         (element) {
           element as _$SimpleAsyncElement;
@@ -907,7 +908,7 @@ final class SimpleAsyncProvider
       );
 
   ProviderListenable<SimpleAsync$Delegated> get delegated =>
-      $LazyProxyListenable<SimpleAsync$Delegated, AsyncValue<int>>(
+      $LazyProxyListenable<SimpleAsync$Delegated, AsyncValue<int>, int>(
         this,
         (element) {
           element as _$SimpleAsyncElement;
@@ -925,7 +926,7 @@ abstract class _$SimpleAsync extends $AsyncNotifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1087,7 +1088,7 @@ final class SimpleAsync2Provider
       _$SimpleAsync2Element(pointer);
 
   ProviderListenable<SimpleAsync2$Increment> get increment =>
-      $LazyProxyListenable<SimpleAsync2$Increment, AsyncValue<int>>(
+      $LazyProxyListenable<SimpleAsync2$Increment, AsyncValue<int>, int>(
         this,
         (element) {
           element as _$SimpleAsync2Element;
@@ -1144,7 +1145,7 @@ abstract class _$SimpleAsync2 extends $StreamNotifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1253,7 +1254,7 @@ final class GenericProvider<T extends num>
       _$GenericElement(pointer);
 
   ProviderListenable<Generic$Increment> get increment =>
-      $LazyProxyListenable<Generic$Increment, AsyncValue<int>>(
+      $LazyProxyListenable<Generic$Increment, AsyncValue<int>, int>(
         this,
         (element) {
           element as _$GenericElement<T>;
@@ -1331,7 +1332,7 @@ abstract class _$Generic<T extends num> extends $AsyncNotifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1433,7 +1434,7 @@ final class GenericMutProvider extends $AsyncNotifierProvider<GenericMut, int> {
       _$GenericMutElement(pointer);
 
   ProviderListenable<GenericMut$Increment> get increment =>
-      $LazyProxyListenable<GenericMut$Increment, AsyncValue<int>>(
+      $LazyProxyListenable<GenericMut$Increment, AsyncValue<int>, int>(
         this,
         (element) {
           element as _$GenericMutElement;
@@ -1451,7 +1452,7 @@ abstract class _$GenericMut extends $AsyncNotifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1556,7 +1557,7 @@ final class FailingCtorProvider extends $NotifierProvider<FailingCtor, int> {
       _$FailingCtorElement(pointer);
 
   ProviderListenable<FailingCtor$Increment> get increment =>
-      $LazyProxyListenable<FailingCtor$Increment, int>(
+      $LazyProxyListenable<FailingCtor$Increment, int, int>(
         this,
         (element) {
           element as _$FailingCtorElement;
@@ -1569,7 +1570,7 @@ final class FailingCtorProvider extends $NotifierProvider<FailingCtor, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -1582,7 +1583,7 @@ abstract class _$FailingCtor extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1685,7 +1686,7 @@ final class TypedProvider extends $NotifierProvider<Typed, String> {
       _$TypedElement(pointer);
 
   ProviderListenable<Typed$Mutate> get mutate =>
-      $LazyProxyListenable<Typed$Mutate, String>(
+      $LazyProxyListenable<Typed$Mutate, String, String>(
         this,
         (element) {
           element as _$TypedElement;
@@ -1698,7 +1699,7 @@ final class TypedProvider extends $NotifierProvider<Typed, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -1711,7 +1712,7 @@ abstract class _$Typed extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);

--- a/packages/riverpod_generator/test/integration/offline.g.dart
+++ b/packages/riverpod_generator/test/integration/offline.g.dart
@@ -10,7 +10,9 @@ part of 'offline.dart';
 const storageProvider = StorageProvider._();
 
 final class StorageProvider extends $FunctionalProvider<
-        AsyncValue<Storage<String, String>>, FutureOr<Storage<String, String>>>
+        AsyncValue<Storage<String, String>>,
+        Storage<String, String>,
+        FutureOr<Storage<String, String>>>
     with
         $FutureModifier<Storage<String, String>>,
         $FutureProvider<Storage<String, String>> {
@@ -81,7 +83,7 @@ abstract class _$CustomAnnotationBase extends $AsyncNotifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,
@@ -175,7 +177,8 @@ abstract class _$JsonBase extends $AsyncNotifier<Map<String, List<int>>> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<Map<String, List<int>>>>;
+    final ref = this.ref
+        as $Ref<AsyncValue<Map<String, List<int>>>, Map<String, List<int>>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<Map<String, List<int>>>, Map<String, List<int>>>,
         AsyncValue<Map<String, List<int>>>,
@@ -224,7 +227,8 @@ abstract class _$Json2Base extends $AsyncNotifier<Map<String, List<int>>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<Map<String, List<int>>>>;
+    final ref = this.ref
+        as $Ref<AsyncValue<Map<String, List<int>>>, Map<String, List<int>>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<Map<String, List<int>>>, Map<String, List<int>>>,
         AsyncValue<Map<String, List<int>>>,
@@ -273,7 +277,8 @@ abstract class _$CustomJsonBase extends $AsyncNotifier<Map<String, Bar>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<Map<String, Bar>>>;
+    final ref =
+        this.ref as $Ref<AsyncValue<Map<String, Bar>>, Map<String, Bar>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<Map<String, Bar>>, Map<String, Bar>>,
         AsyncValue<Map<String, Bar>>,
@@ -322,7 +327,8 @@ abstract class _$CustomKeyBase extends $AsyncNotifier<Map<String, Bar>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<Map<String, Bar>>>;
+    final ref =
+        this.ref as $Ref<AsyncValue<Map<String, Bar>>, Map<String, Bar>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<Map<String, Bar>>, Map<String, Bar>>,
         AsyncValue<Map<String, Bar>>,
@@ -448,7 +454,8 @@ abstract class _$CustomJsonWithArgsBase
       _$args.$2,
       arg3: _$args.arg3,
     );
-    final ref = this.ref as $Ref<AsyncValue<Map<String, Bar>>>;
+    final ref =
+        this.ref as $Ref<AsyncValue<Map<String, Bar>>, Map<String, Bar>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<Map<String, Bar>>, Map<String, Bar>>,
         AsyncValue<Map<String, Bar>>,
@@ -499,7 +506,8 @@ abstract class _$PassEncodeDecodeByHandBase
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<Map<String, String>>>;
+    final ref =
+        this.ref as $Ref<AsyncValue<Map<String, String>>, Map<String, String>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<Map<String, String>>, Map<String, String>>,
         AsyncValue<Map<String, String>>,

--- a/packages/riverpod_generator/test/integration/scopes.g.dart
+++ b/packages/riverpod_generator/test/integration/scopes.g.dart
@@ -38,7 +38,7 @@ final class ScopedClassProvider extends $NotifierProvider<ScopedClass, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -51,7 +51,7 @@ abstract class _$ScopedClass extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -98,7 +98,7 @@ final class ScopedClassFamilyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -149,7 +149,7 @@ abstract class _$ScopedClassFamily extends $Notifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/packages/riverpod_generator/test/integration/split.g.dart
+++ b/packages/riverpod_generator/test/integration/split.g.dart
@@ -9,7 +9,7 @@ part of 'split.dart';
 @ProviderFor(counter2)
 const counter2Provider = Counter2Provider._();
 
-final class Counter2Provider extends $FunctionalProvider<int, int>
+final class Counter2Provider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const Counter2Provider._()
       : super(
@@ -39,7 +39,7 @@ final class Counter2Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -49,7 +49,7 @@ String _$counter2Hash() => r'ab7bef7da79217c780c76761a5ae0c0172ca097e';
 @ProviderFor(counter)
 const counterProvider = CounterProvider._();
 
-final class CounterProvider extends $FunctionalProvider<int, int>
+final class CounterProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const CounterProvider._()
       : super(
@@ -79,7 +79,7 @@ final class CounterProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/packages/riverpod_generator/test/integration/stream.g.dart
+++ b/packages/riverpod_generator/test/integration/stream.g.dart
@@ -10,7 +10,7 @@ part of 'stream.dart';
 const genericProvider = GenericFamily._();
 
 final class GenericProvider<T extends num>
-    extends $FunctionalProvider<AsyncValue<List<T>>, Stream<List<T>>>
+    extends $FunctionalProvider<AsyncValue<List<T>>, List<T>, Stream<List<T>>>
     with $FutureModifier<List<T>>, $StreamProvider<List<T>> {
   const GenericProvider._({required GenericFamily super.from})
       : super(
@@ -196,7 +196,7 @@ abstract class _$GenericClass<T extends num> extends $StreamNotifier<List<T>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<T>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<T>>, List<T>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<T>>, List<T>>,
         AsyncValue<List<T>>,
@@ -210,7 +210,7 @@ abstract class _$GenericClass<T extends num> extends $StreamNotifier<List<T>> {
 const publicProvider = PublicProvider._();
 
 final class PublicProvider
-    extends $FunctionalProvider<AsyncValue<String>, Stream<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, Stream<String>>
     with $FutureModifier<String>, $StreamProvider<String> {
   const PublicProvider._()
       : super(
@@ -243,7 +243,7 @@ String _$publicHash() => r'ed93527425175c4a2475e83a3f44223a2aa604d7';
 const _privateProvider = _PrivateProvider._();
 
 final class _PrivateProvider
-    extends $FunctionalProvider<AsyncValue<String>, Stream<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, Stream<String>>
     with $FutureModifier<String>, $StreamProvider<String> {
   const _PrivateProvider._()
       : super(
@@ -276,7 +276,7 @@ String _$privateHash() => r'7915ccdd16751e7dc6274bb024d1b273d78dc78b';
 const familyProvider = FamilyFamily._();
 
 final class FamilyProvider
-    extends $FunctionalProvider<AsyncValue<String>, Stream<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, Stream<String>>
     with $FutureModifier<String>, $StreamProvider<String> {
   const FamilyProvider._(
       {required FamilyFamily super.from,
@@ -420,7 +420,7 @@ abstract class _$PublicClass extends $StreamNotifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,
@@ -468,7 +468,7 @@ abstract class _$PrivateClass extends $StreamNotifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,
@@ -607,7 +607,7 @@ abstract class _$FamilyClass extends $StreamNotifier<String> {
       fourth: _$args.fourth,
       fifth: _$args.fifth,
     );
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,

--- a/packages/riverpod_generator/test/integration/sync.g.dart
+++ b/packages/riverpod_generator/test/integration/sync.g.dart
@@ -10,7 +10,8 @@ part of 'sync.dart';
 const genericProvider = GenericFamily._();
 
 final class GenericProvider<T extends num>
-    extends $FunctionalProvider<List<T>, List<T>> with $Provider<List<T>> {
+    extends $FunctionalProvider<List<T>, List<T>, List<T>>
+    with $Provider<List<T>> {
   const GenericProvider._({required GenericFamily super.from})
       : super(
           argument: null,
@@ -49,7 +50,7 @@ final class GenericProvider<T extends num>
   Override overrideWithValue(List<T> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<T>>(value),
+      providerOverride: $ValueProvider<List<T>, List<T>>(value),
     );
   }
 
@@ -100,7 +101,8 @@ final class GenericFamily extends $Family {
 const complexGenericProvider = ComplexGenericFamily._();
 
 final class ComplexGenericProvider<T extends num, Foo extends String?>
-    extends $FunctionalProvider<List<T>, List<T>> with $Provider<List<T>> {
+    extends $FunctionalProvider<List<T>, List<T>, List<T>>
+    with $Provider<List<T>> {
   const ComplexGenericProvider._(
       {required ComplexGenericFamily super.from,
       required ({
@@ -153,7 +155,7 @@ final class ComplexGenericProvider<T extends num, Foo extends String?>
   Override overrideWithValue(List<T> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<T>>(value),
+      providerOverride: $ValueProvider<List<T>, List<T>>(value),
     );
   }
 
@@ -264,7 +266,7 @@ final class GenericClassProvider<T extends num>
   Override overrideWithValue(List<T> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<T>>(value),
+      providerOverride: $ValueProvider<List<T>, List<T>>(value),
     );
   }
 
@@ -334,7 +336,7 @@ abstract class _$GenericClass<T extends num> extends $Notifier<List<T>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<List<T>>;
+    final ref = this.ref as $Ref<List<T>, List<T>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<List<T>, List<T>>, List<T>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -344,9 +346,10 @@ abstract class _$GenericClass<T extends num> extends $Notifier<List<T>> {
 @ProviderFor(rawFuture)
 const rawFutureProvider = RawFutureProvider._();
 
-final class RawFutureProvider
-    extends $FunctionalProvider<Raw<Future<String>>, Raw<Future<String>>>
-    with $Provider<Raw<Future<String>>> {
+final class RawFutureProvider extends $FunctionalProvider<
+    Raw<Future<String>>,
+    Raw<Future<String>>,
+    Raw<Future<String>>> with $Provider<Raw<Future<String>>> {
   const RawFutureProvider._()
       : super(
           from: null,
@@ -376,7 +379,8 @@ final class RawFutureProvider
   Override overrideWithValue(Raw<Future<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Future<String>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<Future<String>>, Raw<Future<String>>>(value),
     );
   }
 }
@@ -386,9 +390,10 @@ String _$rawFutureHash() => r'9d397f4c0a578a2741610f9ca6f17438ee8e5a34';
 @ProviderFor(rawStream)
 const rawStreamProvider = RawStreamProvider._();
 
-final class RawStreamProvider
-    extends $FunctionalProvider<Raw<Stream<String>>, Raw<Stream<String>>>
-    with $Provider<Raw<Stream<String>>> {
+final class RawStreamProvider extends $FunctionalProvider<
+    Raw<Stream<String>>,
+    Raw<Stream<String>>,
+    Raw<Stream<String>>> with $Provider<Raw<Stream<String>>> {
   const RawStreamProvider._()
       : super(
           from: null,
@@ -418,7 +423,8 @@ final class RawStreamProvider
   Override overrideWithValue(Raw<Stream<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Stream<String>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<Stream<String>>, Raw<Stream<String>>>(value),
     );
   }
 }
@@ -458,7 +464,8 @@ final class RawFutureClassProvider
   Override overrideWithValue(Raw<Future<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Future<String>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<Future<String>>, Raw<Future<String>>>(value),
     );
   }
 }
@@ -471,7 +478,7 @@ abstract class _$RawFutureClass extends $Notifier<Raw<Future<String>>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<Raw<Future<String>>>;
+    final ref = this.ref as $Ref<Raw<Future<String>>, Raw<Future<String>>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<Raw<Future<String>>, Raw<Future<String>>>,
         Raw<Future<String>>,
@@ -514,7 +521,8 @@ final class RawStreamClassProvider
   Override overrideWithValue(Raw<Stream<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Stream<String>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<Stream<String>>, Raw<Stream<String>>>(value),
     );
   }
 }
@@ -527,7 +535,7 @@ abstract class _$RawStreamClass extends $Notifier<Raw<Stream<String>>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<Raw<Stream<String>>>;
+    final ref = this.ref as $Ref<Raw<Stream<String>>, Raw<Stream<String>>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<Raw<Stream<String>>, Raw<Stream<String>>>,
         Raw<Stream<String>>,
@@ -540,9 +548,10 @@ abstract class _$RawStreamClass extends $Notifier<Raw<Stream<String>>> {
 @ProviderFor(rawFamilyFuture)
 const rawFamilyFutureProvider = RawFamilyFutureFamily._();
 
-final class RawFamilyFutureProvider
-    extends $FunctionalProvider<Raw<Future<String>>, Raw<Future<String>>>
-    with $Provider<Raw<Future<String>>> {
+final class RawFamilyFutureProvider extends $FunctionalProvider<
+    Raw<Future<String>>,
+    Raw<Future<String>>,
+    Raw<Future<String>>> with $Provider<Raw<Future<String>>> {
   const RawFamilyFutureProvider._(
       {required RawFamilyFutureFamily super.from, required int super.argument})
       : super(
@@ -582,7 +591,8 @@ final class RawFamilyFutureProvider
   Override overrideWithValue(Raw<Future<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Future<String>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<Future<String>>, Raw<Future<String>>>(value),
     );
   }
 
@@ -622,9 +632,10 @@ final class RawFamilyFutureFamily extends $Family
 @ProviderFor(rawFamilyStream)
 const rawFamilyStreamProvider = RawFamilyStreamFamily._();
 
-final class RawFamilyStreamProvider
-    extends $FunctionalProvider<Raw<Stream<String>>, Raw<Stream<String>>>
-    with $Provider<Raw<Stream<String>>> {
+final class RawFamilyStreamProvider extends $FunctionalProvider<
+    Raw<Stream<String>>,
+    Raw<Stream<String>>,
+    Raw<Stream<String>>> with $Provider<Raw<Stream<String>>> {
   const RawFamilyStreamProvider._(
       {required RawFamilyStreamFamily super.from, required int super.argument})
       : super(
@@ -664,7 +675,8 @@ final class RawFamilyStreamProvider
   Override overrideWithValue(Raw<Stream<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Stream<String>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<Stream<String>>, Raw<Stream<String>>>(value),
     );
   }
 
@@ -741,7 +753,8 @@ final class RawFamilyFutureClassProvider
   Override overrideWithValue(Raw<Future<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Future<String>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<Future<String>>, Raw<Future<String>>>(value),
     );
   }
 
@@ -794,7 +807,7 @@ abstract class _$RawFamilyFutureClass extends $Notifier<Raw<Future<String>>> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<Raw<Future<String>>>;
+    final ref = this.ref as $Ref<Raw<Future<String>>, Raw<Future<String>>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<Raw<Future<String>>, Raw<Future<String>>>,
         Raw<Future<String>>,
@@ -844,7 +857,8 @@ final class RawFamilyStreamClassProvider
   Override overrideWithValue(Raw<Stream<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Stream<String>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<Stream<String>>, Raw<Stream<String>>>(value),
     );
   }
 
@@ -897,7 +911,7 @@ abstract class _$RawFamilyStreamClass extends $Notifier<Raw<Stream<String>>> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<Raw<Stream<String>>>;
+    final ref = this.ref as $Ref<Raw<Stream<String>>, Raw<Stream<String>>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<Raw<Stream<String>>, Raw<Stream<String>>>,
         Raw<Stream<String>>,
@@ -912,7 +926,7 @@ abstract class _$RawFamilyStreamClass extends $Notifier<Raw<Stream<String>>> {
 const publicProvider = PublicProvider._();
 
 /// This is some documentation
-final class PublicProvider extends $FunctionalProvider<String, String>
+final class PublicProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   /// This is some documentation
   const PublicProvider._()
@@ -943,7 +957,7 @@ final class PublicProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -953,8 +967,8 @@ String _$publicHash() => r'94bee36125844f9fe521363bb228632b9f3bfbc7';
 @ProviderFor(supports$inNames)
 const supports$inNamesProvider = Supports$inNamesProvider._();
 
-final class Supports$inNamesProvider extends $FunctionalProvider<String, String>
-    with $Provider<String> {
+final class Supports$inNamesProvider
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const Supports$inNamesProvider._()
       : super(
           from: null,
@@ -983,7 +997,7 @@ final class Supports$inNamesProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -995,7 +1009,7 @@ String _$supports$inNamesHash() => r'8da1f9329f302ce75e38d03c96595de3260b4d2d';
 const familyProvider = FamilyFamily._();
 
 /// This is some documentation
-final class FamilyProvider extends $FunctionalProvider<String, String>
+final class FamilyProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   /// This is some documentation
   const FamilyProvider._(
@@ -1054,7 +1068,7 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -1115,7 +1129,7 @@ final class FamilyFamily extends $Family
 @ProviderFor(_private)
 const _privateProvider = _PrivateProvider._();
 
-final class _PrivateProvider extends $FunctionalProvider<String, String>
+final class _PrivateProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const _PrivateProvider._()
       : super(
@@ -1145,7 +1159,7 @@ final class _PrivateProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -1187,7 +1201,7 @@ final class PublicClassProvider extends $NotifierProvider<PublicClass, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -1200,7 +1214,7 @@ abstract class _$PublicClass extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1240,7 +1254,7 @@ final class _PrivateClassProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -1253,7 +1267,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1309,7 +1323,7 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -1401,7 +1415,7 @@ abstract class _$FamilyClass extends $Notifier<String> {
       fourth: _$args.fourth,
       fifth: _$args.fifth,
     );
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1412,7 +1426,7 @@ abstract class _$FamilyClass extends $Notifier<String> {
 const supports$InFnNameProvider = Supports$InFnNameFamily._();
 
 final class Supports$InFnNameProvider<And$InT>
-    extends $FunctionalProvider<String, String> with $Provider<String> {
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const Supports$InFnNameProvider._(
       {required Supports$InFnNameFamily super.from})
       : super(
@@ -1452,7 +1466,7 @@ final class Supports$InFnNameProvider<And$InT>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -1506,7 +1520,7 @@ final class Supports$InFnNameFamily extends $Family {
 const supports$InFnNameFamilyProvider = Supports$InFnNameFamilyFamily._();
 
 final class Supports$InFnNameFamilyProvider<And$InT>
-    extends $FunctionalProvider<String, String> with $Provider<String> {
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const Supports$InFnNameFamilyProvider._(
       {required Supports$InFnNameFamilyFamily super.from,
       required (
@@ -1561,7 +1575,7 @@ final class Supports$InFnNameFamilyProvider<And$InT>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -1677,7 +1691,7 @@ final class Supports$InClassNameProvider<And$InT>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -1752,7 +1766,7 @@ abstract class _$Supports$InClassName<And$InT> extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1809,7 +1823,7 @@ final class Supports$InClassFamilyNameProvider<And$InT>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -1911,7 +1925,7 @@ abstract class _$Supports$InClassFamilyName<And$InT> extends $Notifier<String> {
       named$arg: _$args.named$arg,
       defaultArg: _$args.defaultArg,
     );
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1921,8 +1935,8 @@ abstract class _$Supports$InClassFamilyName<And$InT> extends $Notifier<String> {
 @ProviderFor(generated)
 const generatedProvider = GeneratedProvider._();
 
-final class GeneratedProvider extends $FunctionalProvider<String, String>
-    with $Provider<String> {
+final class GeneratedProvider
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const GeneratedProvider._()
       : super(
           from: null,
@@ -1951,7 +1965,7 @@ final class GeneratedProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -1961,8 +1975,8 @@ String _$generatedHash() => r'24bfb5df4dc529258ab568372e90a1cbfc2d8c24';
 @ProviderFor(unnecessaryCast)
 const unnecessaryCastProvider = UnnecessaryCastFamily._();
 
-final class UnnecessaryCastProvider extends $FunctionalProvider<String, String>
-    with $Provider<String> {
+final class UnnecessaryCastProvider
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const UnnecessaryCastProvider._(
       {required UnnecessaryCastFamily super.from,
       required Object? super.argument})
@@ -2002,7 +2016,7 @@ final class UnnecessaryCastProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -2079,7 +2093,7 @@ final class UnnecessaryCastClassProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -2132,7 +2146,7 @@ abstract class _$UnnecessaryCastClass extends $Notifier<String> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -2143,7 +2157,7 @@ abstract class _$UnnecessaryCastClass extends $Notifier<String> {
 const manyDataStreamProvider = ManyDataStreamFamily._();
 
 final class ManyDataStreamProvider<T extends Object, S extends Object>
-    extends $FunctionalProvider<AsyncValue<List<T>>, Stream<List<T>>>
+    extends $FunctionalProvider<AsyncValue<List<T>>, List<T>, Stream<List<T>>>
     with $FutureModifier<List<T>>, $StreamProvider<List<T>> {
   const ManyDataStreamProvider._(
       {required ManyDataStreamFamily super.from,

--- a/packages/riverpod_generator/test/mock.dart
+++ b/packages/riverpod_generator/test/mock.dart
@@ -192,7 +192,7 @@ class ObserverMock extends Mock implements ProviderObserver {
 }
 
 TypeMatcher<ProviderObserverContext> isProviderObserverContext(
-  ProviderBase<Object?> provider,
+  ProviderBase<Object?, Object?> provider,
   ProviderContainer container, {
   required Object? mutation,
 }) {

--- a/packages/riverpod_generator/test/notifier_test.dart
+++ b/packages/riverpod_generator/test/notifier_test.dart
@@ -11,7 +11,7 @@ void main() {
       () {
     final container = ProviderContainer.test();
 
-    const ProviderBase<String> provider = publicClassProvider;
+    const ProviderBase<String, String> provider = publicClassProvider;
     final String result = container.read(publicProvider);
 
     expect(result, 'Hello world');
@@ -108,7 +108,7 @@ void main() {
       fifth: const ['x42'],
     );
     // ignore: invalid_use_of_internal_member //
-    final ProviderBase<String> futureProvider = provider;
+    final ProviderBase<String, String> futureProvider = provider;
 
     final String result = container.read(
       familyClassProvider(

--- a/packages/riverpod_generator/test/stream_notifier_test.dart
+++ b/packages/riverpod_generator/test/stream_notifier_test.dart
@@ -12,7 +12,8 @@ void main() {
       () async {
     final container = ProviderContainer.test();
 
-    const ProviderBase<AsyncValue<String>> provider = publicClassProvider;
+    const ProviderBase<AsyncValue<String>, String> provider =
+        publicClassProvider;
 
     expect(
       await container.listen(publicClassProvider.future, (_, __) {}).read(),
@@ -110,7 +111,7 @@ void main() {
       fourth: false,
       fifth: const ['x42'],
     );
-    final ProviderBase<AsyncValue<String>> futureProvider = provider;
+    final ProviderBase<AsyncValue<String>, String> futureProvider = provider;
 
     expect(
       await container

--- a/packages/riverpod_generator/test/stream_test.dart
+++ b/packages/riverpod_generator/test/stream_test.dart
@@ -11,7 +11,7 @@ void main() {
       () async {
     final container = ProviderContainer.test();
 
-    const ProviderBase<AsyncValue<String>> provider = publicProvider;
+    const ProviderBase<AsyncValue<String>, String> provider = publicProvider;
 
     expect(
       await container.listen(publicProvider.future, (_, __) {}).read(),
@@ -112,7 +112,7 @@ void main() {
       fourth: false,
       fifth: const ['x42'],
     );
-    final ProviderBase<AsyncValue<String>> futureProvider = provider;
+    final ProviderBase<AsyncValue<String>, String> futureProvider = provider;
 
     expect(
       await container

--- a/packages/riverpod_generator/test/sync_test.dart
+++ b/packages/riverpod_generator/test/sync_test.dart
@@ -204,7 +204,8 @@ void main() {
       () async {
     final container = ProviderContainer.test();
 
-    const ProviderBase<Stream<String>> provider = rawStreamProvider;
+    const ProviderBase<Stream<String>, Stream<String>> provider =
+        rawStreamProvider;
     final Stream<String> result = container.read(rawStreamProvider);
 
     await expectLater(result, emits('Hello world'));
@@ -214,7 +215,7 @@ void main() {
       () {
     final container = ProviderContainer.test();
 
-    const ProviderBase<String> provider = publicProvider;
+    const ProviderBase<String, String> provider = publicProvider;
     final String result = container.read(publicProvider);
 
     expect(result, 'Hello world');
@@ -274,7 +275,7 @@ void main() {
       fifth: const ['x42'],
     );
 
-    final ProviderBase<String> futureProvider = provider;
+    final ProviderBase<String, String> futureProvider = provider;
 
     final argument = provider.argument! as (
       int, {

--- a/packages/riverpod_graph/test/integration/generated/golden/lib/sync.g.dart
+++ b/packages/riverpod_graph/test/integration/generated/golden/lib/sync.g.dart
@@ -11,7 +11,7 @@ part of 'sync.dart';
 const publicProvider = PublicProvider._();
 
 /// A public generated provider.
-final class PublicProvider extends $FunctionalProvider<String, String>
+final class PublicProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   /// A public generated provider.
   const PublicProvider._()
@@ -42,7 +42,7 @@ final class PublicProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -54,8 +54,8 @@ String _$publicHash() => r'94bee36125844f9fe521363bb228632b9f3bfbc7';
 const supports$inNamesProvider = Supports$inNamesProvider._();
 
 /// A generated provider with a '$' in its name.
-final class Supports$inNamesProvider extends $FunctionalProvider<String, String>
-    with $Provider<String> {
+final class Supports$inNamesProvider
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   /// A generated provider with a '$' in its name.
   const Supports$inNamesProvider._()
       : super(
@@ -85,7 +85,7 @@ final class Supports$inNamesProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -97,7 +97,7 @@ String _$supports$inNamesHash() => r'a883450ddca90a227631fe54d1d9ae305bc558d9';
 const familyProvider = FamilyFamily._();
 
 /// A generated family provider.
-final class FamilyProvider extends $FunctionalProvider<String, String>
+final class FamilyProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   /// A generated family provider.
   const FamilyProvider._(
@@ -156,7 +156,7 @@ final class FamilyProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -217,7 +217,7 @@ final class FamilyFamily extends $Family
 @ProviderFor(_private)
 const _privateProvider = _PrivateProvider._();
 
-final class _PrivateProvider extends $FunctionalProvider<String, String>
+final class _PrivateProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const _PrivateProvider._()
       : super(
@@ -247,7 +247,7 @@ final class _PrivateProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -289,7 +289,7 @@ final class PublicClassProvider extends $NotifierProvider<PublicClass, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -302,7 +302,7 @@ abstract class _$PublicClass extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -342,7 +342,7 @@ final class _PrivateClassProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -355,7 +355,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -411,7 +411,7 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -503,7 +503,7 @@ abstract class _$FamilyClass extends $Notifier<String> {
       forth: _$args.forth,
       fifth: _$args.fifth,
     );
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -546,7 +546,7 @@ final class Supports$InClassNameProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -560,7 +560,7 @@ abstract class _$Supports$InClassName extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional/convert_class_based_provider_to_functional.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional/convert_class_based_provider_to_functional.g.dart
@@ -41,7 +41,7 @@ final class ExampleProvider extends $NotifierProvider<Example, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -54,7 +54,7 @@ abstract class _$Example extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -108,7 +108,7 @@ final class ExampleFamilyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -179,7 +179,7 @@ abstract class _$ExampleFamily extends $Notifier<int> {
       a: _$args.a,
       b: _$args.b,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -229,7 +229,7 @@ final class GenericProvider<A, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -299,7 +299,7 @@ abstract class _$Generic<A, B> extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based/convert_functional_provider_to_class_based.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based/convert_functional_provider_to_class_based.g.dart
@@ -11,7 +11,7 @@ part of 'convert_functional_provider_to_class_based.dart';
 const exampleProvider = ExampleProvider._();
 
 /// Some comment
-final class ExampleProvider extends $FunctionalProvider<int, int>
+final class ExampleProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   /// Some comment
   const ExampleProvider._()
@@ -42,7 +42,7 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -54,7 +54,7 @@ String _$exampleHash() => r'67898608b444d39a000852f647ca6d3326740c98';
 const exampleFamilyProvider = ExampleFamilyFamily._();
 
 /// Some comment
-final class ExampleFamilyProvider extends $FunctionalProvider<int, int>
+final class ExampleFamilyProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   /// Some comment
   const ExampleFamilyProvider._(
@@ -104,7 +104,7 @@ final class ExampleFamilyProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/avoid_build_context_in_providers.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/avoid_build_context_in_providers.g.dart
@@ -9,7 +9,7 @@ part of 'avoid_build_context_in_providers.dart';
 @ProviderFor(fn)
 const fnProvider = FnFamily._();
 
-final class FnProvider extends $FunctionalProvider<int, int>
+final class FnProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const FnProvider._(
       {required FnFamily super.from,
@@ -58,7 +58,7 @@ final class FnProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -148,7 +148,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -218,7 +218,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
       _$args.$1,
       context2: _$args.context2,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -258,7 +258,7 @@ final class Regression2959Provider
   Override overrideWithValue(void value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<void>(value),
+      providerOverride: $ValueProvider<void, void>(value),
     );
   }
 }
@@ -271,7 +271,7 @@ abstract class _$Regression2959 extends $Notifier<void> {
   @override
   void runBuild() {
     build();
-    final ref = this.ref as $Ref<void>;
+    final ref = this.ref as $Ref<void, void>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<void, void>, void, Object?, Object?>;
     element.handleValue(ref, null);

--- a/packages/riverpod_lint_flutter_test/test/lints/avoid_public_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/avoid_public_notifier_properties.g.dart
@@ -46,7 +46,7 @@ final class GeneratedNotifierProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -96,7 +96,7 @@ abstract class _$GeneratedNotifier extends $Notifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/packages/riverpod_lint_flutter_test/test/lints/functional_ref/functional_ref.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/functional_ref/functional_ref.g.dart
@@ -9,7 +9,7 @@ part of 'functional_ref.dart';
 @ProviderFor(nameless)
 const namelessProvider = NamelessProvider._();
 
-final class NamelessProvider extends $FunctionalProvider<int, int>
+final class NamelessProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const NamelessProvider._()
       : super(
@@ -39,7 +39,7 @@ final class NamelessProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -50,7 +50,7 @@ String _$namelessHash() => r'1a2aa61445a64c65301051820b159c5998195606';
 const genericsProvider = GenericsFamily._();
 
 final class GenericsProvider<A extends num, B>
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const GenericsProvider._({required GenericsFamily super.from})
       : super(
           argument: null,
@@ -89,7 +89,7 @@ final class GenericsProvider<A extends num, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -142,7 +142,7 @@ final class GenericsFamily extends $Family {
 @ProviderFor(valid)
 const validProvider = ValidProvider._();
 
-final class ValidProvider extends $FunctionalProvider<int, int>
+final class ValidProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const ValidProvider._()
       : super(
@@ -172,7 +172,7 @@ final class ValidProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.g.dart
@@ -38,7 +38,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -51,7 +51,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -91,7 +91,7 @@ final class _PrivateClassProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -104,7 +104,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);
@@ -154,7 +154,7 @@ final class GenericsProvider<A extends num, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -226,7 +226,7 @@ abstract class _$Generics<A extends num, B> extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -276,7 +276,7 @@ final class NoGenericsProvider<A extends num, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -348,7 +348,7 @@ abstract class _$NoGenerics<A extends num, B> extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -398,7 +398,7 @@ final class MissingGenericsProvider<A, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -469,7 +469,7 @@ abstract class _$MissingGenerics<A, B> extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -519,7 +519,7 @@ final class WrongOrderProvider<A, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -590,7 +590,7 @@ abstract class _$WrongOrder<A, B> extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/packages/riverpod_lint_flutter_test/test/lints/only_use_keep_alive_inside_keep_alive.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/only_use_keep_alive_inside_keep_alive.g.dart
@@ -9,7 +9,7 @@ part of 'only_use_keep_alive_inside_keep_alive.dart';
 @ProviderFor(keepAlive)
 const keepAliveProvider = KeepAliveProvider._();
 
-final class KeepAliveProvider extends $FunctionalProvider<int, int>
+final class KeepAliveProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const KeepAliveProvider._()
       : super(
@@ -39,7 +39,7 @@ final class KeepAliveProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -79,7 +79,7 @@ final class KeepAliveClassProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -92,7 +92,7 @@ abstract class _$KeepAliveClass extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -102,7 +102,7 @@ abstract class _$KeepAliveClass extends $Notifier<int> {
 @ProviderFor(autoDispose)
 const autoDisposeProvider = AutoDisposeProvider._();
 
-final class AutoDisposeProvider extends $FunctionalProvider<int, int>
+final class AutoDisposeProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const AutoDisposeProvider._()
       : super(
@@ -132,7 +132,7 @@ final class AutoDisposeProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -172,7 +172,7 @@ final class AutoDisposeClassProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -185,7 +185,7 @@ abstract class _$AutoDisposeClass extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -195,7 +195,7 @@ abstract class _$AutoDisposeClass extends $Notifier<int> {
 @ProviderFor(fn)
 const fnProvider = FnProvider._();
 
-final class FnProvider extends $FunctionalProvider<int, int>
+final class FnProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const FnProvider._()
       : super(
@@ -225,7 +225,7 @@ final class FnProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
@@ -37,7 +37,7 @@ final class AProvider extends $NotifierProvider<A, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -50,7 +50,7 @@ abstract class _$A extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -88,7 +88,7 @@ final class A2Provider extends $NotifierProvider<A2, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -101,7 +101,7 @@ abstract class _$A2 extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -145,7 +145,7 @@ final class A3Provider extends $NotifierProvider<A3, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -195,7 +195,7 @@ abstract class _$A3 extends $Notifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -239,7 +239,7 @@ final class A4Provider extends $NotifierProvider<A4, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -289,7 +289,7 @@ abstract class _$A4 extends $Notifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -376,7 +376,7 @@ abstract class _$A5 extends $AsyncNotifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -463,7 +463,7 @@ abstract class _$A6 extends $AsyncNotifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -550,7 +550,7 @@ abstract class _$A7 extends $StreamNotifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -637,7 +637,7 @@ abstract class _$A8 extends $StreamNotifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -675,7 +675,7 @@ final class BProvider extends $NotifierProvider<B, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -688,7 +688,7 @@ abstract class _$B extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -726,7 +726,7 @@ final class B2Provider extends $NotifierProvider<B2, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -739,7 +739,7 @@ abstract class _$B2 extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/another.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/another.g.dart
@@ -9,7 +9,7 @@ part of 'another.dart';
 @ProviderFor(b)
 const bProvider = BProvider._();
 
-final class BProvider extends $FunctionalProvider<int, int>
+final class BProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const BProvider._()
       : super(
@@ -39,7 +39,7 @@ final class BProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -49,7 +49,7 @@ String _$bHash() => r'31624e9aa10c9cd7941c9626e841c6df3468723b';
 @ProviderFor(anotherScoped)
 const anotherScopedProvider = AnotherScopedProvider._();
 
-final class AnotherScopedProvider extends $FunctionalProvider<int, int>
+final class AnotherScopedProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const AnotherScopedProvider._()
       : super(
@@ -79,7 +79,7 @@ final class AnotherScopedProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -89,8 +89,8 @@ String _$anotherScopedHash() => r'edf3ccffb7c3ce1b1e4ffdd4009aeed4fa38c3f8';
 @ProviderFor(anotherNonEmptyScoped)
 const anotherNonEmptyScopedProvider = AnotherNonEmptyScopedProvider._();
 
-final class AnotherNonEmptyScopedProvider extends $FunctionalProvider<int, int>
-    with $Provider<int> {
+final class AnotherNonEmptyScopedProvider
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const AnotherNonEmptyScopedProvider._()
       : super(
           from: null,
@@ -123,7 +123,7 @@ final class AnotherNonEmptyScopedProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies.g.dart
@@ -9,7 +9,7 @@ part of 'missing_dependencies.dart';
 @ProviderFor(dep)
 const depProvider = DepProvider._();
 
-final class DepProvider extends $FunctionalProvider<int, int>
+final class DepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const DepProvider._()
       : super(
@@ -39,7 +39,7 @@ final class DepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -49,7 +49,7 @@ String _$depHash() => r'578a350a40cda46444ecd9fa3ea2fd7bd0994692';
 @ProviderFor(transitiveDep)
 const transitiveDepProvider = TransitiveDepProvider._();
 
-final class TransitiveDepProvider extends $FunctionalProvider<int, int>
+final class TransitiveDepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const TransitiveDepProvider._()
       : super(
@@ -83,7 +83,7 @@ final class TransitiveDepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -93,7 +93,7 @@ String _$transitiveDepHash() => r'cedc000b7d16447684dff970ddea659cca24cdf6';
 @ProviderFor(dep2)
 const dep2Provider = Dep2Provider._();
 
-final class Dep2Provider extends $FunctionalProvider<int, int>
+final class Dep2Provider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const Dep2Provider._()
       : super(
@@ -123,7 +123,7 @@ final class Dep2Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -133,7 +133,7 @@ String _$dep2Hash() => r'97901e825cdcf5b1ac455b0fe8a2111662ce9f13';
 @ProviderFor(depFamily)
 const depFamilyProvider = DepFamilyFamily._();
 
-final class DepFamilyProvider extends $FunctionalProvider<int, int>
+final class DepFamilyProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const DepFamilyProvider._(
       {required DepFamilyFamily super.from, required int super.argument})
@@ -173,7 +173,7 @@ final class DepFamilyProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -217,7 +217,7 @@ const plainAnnotationProvider = PlainAnnotationProvider._();
 
 ////////////
 // expect_lint: provider_dependencies
-final class PlainAnnotationProvider extends $FunctionalProvider<int, int>
+final class PlainAnnotationProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   ////////////
 // expect_lint: provider_dependencies
@@ -249,7 +249,7 @@ final class PlainAnnotationProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -259,7 +259,7 @@ String _$plainAnnotationHash() => r'6a3d1f1f2e53902af56cd7ce6ceba17358690b70';
 @ProviderFor(customAnnotation)
 const customAnnotationProvider = CustomAnnotationProvider._();
 
-final class CustomAnnotationProvider extends $FunctionalProvider<int, int>
+final class CustomAnnotationProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const CustomAnnotationProvider._()
       : super(
@@ -289,7 +289,7 @@ final class CustomAnnotationProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -301,7 +301,7 @@ const customAnnotationWithTrailingCommaProvider =
     CustomAnnotationWithTrailingCommaProvider._();
 
 final class CustomAnnotationWithTrailingCommaProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const CustomAnnotationWithTrailingCommaProvider._()
       : super(
           from: null,
@@ -331,7 +331,7 @@ final class CustomAnnotationWithTrailingCommaProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -342,7 +342,7 @@ String _$customAnnotationWithTrailingCommaHash() =>
 @ProviderFor(existingDep)
 const existingDepProvider = ExistingDepProvider._();
 
-final class ExistingDepProvider extends $FunctionalProvider<int, int>
+final class ExistingDepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const ExistingDepProvider._()
       : super(
@@ -372,7 +372,7 @@ final class ExistingDepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -382,7 +382,7 @@ String _$existingDepHash() => r'73e7e1a0d4c2ae07ed03fb248408c3d82fe85554';
 @ProviderFor(multipleDeps)
 const multipleDepsProvider = MultipleDepsProvider._();
 
-final class MultipleDepsProvider extends $FunctionalProvider<int, int>
+final class MultipleDepsProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const MultipleDepsProvider._()
       : super(
@@ -412,7 +412,7 @@ final class MultipleDepsProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -426,8 +426,8 @@ const providerWithDartDocProvider = ProviderWithDartDocProvider._();
 
 /// Random doc to test that identifiers in docs don't trigger the lint.
 /// [dep], [DepWidget], [depProvider]
-final class ProviderWithDartDocProvider extends $FunctionalProvider<int, int>
-    with $Provider<int> {
+final class ProviderWithDartDocProvider
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   /// Random doc to test that identifiers in docs don't trigger the lint.
   /// [dep], [DepWidget], [depProvider]
   const ProviderWithDartDocProvider._()
@@ -458,7 +458,7 @@ final class ProviderWithDartDocProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.g.dart
@@ -9,7 +9,7 @@ part of 'missing_dependencies2.dart';
 @ProviderFor(dep)
 const depProvider = DepProvider._();
 
-final class DepProvider extends $FunctionalProvider<int, int>
+final class DepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const DepProvider._()
       : super(
@@ -39,7 +39,7 @@ final class DepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -49,7 +49,7 @@ String _$depHash() => r'578a350a40cda46444ecd9fa3ea2fd7bd0994692';
 @ProviderFor(generatedScoped)
 const generatedScopedProvider = GeneratedScopedProvider._();
 
-final class GeneratedScopedProvider extends $FunctionalProvider<int, int>
+final class GeneratedScopedProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const GeneratedScopedProvider._()
       : super(
@@ -79,7 +79,7 @@ final class GeneratedScopedProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -89,7 +89,7 @@ String _$generatedScopedHash() => r'f8e5b6926ce13765c83dbb7f8c8458c9c5fe7d69';
 @ProviderFor(generatedRoot)
 const generatedRootProvider = GeneratedRootProvider._();
 
-final class GeneratedRootProvider extends $FunctionalProvider<int, int>
+final class GeneratedRootProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const GeneratedRootProvider._()
       : super(
@@ -119,7 +119,7 @@ final class GeneratedRootProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -131,7 +131,7 @@ const watchScopedButNoDependenciesProvider =
     WatchScopedButNoDependenciesProvider._();
 
 final class WatchScopedButNoDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchScopedButNoDependenciesProvider._()
       : super(
           from: null,
@@ -160,7 +160,7 @@ final class WatchScopedButNoDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -173,7 +173,7 @@ const watchGeneratedScopedButNoDependenciesProvider =
     WatchGeneratedScopedButNoDependenciesProvider._();
 
 final class WatchGeneratedScopedButNoDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchGeneratedScopedButNoDependenciesProvider._()
       : super(
           from: null,
@@ -203,7 +203,7 @@ final class WatchGeneratedScopedButNoDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -216,7 +216,7 @@ const watchRootButNoDependenciesProvider =
     WatchRootButNoDependenciesProvider._();
 
 final class WatchRootButNoDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchRootButNoDependenciesProvider._()
       : super(
           from: null,
@@ -245,7 +245,7 @@ final class WatchRootButNoDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -258,7 +258,7 @@ const watchGeneratedRootButNoDependenciesProvider =
     WatchGeneratedRootButNoDependenciesProvider._();
 
 final class WatchGeneratedRootButNoDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchGeneratedRootButNoDependenciesProvider._()
       : super(
           from: null,
@@ -288,7 +288,7 @@ final class WatchGeneratedRootButNoDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -301,7 +301,7 @@ const watchScopedButEmptyDependenciesProvider =
     WatchScopedButEmptyDependenciesProvider._();
 
 final class WatchScopedButEmptyDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchScopedButEmptyDependenciesProvider._()
       : super(
           from: null,
@@ -330,7 +330,7 @@ final class WatchScopedButEmptyDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -343,7 +343,7 @@ const watchGeneratedScopedButEmptyDependenciesProvider =
     WatchGeneratedScopedButEmptyDependenciesProvider._();
 
 final class WatchGeneratedScopedButEmptyDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchGeneratedScopedButEmptyDependenciesProvider._()
       : super(
           from: null,
@@ -373,7 +373,7 @@ final class WatchGeneratedScopedButEmptyDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -386,7 +386,7 @@ const watchRootButEmptyDependenciesProvider =
     WatchRootButEmptyDependenciesProvider._();
 
 final class WatchRootButEmptyDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchRootButEmptyDependenciesProvider._()
       : super(
           from: null,
@@ -415,7 +415,7 @@ final class WatchRootButEmptyDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -428,7 +428,7 @@ const watchGeneratedRootButEmptyDependenciesProvider =
     WatchGeneratedRootButEmptyDependenciesProvider._();
 
 final class WatchGeneratedRootButEmptyDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchGeneratedRootButEmptyDependenciesProvider._()
       : super(
           from: null,
@@ -458,7 +458,7 @@ final class WatchGeneratedRootButEmptyDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -471,7 +471,7 @@ const watchScopedButMissingDependenciesProvider =
     WatchScopedButMissingDependenciesProvider._();
 
 final class WatchScopedButMissingDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchScopedButMissingDependenciesProvider._()
       : super(
           from: null,
@@ -506,7 +506,7 @@ final class WatchScopedButMissingDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -519,7 +519,7 @@ const watchGeneratedScopedButMissingDependenciesProvider =
     WatchGeneratedScopedButMissingDependenciesProvider._();
 
 final class WatchGeneratedScopedButMissingDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchGeneratedScopedButMissingDependenciesProvider._()
       : super(
           from: null,
@@ -554,7 +554,7 @@ final class WatchGeneratedScopedButMissingDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -567,7 +567,7 @@ const watchRootButMissingDependenciesProvider =
     WatchRootButMissingDependenciesProvider._();
 
 final class WatchRootButMissingDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchRootButMissingDependenciesProvider._()
       : super(
           from: null,
@@ -600,7 +600,7 @@ final class WatchRootButMissingDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -613,7 +613,7 @@ const watchGeneratedRootButMissingDependenciesProvider =
     WatchGeneratedRootButMissingDependenciesProvider._();
 
 final class WatchGeneratedRootButMissingDependenciesProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchGeneratedRootButMissingDependenciesProvider._()
       : super(
           from: null,
@@ -648,7 +648,7 @@ final class WatchGeneratedRootButMissingDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -661,7 +661,7 @@ const watchGeneratedScopedAndContainsDependencyProvider =
     WatchGeneratedScopedAndContainsDependencyProvider._();
 
 final class WatchGeneratedScopedAndContainsDependencyProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchGeneratedScopedAndContainsDependencyProvider._()
       : super(
           from: null,
@@ -696,7 +696,7 @@ final class WatchGeneratedScopedAndContainsDependencyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -709,7 +709,7 @@ const watchGeneratedRootAndContainsDependencyProvider =
     WatchGeneratedRootAndContainsDependencyProvider._();
 
 final class WatchGeneratedRootAndContainsDependencyProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const WatchGeneratedRootAndContainsDependencyProvider._()
       : super(
           from: null,
@@ -744,7 +744,7 @@ final class WatchGeneratedRootAndContainsDependencyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -757,7 +757,7 @@ const specifiedDependencyButNeverUsedProvider =
     SpecifiedDependencyButNeverUsedProvider._();
 
 final class SpecifiedDependencyButNeverUsedProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const SpecifiedDependencyButNeverUsedProvider._()
       : super(
           from: null,
@@ -795,7 +795,7 @@ final class SpecifiedDependencyButNeverUsedProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -840,7 +840,7 @@ final class ClassWatchGeneratedRootButMissingDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -855,7 +855,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -865,7 +865,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
 @ProviderFor(regression2348)
 const regression2348Provider = Regression2348Provider._();
 
-final class Regression2348Provider extends $FunctionalProvider<int, int>
+final class Regression2348Provider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const Regression2348Provider._()
       : super(
@@ -899,7 +899,7 @@ final class Regression2348Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -943,7 +943,7 @@ final class Regression2417Provider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -956,7 +956,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -966,7 +966,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
 @ProviderFor(familyDep)
 const familyDepProvider = FamilyDepFamily._();
 
-final class FamilyDepProvider extends $FunctionalProvider<int, int>
+final class FamilyDepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const FamilyDepProvider._(
       {required FamilyDepFamily super.from, required int super.argument})
@@ -1008,7 +1008,7 @@ final class FamilyDepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -1050,7 +1050,7 @@ final class FamilyDepFamily extends $Family
 @ProviderFor(familyDep2)
 const familyDep2Provider = FamilyDep2Family._();
 
-final class FamilyDep2Provider extends $FunctionalProvider<int, int>
+final class FamilyDep2Provider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const FamilyDep2Provider._(
       {required FamilyDep2Family super.from, required int super.argument})
@@ -1094,7 +1094,7 @@ final class FamilyDep2Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 
@@ -1137,7 +1137,7 @@ final class FamilyDep2Family extends $Family
 @ProviderFor(alias)
 const aliasProvider = AliasProvider._();
 
-final class AliasProvider extends $FunctionalProvider<int, int>
+final class AliasProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const AliasProvider._()
       : super(
@@ -1167,7 +1167,7 @@ final class AliasProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -1206,7 +1206,7 @@ final class AliasClassProvider extends $NotifierProvider<AliasClass, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -1219,7 +1219,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1263,7 +1263,7 @@ final class RiverpodDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -1277,7 +1277,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -1287,7 +1287,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
 @ProviderFor(foo)
 const fooProvider = FooProvider._();
 
-final class FooProvider extends $FunctionalProvider<int, int>
+final class FooProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const FooProvider._()
       : super(
@@ -1317,7 +1317,7 @@ final class FooProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -1327,8 +1327,8 @@ String _$fooHash() => r'a390b7b969bb0eec183426bfc85bec32750e9475';
 @ProviderFor(crossFileDependency)
 const crossFileDependencyProvider = CrossFileDependencyProvider._();
 
-final class CrossFileDependencyProvider extends $FunctionalProvider<int, int>
-    with $Provider<int> {
+final class CrossFileDependencyProvider
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const CrossFileDependencyProvider._()
       : super(
           from: null,
@@ -1357,7 +1357,7 @@ final class CrossFileDependencyProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/unused_dependency.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/unused_dependency.g.dart
@@ -9,7 +9,7 @@ part of 'unused_dependency.dart';
 @ProviderFor(root)
 const rootProvider = RootProvider._();
 
-final class RootProvider extends $FunctionalProvider<int, int>
+final class RootProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const RootProvider._()
       : super(
@@ -39,7 +39,7 @@ final class RootProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -49,7 +49,7 @@ String _$rootHash() => r'dda8bbb46cb4d7c658597669e3be92e2447dcfb0';
 @ProviderFor(dep)
 const depProvider = DepProvider._();
 
-final class DepProvider extends $FunctionalProvider<int, int>
+final class DepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const DepProvider._()
       : super(
@@ -79,7 +79,7 @@ final class DepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -89,7 +89,7 @@ String _$depHash() => r'578a350a40cda46444ecd9fa3ea2fd7bd0994692';
 @ProviderFor(dep2)
 const dep2Provider = Dep2Provider._();
 
-final class Dep2Provider extends $FunctionalProvider<int, int>
+final class Dep2Provider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const Dep2Provider._()
       : super(
@@ -119,7 +119,7 @@ final class Dep2Provider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -131,7 +131,7 @@ String _$dep2Hash() => r'97901e825cdcf5b1ac455b0fe8a2111662ce9f13';
 const extraDepProvider = ExtraDepProvider._();
 
 ////////////
-final class ExtraDepProvider extends $FunctionalProvider<int, int>
+final class ExtraDepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   ////////////
   const ExtraDepProvider._()
@@ -168,7 +168,7 @@ final class ExtraDepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -178,7 +178,7 @@ String _$extraDepHash() => r'586c1a0f0ac120f8608c025a6a47fe5282b80320';
 @ProviderFor(noDep)
 const noDepProvider = NoDepProvider._();
 
-final class NoDepProvider extends $FunctionalProvider<int, int>
+final class NoDepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const NoDepProvider._()
       : super(
@@ -212,7 +212,7 @@ final class NoDepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -224,7 +224,7 @@ const dependenciesFirstThenKeepAliveProvider =
     DependenciesFirstThenKeepAliveProvider._();
 
 final class DependenciesFirstThenKeepAliveProvider
-    extends $FunctionalProvider<int, int> with $Provider<int> {
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const DependenciesFirstThenKeepAliveProvider._()
       : super(
           from: null,
@@ -257,7 +257,7 @@ final class DependenciesFirstThenKeepAliveProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -268,7 +268,7 @@ String _$dependenciesFirstThenKeepAliveHash() =>
 @ProviderFor(noDepNoParam)
 const noDepNoParamProvider = NoDepNoParamProvider._();
 
-final class NoDepNoParamProvider extends $FunctionalProvider<int, int>
+final class NoDepNoParamProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const NoDepNoParamProvider._()
       : super(
@@ -302,7 +302,7 @@ final class NoDepNoParamProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -312,7 +312,7 @@ String _$noDepNoParamHash() => r'ea3e66e28bbfb716adf89cea37a1607c78283e06';
 @ProviderFor(noDepWithoutComma)
 const noDepWithoutCommaProvider = NoDepWithoutCommaProvider._();
 
-final class NoDepWithoutCommaProvider extends $FunctionalProvider<int, int>
+final class NoDepWithoutCommaProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const NoDepWithoutCommaProvider._()
       : super(
@@ -346,7 +346,7 @@ final class NoDepWithoutCommaProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -356,7 +356,7 @@ String _$noDepWithoutCommaHash() => r'a3b07e526b4829ee4ed1848de4ff64c3b05c1a30';
 @ProviderFor(rootDep)
 const rootDepProvider = RootDepProvider._();
 
-final class RootDepProvider extends $FunctionalProvider<int, int>
+final class RootDepProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const RootDepProvider._()
       : super(
@@ -390,7 +390,7 @@ final class RootDepProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.g.dart
@@ -9,7 +9,7 @@ part of 'provider_parameters.dart';
 @ProviderFor(generator)
 const generatorProvider = GeneratorFamily._();
 
-final class GeneratorProvider extends $FunctionalProvider<int, int>
+final class GeneratorProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const GeneratorProvider._(
       {required GeneratorFamily super.from, required Object? super.argument})
@@ -49,7 +49,7 @@ final class GeneratorProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/scoped_providers_should_specify_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/scoped_providers_should_specify_dependencies.g.dart
@@ -39,7 +39,7 @@ final class UnimplementedScopedProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$UnimplementedScoped extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -63,7 +63,7 @@ abstract class _$UnimplementedScoped extends $Notifier<int> {
 @ProviderFor(scoped)
 const scopedProvider = ScopedProvider._();
 
-final class ScopedProvider extends $FunctionalProvider<int, int>
+final class ScopedProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const ScopedProvider._()
       : super(
@@ -93,7 +93,7 @@ final class ScopedProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -103,7 +103,7 @@ String _$scopedHash() => r'5a271e9b23e18517694454448b922a6c9d03781e';
 @ProviderFor(root)
 const rootProvider = RootProvider._();
 
-final class RootProvider extends $FunctionalProvider<int, int>
+final class RootProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const RootProvider._()
       : super(
@@ -133,7 +133,7 @@ final class RootProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/unsupported_provider_value.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/unsupported_provider_value.g.dart
@@ -9,7 +9,7 @@ part of 'unsupported_provider_value.dart';
 @ProviderFor(integer)
 const integerProvider = IntegerProvider._();
 
-final class IntegerProvider extends $FunctionalProvider<int, int>
+final class IntegerProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const IntegerProvider._()
       : super(
@@ -39,7 +39,7 @@ final class IntegerProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -49,9 +49,8 @@ String _$integerHash() => r'8ad63bb35c89ffcf2ef281d7c39539760afff303';
 @ProviderFor(stateNotifier)
 const stateNotifierProvider = StateNotifierProvider._();
 
-final class StateNotifierProvider
-    extends $FunctionalProvider<MyStateNotifier, MyStateNotifier>
-    with $Provider<MyStateNotifier> {
+final class StateNotifierProvider extends $FunctionalProvider<MyStateNotifier,
+    MyStateNotifier, MyStateNotifier> with $Provider<MyStateNotifier> {
   const StateNotifierProvider._()
       : super(
           from: null,
@@ -80,7 +79,7 @@ final class StateNotifierProvider
   Override overrideWithValue(MyStateNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyStateNotifier>(value),
+      providerOverride: $ValueProvider<MyStateNotifier, MyStateNotifier>(value),
     );
   }
 }
@@ -91,7 +90,7 @@ String _$stateNotifierHash() => r'2505b564fd3a623976548c715b1623dea507f6d3';
 const asyncStateNotifierProvider = AsyncStateNotifierProvider._();
 
 final class AsyncStateNotifierProvider extends $FunctionalProvider<
-        AsyncValue<MyStateNotifier>, FutureOr<MyStateNotifier>>
+        AsyncValue<MyStateNotifier>, MyStateNotifier, FutureOr<MyStateNotifier>>
     with $FutureModifier<MyStateNotifier>, $FutureProvider<MyStateNotifier> {
   const AsyncStateNotifierProvider._()
       : super(
@@ -155,7 +154,7 @@ final class StateNotifierClassProvider
   Override overrideWithValue(MyStateNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyStateNotifier>(value),
+      providerOverride: $ValueProvider<MyStateNotifier, MyStateNotifier>(value),
     );
   }
 }
@@ -169,7 +168,7 @@ abstract class _$StateNotifierClass extends $Notifier<MyStateNotifier> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<MyStateNotifier>;
+    final ref = this.ref as $Ref<MyStateNotifier, MyStateNotifier>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<MyStateNotifier, MyStateNotifier>,
         MyStateNotifier,
@@ -183,7 +182,7 @@ abstract class _$StateNotifierClass extends $Notifier<MyStateNotifier> {
 const stateNotifierAsyncProvider = StateNotifierAsyncProvider._();
 
 final class StateNotifierAsyncProvider extends $FunctionalProvider<
-        AsyncValue<MyStateNotifier>, FutureOr<MyStateNotifier>>
+        AsyncValue<MyStateNotifier>, MyStateNotifier, FutureOr<MyStateNotifier>>
     with $FutureModifier<MyStateNotifier>, $FutureProvider<MyStateNotifier> {
   const StateNotifierAsyncProvider._()
       : super(
@@ -252,7 +251,7 @@ abstract class _$SelfNotifier extends $AsyncNotifier<SelfNotifier> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<SelfNotifier>>;
+    final ref = this.ref as $Ref<AsyncValue<SelfNotifier>, SelfNotifier>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<SelfNotifier>, SelfNotifier>,
         AsyncValue<SelfNotifier>,
@@ -295,7 +294,8 @@ final class SyncSelfNotifierProvider
   Override overrideWithValue(SyncSelfNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<SyncSelfNotifier>(value),
+      providerOverride:
+          $ValueProvider<SyncSelfNotifier, SyncSelfNotifier>(value),
     );
   }
 }
@@ -308,7 +308,7 @@ abstract class _$SyncSelfNotifier extends $Notifier<SyncSelfNotifier> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<SyncSelfNotifier>;
+    final ref = this.ref as $Ref<SyncSelfNotifier, SyncSelfNotifier>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<SyncSelfNotifier, SyncSelfNotifier>,
         SyncSelfNotifier,
@@ -358,7 +358,8 @@ abstract class _$StreamSelfNotifier
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<StreamSelfNotifier>>;
+    final ref =
+        this.ref as $Ref<AsyncValue<StreamSelfNotifier>, StreamSelfNotifier>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<StreamSelfNotifier>, StreamSelfNotifier>,
         AsyncValue<StreamSelfNotifier>,
@@ -408,7 +409,7 @@ abstract class _$StateNotifierClassAsync
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<MyStateNotifier>>;
+    final ref = this.ref as $Ref<AsyncValue<MyStateNotifier>, MyStateNotifier>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<MyStateNotifier>, MyStateNotifier>,
         AsyncValue<MyStateNotifier>,
@@ -421,9 +422,8 @@ abstract class _$StateNotifierClassAsync
 @ProviderFor(changeNotifier)
 const changeNotifierProvider = ChangeNotifierProvider._();
 
-final class ChangeNotifierProvider
-    extends $FunctionalProvider<MyChangeNotifier, MyChangeNotifier>
-    with $Provider<MyChangeNotifier> {
+final class ChangeNotifierProvider extends $FunctionalProvider<MyChangeNotifier,
+    MyChangeNotifier, MyChangeNotifier> with $Provider<MyChangeNotifier> {
   const ChangeNotifierProvider._()
       : super(
           from: null,
@@ -452,7 +452,8 @@ final class ChangeNotifierProvider
   Override overrideWithValue(MyChangeNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyChangeNotifier>(value),
+      providerOverride:
+          $ValueProvider<MyChangeNotifier, MyChangeNotifier>(value),
     );
   }
 }
@@ -492,7 +493,8 @@ final class ChangeNotifierClassProvider
   Override overrideWithValue(MyChangeNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyChangeNotifier>(value),
+      providerOverride:
+          $ValueProvider<MyChangeNotifier, MyChangeNotifier>(value),
     );
   }
 }
@@ -506,7 +508,7 @@ abstract class _$ChangeNotifierClass extends $Notifier<MyChangeNotifier> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<MyChangeNotifier>;
+    final ref = this.ref as $Ref<MyChangeNotifier, MyChangeNotifier>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<MyChangeNotifier, MyChangeNotifier>,
         MyChangeNotifier,
@@ -519,7 +521,8 @@ abstract class _$ChangeNotifierClass extends $Notifier<MyChangeNotifier> {
 @ProviderFor(notifier)
 const notifierProvider = NotifierProvider._();
 
-final class NotifierProvider extends $FunctionalProvider<MyNotifier, MyNotifier>
+final class NotifierProvider
+    extends $FunctionalProvider<MyNotifier, MyNotifier, MyNotifier>
     with $Provider<MyNotifier> {
   const NotifierProvider._()
       : super(
@@ -549,7 +552,7 @@ final class NotifierProvider extends $FunctionalProvider<MyNotifier, MyNotifier>
   Override overrideWithValue(MyNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyNotifier>(value),
+      providerOverride: $ValueProvider<MyNotifier, MyNotifier>(value),
     );
   }
 }
@@ -559,9 +562,10 @@ String _$notifierHash() => r'5ad63d9ccd05ab78e7a6ba5c763cacf0b1decb7b';
 @ProviderFor(autoDisposeNotifier)
 const autoDisposeNotifierProvider = AutoDisposeNotifierProvider._();
 
-final class AutoDisposeNotifierProvider
-    extends $FunctionalProvider<MyAutoDisposeNotifier, MyAutoDisposeNotifier>
-    with $Provider<MyAutoDisposeNotifier> {
+final class AutoDisposeNotifierProvider extends $FunctionalProvider<
+    MyAutoDisposeNotifier,
+    MyAutoDisposeNotifier,
+    MyAutoDisposeNotifier> with $Provider<MyAutoDisposeNotifier> {
   const AutoDisposeNotifierProvider._()
       : super(
           from: null,
@@ -591,7 +595,8 @@ final class AutoDisposeNotifierProvider
   Override overrideWithValue(MyAutoDisposeNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyAutoDisposeNotifier>(value),
+      providerOverride:
+          $ValueProvider<MyAutoDisposeNotifier, MyAutoDisposeNotifier>(value),
     );
   }
 }
@@ -632,7 +637,7 @@ final class NotifierClassProvider
   Override overrideWithValue(MyNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyNotifier>(value),
+      providerOverride: $ValueProvider<MyNotifier, MyNotifier>(value),
     );
   }
 }
@@ -645,7 +650,7 @@ abstract class _$NotifierClass extends $Notifier<MyNotifier> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<MyNotifier>;
+    final ref = this.ref as $Ref<MyNotifier, MyNotifier>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<MyNotifier, MyNotifier>, MyNotifier, Object?, Object?>;
     element.handleValue(ref, created);
@@ -655,9 +660,8 @@ abstract class _$NotifierClass extends $Notifier<MyNotifier> {
 @ProviderFor(asyncNotifier)
 const asyncNotifierProvider = AsyncNotifierProvider._();
 
-final class AsyncNotifierProvider
-    extends $FunctionalProvider<MyAsyncNotifier, MyAsyncNotifier>
-    with $Provider<MyAsyncNotifier> {
+final class AsyncNotifierProvider extends $FunctionalProvider<MyAsyncNotifier,
+    MyAsyncNotifier, MyAsyncNotifier> with $Provider<MyAsyncNotifier> {
   const AsyncNotifierProvider._()
       : super(
           from: null,
@@ -686,7 +690,7 @@ final class AsyncNotifierProvider
   Override overrideWithValue(MyAsyncNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyAsyncNotifier>(value),
+      providerOverride: $ValueProvider<MyAsyncNotifier, MyAsyncNotifier>(value),
     );
   }
 }
@@ -726,7 +730,7 @@ final class AsyncNotifierClassProvider
   Override overrideWithValue(MyAsyncNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyAsyncNotifier>(value),
+      providerOverride: $ValueProvider<MyAsyncNotifier, MyAsyncNotifier>(value),
     );
   }
 }
@@ -740,7 +744,7 @@ abstract class _$AsyncNotifierClass extends $Notifier<MyAsyncNotifier> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<MyAsyncNotifier>;
+    final ref = this.ref as $Ref<MyAsyncNotifier, MyAsyncNotifier>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<MyAsyncNotifier, MyAsyncNotifier>,
         MyAsyncNotifier,
@@ -753,9 +757,10 @@ abstract class _$AsyncNotifierClass extends $Notifier<MyAsyncNotifier> {
 @ProviderFor(rawNotifier)
 const rawNotifierProvider = RawNotifierProvider._();
 
-final class RawNotifierProvider
-    extends $FunctionalProvider<Raw<MyChangeNotifier>, Raw<MyChangeNotifier>>
-    with $Provider<Raw<MyChangeNotifier>> {
+final class RawNotifierProvider extends $FunctionalProvider<
+    Raw<MyChangeNotifier>,
+    Raw<MyChangeNotifier>,
+    Raw<MyChangeNotifier>> with $Provider<Raw<MyChangeNotifier>> {
   const RawNotifierProvider._()
       : super(
           from: null,
@@ -785,7 +790,8 @@ final class RawNotifierProvider
   Override overrideWithValue(Raw<MyChangeNotifier> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<MyChangeNotifier>>(value),
+      providerOverride:
+          $ValueProvider<Raw<MyChangeNotifier>, Raw<MyChangeNotifier>>(value),
     );
   }
 }
@@ -796,7 +802,9 @@ String _$rawNotifierHash() => r'c667d10419c9ce1fdd227e2afd1f3aaf63c3380b';
 const rawFutureNotifierProvider = RawFutureNotifierProvider._();
 
 final class RawFutureNotifierProvider extends $FunctionalProvider<
-        Raw<Future<MyChangeNotifier>>, Raw<Future<MyChangeNotifier>>>
+        Raw<Future<MyChangeNotifier>>,
+        Raw<Future<MyChangeNotifier>>,
+        Raw<Future<MyChangeNotifier>>>
     with $Provider<Raw<Future<MyChangeNotifier>>> {
   const RawFutureNotifierProvider._()
       : super(
@@ -827,7 +835,8 @@ final class RawFutureNotifierProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<Future<MyChangeNotifier>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Future<MyChangeNotifier>>>(value),
+      providerOverride: $ValueProvider<Raw<Future<MyChangeNotifier>>,
+          Raw<Future<MyChangeNotifier>>>(value),
     );
   }
 }
@@ -838,7 +847,9 @@ String _$rawFutureNotifierHash() => r'ff2744c369ebd96615f19451eae416d7afeef03f';
 const rawStreamNotifierProvider = RawStreamNotifierProvider._();
 
 final class RawStreamNotifierProvider extends $FunctionalProvider<
-        Raw<Stream<MyChangeNotifier>>, Raw<Stream<MyChangeNotifier>>>
+        Raw<Stream<MyChangeNotifier>>,
+        Raw<Stream<MyChangeNotifier>>,
+        Raw<Stream<MyChangeNotifier>>>
     with $Provider<Raw<Stream<MyChangeNotifier>>> {
   const RawStreamNotifierProvider._()
       : super(
@@ -869,7 +880,8 @@ final class RawStreamNotifierProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<Stream<MyChangeNotifier>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Stream<MyChangeNotifier>>>(value),
+      providerOverride: $ValueProvider<Raw<Stream<MyChangeNotifier>>,
+          Raw<Stream<MyChangeNotifier>>>(value),
     );
   }
 }
@@ -880,7 +892,9 @@ String _$rawStreamNotifierHash() => r'9a13efb8fbcef6c4388d5a2535b1b0aec6e46a9a';
 const futureRawNotifierProvider = FutureRawNotifierProvider._();
 
 final class FutureRawNotifierProvider extends $FunctionalProvider<
-        AsyncValue<Raw<MyChangeNotifier>>, FutureOr<Raw<MyChangeNotifier>>>
+        AsyncValue<Raw<MyChangeNotifier>>,
+        Raw<MyChangeNotifier>,
+        FutureOr<Raw<MyChangeNotifier>>>
     with
         $FutureModifier<Raw<MyChangeNotifier>>,
         $FutureProvider<Raw<MyChangeNotifier>> {
@@ -916,7 +930,9 @@ String _$futureRawNotifierHash() => r'87103845bce1f4cae4ad62ae3b7da6ca3539581f';
 const streamRawNotifierProvider = StreamRawNotifierProvider._();
 
 final class StreamRawNotifierProvider extends $FunctionalProvider<
-        AsyncValue<Raw<MyChangeNotifier>>, Stream<Raw<MyChangeNotifier>>>
+        AsyncValue<Raw<MyChangeNotifier>>,
+        Raw<MyChangeNotifier>,
+        Stream<Raw<MyChangeNotifier>>>
     with
         $FutureModifier<Raw<MyChangeNotifier>>,
         $StreamProvider<Raw<MyChangeNotifier>> {

--- a/packages/riverpod_sqflite/example/lib/generated.g.dart
+++ b/packages/riverpod_sqflite/example/lib/generated.g.dart
@@ -26,7 +26,9 @@ Map<String, dynamic> _$TodoToJson(_Todo instance) => <String, dynamic>{
 const storageProvider = StorageProvider._();
 
 final class StorageProvider extends $FunctionalProvider<
-        AsyncValue<JsonSqFliteStorage>, FutureOr<JsonSqFliteStorage>>
+        AsyncValue<JsonSqFliteStorage>,
+        JsonSqFliteStorage,
+        FutureOr<JsonSqFliteStorage>>
     with
         $FutureModifier<JsonSqFliteStorage>,
         $FutureProvider<JsonSqFliteStorage> {
@@ -97,7 +99,7 @@ abstract class _$TodosNotifierBase extends $AsyncNotifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<Todo>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<Todo>>, List<Todo>>,
         AsyncValue<List<Todo>>,

--- a/website/docs/advanced/select/select/codegen.g.dart
+++ b/website/docs/advanced/select/select/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(example)
 const exampleProvider = ExampleProvider._();
 
-final class ExampleProvider extends $FunctionalProvider<User, User>
+final class ExampleProvider extends $FunctionalProvider<User, User, User>
     with $Provider<User> {
   const ExampleProvider._()
       : super(
@@ -41,7 +41,7 @@ final class ExampleProvider extends $FunctionalProvider<User, User>
   Override overrideWithValue(User value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<User>(value),
+      providerOverride: $ValueProvider<User, User>(value),
     );
   }
 }

--- a/website/docs/advanced/select/select_async/codegen.g.dart
+++ b/website/docs/advanced/select/select_async/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const userProvider = UserProvider._();
 
 final class UserProvider
-    extends $FunctionalProvider<AsyncValue<User>, FutureOr<User>>
+    extends $FunctionalProvider<AsyncValue<User>, User, FutureOr<User>>
     with $FutureModifier<User>, $FutureProvider<User> {
   const UserProvider._()
       : super(
@@ -44,7 +44,8 @@ String _$userHash() => r'b83ca110a6fae2341d1bfca73fb3d89c4d12723d';
 @ProviderFor(example)
 const exampleProvider = ExampleProvider._();
 
-final class ExampleProvider extends $FunctionalProvider<Object?, Object?>
+final class ExampleProvider
+    extends $FunctionalProvider<Object?, Object?, Object?>
     with $Provider<Object?> {
   const ExampleProvider._()
       : super(
@@ -74,7 +75,7 @@ final class ExampleProvider extends $FunctionalProvider<Object?, Object?>
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?>(value),
+      providerOverride: $ValueProvider<Object?, Object?>(value),
     );
   }
 }

--- a/website/docs/case_studies/cancel/detail_screen/codegen.g.dart
+++ b/website/docs/case_studies/cancel/detail_screen/codegen.g.dart
@@ -29,8 +29,8 @@ Map<String, dynamic> _$ActivityToJson(_Activity instance) => <String, dynamic>{
 @ProviderFor(activity)
 const activityProvider = ActivityProvider._();
 
-final class ActivityProvider
-    extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
+final class ActivityProvider extends $FunctionalProvider<AsyncValue<Activity>,
+        Activity, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
   const ActivityProvider._()
       : super(

--- a/website/docs/case_studies/cancel/detail_screen_cancel/codegen.g.dart
+++ b/website/docs/case_studies/cancel/detail_screen_cancel/codegen.g.dart
@@ -11,8 +11,8 @@ part of 'codegen.dart';
 @ProviderFor(activity)
 const activityProvider = ActivityProvider._();
 
-final class ActivityProvider
-    extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
+final class ActivityProvider extends $FunctionalProvider<AsyncValue<Activity>,
+        Activity, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
   const ActivityProvider._()
       : super(

--- a/website/docs/case_studies/cancel/detail_screen_debounce/codegen.g.dart
+++ b/website/docs/case_studies/cancel/detail_screen_debounce/codegen.g.dart
@@ -11,8 +11,8 @@ part of 'codegen.dart';
 @ProviderFor(activity)
 const activityProvider = ActivityProvider._();
 
-final class ActivityProvider
-    extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
+final class ActivityProvider extends $FunctionalProvider<AsyncValue<Activity>,
+        Activity, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
   const ActivityProvider._()
       : super(

--- a/website/docs/case_studies/cancel/provider_with_extension/codegen.g.dart
+++ b/website/docs/case_studies/cancel/provider_with_extension/codegen.g.dart
@@ -11,8 +11,8 @@ part of 'codegen.dart';
 @ProviderFor(activity)
 const activityProvider = ActivityProvider._();
 
-final class ActivityProvider
-    extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
+final class ActivityProvider extends $FunctionalProvider<AsyncValue<Activity>,
+        Activity, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
   const ActivityProvider._()
       : super(

--- a/website/docs/case_studies/pull_to_refresh/fetch_activity/codegen.g.dart
+++ b/website/docs/case_studies/pull_to_refresh/fetch_activity/codegen.g.dart
@@ -11,8 +11,8 @@ part of 'codegen.dart';
 @ProviderFor(activity)
 const activityProvider = ActivityProvider._();
 
-final class ActivityProvider
-    extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
+final class ActivityProvider extends $FunctionalProvider<AsyncValue<Activity>,
+        Activity, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
   const ActivityProvider._()
       : super(

--- a/website/docs/case_studies/pull_to_refresh/full_app/codegen.g.dart
+++ b/website/docs/case_studies/pull_to_refresh/full_app/codegen.g.dart
@@ -29,8 +29,8 @@ Map<String, dynamic> _$ActivityToJson(_Activity instance) => <String, dynamic>{
 @ProviderFor(activity)
 const activityProvider = ActivityProvider._();
 
-final class ActivityProvider
-    extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
+final class ActivityProvider extends $FunctionalProvider<AsyncValue<Activity>,
+        Activity, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
   const ActivityProvider._()
       : super(

--- a/website/docs/concepts/about_codegen/main.g.dart
+++ b/website/docs/concepts/about_codegen/main.g.dart
@@ -12,7 +12,7 @@ part of 'main.dart';
 const fetchUserProvider = FetchUserFamily._();
 
 final class FetchUserProvider
-    extends $FunctionalProvider<AsyncValue<User>, FutureOr<User>>
+    extends $FunctionalProvider<AsyncValue<User>, User, FutureOr<User>>
     with $FutureModifier<User>, $FutureProvider<User> {
   const FetchUserProvider._(
       {required FetchUserFamily super.from, required int super.argument})

--- a/website/docs/concepts/about_codegen/provider_type/async_class_future.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_class_future.g.dart
@@ -45,7 +45,7 @@ abstract class _$Example extends $AsyncNotifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,

--- a/website/docs/concepts/about_codegen/provider_type/async_class_stream.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_class_stream.g.dart
@@ -45,7 +45,7 @@ abstract class _$Example extends $StreamNotifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<String>>;
+    final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<String>, String>,
         AsyncValue<String>,

--- a/website/docs/concepts/about_codegen/provider_type/async_fn_future.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_fn_future.g.dart
@@ -12,7 +12,7 @@ part of 'async_fn_future.dart';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider
-    extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
   const ExampleProvider._()
       : super(

--- a/website/docs/concepts/about_codegen/provider_type/async_fn_stream.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_fn_stream.g.dart
@@ -12,7 +12,7 @@ part of 'async_fn_stream.dart';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider
-    extends $FunctionalProvider<AsyncValue<String>, Stream<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, Stream<String>>
     with $FutureModifier<String>, $StreamProvider<String> {
   const ExampleProvider._()
       : super(

--- a/website/docs/concepts/about_codegen/provider_type/auto_dispose.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/auto_dispose.g.dart
@@ -11,7 +11,7 @@ part of 'auto_dispose.dart';
 @ProviderFor(example1)
 const example1Provider = Example1Provider._();
 
-final class Example1Provider extends $FunctionalProvider<String, String>
+final class Example1Provider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const Example1Provider._()
       : super(
@@ -41,7 +41,7 @@ final class Example1Provider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -51,7 +51,7 @@ String _$example1Hash() => r'6a361ee6f9dd1d0cdbb42f967f6356aa058f7041';
 @ProviderFor(example2)
 const example2Provider = Example2Provider._();
 
-final class Example2Provider extends $FunctionalProvider<String, String>
+final class Example2Provider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const Example2Provider._()
       : super(
@@ -81,7 +81,7 @@ final class Example2Provider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }

--- a/website/docs/concepts/about_codegen/provider_type/family.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family.g.dart
@@ -11,7 +11,7 @@ part of 'family.dart';
 @ProviderFor(example)
 const exampleProvider = ExampleFamily._();
 
-final class ExampleProvider extends $FunctionalProvider<String, String>
+final class ExampleProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const ExampleProvider._(
       {required ExampleFamily super.from, required int super.argument})
@@ -51,7 +51,7 @@ final class ExampleProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 

--- a/website/docs/concepts/about_codegen/provider_type/family_class.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_class.g.dart
@@ -51,7 +51,7 @@ final class ExampleProvider extends $NotifierProvider<Example, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 
@@ -120,7 +120,7 @@ abstract class _$Example extends $Notifier<String> {
       _$args.$1,
       param2: _$args.param2,
     );
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/about_codegen/provider_type/family_fn.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_fn.g.dart
@@ -11,7 +11,7 @@ part of 'family_fn.dart';
 @ProviderFor(example)
 const exampleProvider = ExampleFamily._();
 
-final class ExampleProvider extends $FunctionalProvider<String, String>
+final class ExampleProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const ExampleProvider._(
       {required ExampleFamily super.from,
@@ -60,7 +60,7 @@ final class ExampleProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 

--- a/website/docs/concepts/about_codegen/provider_type/sync_class.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/sync_class.g.dart
@@ -40,7 +40,7 @@ final class ExampleProvider extends $NotifierProvider<Example, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Example extends $Notifier<String> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<String>;
+    final ref = this.ref as $Ref<String, String>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<String, String>, String, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/about_codegen/provider_type/sync_fn.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/sync_fn.g.dart
@@ -11,7 +11,7 @@ part of 'sync_fn.dart';
 @ProviderFor(example)
 const exampleProvider = ExampleProvider._();
 
-final class ExampleProvider extends $FunctionalProvider<String, String>
+final class ExampleProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const ExampleProvider._()
       : super(
@@ -41,7 +41,7 @@ final class ExampleProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }

--- a/website/docs/concepts/combining_provider_states/characters_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/characters_provider/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(search)
 const searchProvider = SearchProvider._();
 
-final class SearchProvider extends $FunctionalProvider<String, String>
+final class SearchProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const SearchProvider._()
       : super(
@@ -41,7 +41,7 @@ final class SearchProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -52,7 +52,7 @@ String _$searchHash() => r'bc08d7ad4026615f3c0e4824c6b943f315cf18be';
 const configsProvider = ConfigsProvider._();
 
 final class ConfigsProvider extends $FunctionalProvider<
-        AsyncValue<Configuration>, Stream<Configuration>>
+        AsyncValue<Configuration>, Configuration, Stream<Configuration>>
     with $FutureModifier<Configuration>, $StreamProvider<Configuration> {
   const ConfigsProvider._()
       : super(
@@ -86,7 +86,7 @@ String _$configsHash() => r'6416514dacd408abb24de2bd1404860e6518c564';
 const charactersProvider = CharactersProvider._();
 
 final class CharactersProvider extends $FunctionalProvider<
-        AsyncValue<List<Character>>, FutureOr<List<Character>>>
+        AsyncValue<List<Character>>, List<Character>, FutureOr<List<Character>>>
     with $FutureModifier<List<Character>>, $FutureProvider<List<Character>> {
   const CharactersProvider._()
       : super(

--- a/website/docs/concepts/combining_provider_states/city_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/city_provider/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(city)
 const cityProvider = CityProvider._();
 
-final class CityProvider extends $FunctionalProvider<String, String>
+final class CityProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const CityProvider._()
       : super(
@@ -41,7 +41,7 @@ final class CityProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }

--- a/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(filter)
 const filterProvider = FilterProvider._();
 
-final class FilterProvider extends $FunctionalProvider<Filter, Filter>
+final class FilterProvider extends $FunctionalProvider<Filter, Filter, Filter>
     with $Provider<Filter> {
   const FilterProvider._()
       : super(
@@ -41,7 +41,7 @@ final class FilterProvider extends $FunctionalProvider<Filter, Filter>
   Override overrideWithValue(Filter value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Filter>(value),
+      providerOverride: $ValueProvider<Filter, Filter>(value),
     );
   }
 }
@@ -52,7 +52,7 @@ String _$filterHash() => r'6583f8bace972f4385964cd26f217751164b537b';
 const filteredTodoListProvider = FilteredTodoListProvider._();
 
 final class FilteredTodoListProvider
-    extends $FunctionalProvider<List<Todo>, List<Todo>>
+    extends $FunctionalProvider<List<Todo>, List<Todo>, List<Todo>>
     with $Provider<List<Todo>> {
   const FilteredTodoListProvider._()
       : super(
@@ -82,7 +82,7 @@ final class FilteredTodoListProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }

--- a/website/docs/concepts/combining_provider_states/read_in_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/read_in_provider/codegen.g.dart
@@ -11,7 +11,8 @@ part of 'codegen.dart';
 @ProviderFor(another)
 const anotherProvider = AnotherProvider._();
 
-final class AnotherProvider extends $FunctionalProvider<MyValue, MyValue>
+final class AnotherProvider
+    extends $FunctionalProvider<MyValue, MyValue, MyValue>
     with $Provider<MyValue> {
   const AnotherProvider._()
       : super(
@@ -41,7 +42,7 @@ final class AnotherProvider extends $FunctionalProvider<MyValue, MyValue>
   Override overrideWithValue(MyValue value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyValue>(value),
+      providerOverride: $ValueProvider<MyValue, MyValue>(value),
     );
   }
 }
@@ -51,7 +52,7 @@ String _$anotherHash() => r'07629e5ae4a53bcd316b91c07d7558edbdea9317';
 @ProviderFor(my)
 const myProvider = MyProvider._();
 
-final class MyProvider extends $FunctionalProvider<MyValue, MyValue>
+final class MyProvider extends $FunctionalProvider<MyValue, MyValue, MyValue>
     with $Provider<MyValue> {
   const MyProvider._()
       : super(
@@ -81,7 +82,7 @@ final class MyProvider extends $FunctionalProvider<MyValue, MyValue>
   Override overrideWithValue(MyValue value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyValue>(value),
+      providerOverride: $ValueProvider<MyValue, MyValue>(value),
     );
   }
 }

--- a/website/docs/concepts/combining_provider_states/select_async_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/select_async_provider/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const configProvider = ConfigProvider._();
 
 final class ConfigProvider extends $FunctionalProvider<
-        AsyncValue<Configuration>, Stream<Configuration>>
+        AsyncValue<Configuration>, Configuration, Stream<Configuration>>
     with $FutureModifier<Configuration>, $StreamProvider<Configuration> {
   const ConfigProvider._()
       : super(
@@ -46,7 +46,7 @@ String _$configHash() => r'66f48a02bf939463649f0e7ad34137265e5c8b66';
 const productsProvider = ProductsProvider._();
 
 final class ProductsProvider extends $FunctionalProvider<
-        AsyncValue<List<Product>>, FutureOr<List<Product>>>
+        AsyncValue<List<Product>>, List<Product>, FutureOr<List<Product>>>
     with $FutureModifier<List<Product>>, $FutureProvider<List<Product>> {
   const ProductsProvider._()
       : super(

--- a/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.g.dart
@@ -40,7 +40,7 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$TodoList extends $Notifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<List<Todo>>;
+    final ref = this.ref as $Ref<List<Todo>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<List<Todo>, List<Todo>>, List<Todo>, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/combining_provider_states/weather_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/weather_provider/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(city)
 const cityProvider = CityProvider._();
 
-final class CityProvider extends $FunctionalProvider<String, String>
+final class CityProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const CityProvider._()
       : super(
@@ -41,7 +41,7 @@ final class CityProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -52,7 +52,7 @@ String _$cityHash() => r'6a5023a3aba119f1ecaee6c7db44b3f519e72759';
 const weatherProvider = WeatherProvider._();
 
 final class WeatherProvider
-    extends $FunctionalProvider<AsyncValue<Weather>, FutureOr<Weather>>
+    extends $FunctionalProvider<AsyncValue<Weather>, Weather, FutureOr<Weather>>
     with $FutureModifier<Weather>, $FutureProvider<Weather> {
   const WeatherProvider._()
       : super(

--- a/website/docs/concepts/combining_provider_states/whole_object_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/whole_object_provider/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const configProvider = ConfigProvider._();
 
 final class ConfigProvider extends $FunctionalProvider<
-        AsyncValue<Configuration>, Stream<Configuration>>
+        AsyncValue<Configuration>, Configuration, Stream<Configuration>>
     with $FutureModifier<Configuration>, $StreamProvider<Configuration> {
   const ConfigProvider._()
       : super(
@@ -46,7 +46,7 @@ String _$configHash() => r'66f48a02bf939463649f0e7ad34137265e5c8b66';
 const productsProvider = ProductsProvider._();
 
 final class ProductsProvider extends $FunctionalProvider<
-        AsyncValue<List<Product>>, FutureOr<List<Product>>>
+        AsyncValue<List<Product>>, List<Product>, FutureOr<List<Product>>>
     with $FutureModifier<List<Product>>, $FutureProvider<List<Product>> {
   const ProductsProvider._()
       : super(

--- a/website/docs/concepts/lifecycle_on_dispose/codegen.g.dart
+++ b/website/docs/concepts/lifecycle_on_dispose/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider
-    extends $FunctionalProvider<AsyncValue<int>, Stream<int>>
+    extends $FunctionalProvider<AsyncValue<int>, int, Stream<int>>
     with $FutureModifier<int>, $StreamProvider<int> {
   const ExampleProvider._()
       : super(

--- a/website/docs/concepts/providers/creating_a_provider/codegen.g.dart
+++ b/website/docs/concepts/providers/creating_a_provider/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(my)
 const myProvider = MyProvider._();
 
-final class MyProvider extends $FunctionalProvider<MyValue, MyValue>
+final class MyProvider extends $FunctionalProvider<MyValue, MyValue, MyValue>
     with $Provider<MyValue> {
   const MyProvider._()
       : super(
@@ -41,7 +41,7 @@ final class MyProvider extends $FunctionalProvider<MyValue, MyValue>
   Override overrideWithValue(MyValue value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyValue>(value),
+      providerOverride: $ValueProvider<MyValue, MyValue>(value),
     );
   }
 }

--- a/website/docs/concepts/providers/declaring_many_providers/codegen.g.dart
+++ b/website/docs/concepts/providers/declaring_many_providers/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(city)
 const cityProvider = CityProvider._();
 
-final class CityProvider extends $FunctionalProvider<String, String>
+final class CityProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const CityProvider._()
       : super(
@@ -41,7 +41,7 @@ final class CityProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }
@@ -51,7 +51,7 @@ String _$cityHash() => r'6a5023a3aba119f1ecaee6c7db44b3f519e72759';
 @ProviderFor(country)
 const countryProvider = CountryProvider._();
 
-final class CountryProvider extends $FunctionalProvider<String, String>
+final class CountryProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const CountryProvider._()
       : super(
@@ -81,7 +81,7 @@ final class CountryProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/counter/codegen.g.dart
+++ b/website/docs/concepts/reading/counter/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const repositoryProvider = RepositoryProvider._();
 
 final class RepositoryProvider
-    extends $FunctionalProvider<Repository, Repository>
+    extends $FunctionalProvider<Repository, Repository, Repository>
     with $Provider<Repository> {
   const RepositoryProvider._()
       : super(
@@ -42,7 +42,7 @@ final class RepositoryProvider
   Override overrideWithValue(Repository value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Repository>(value),
+      providerOverride: $ValueProvider<Repository, Repository>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -94,7 +94,7 @@ abstract class _$Counter extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/reading/listen/codegen.g.dart
+++ b/website/docs/concepts/reading/listen/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(another)
 const anotherProvider = AnotherProvider._();
 
-final class AnotherProvider extends $FunctionalProvider<void, void>
+final class AnotherProvider extends $FunctionalProvider<void, void, void>
     with $Provider<void> {
   const AnotherProvider._()
       : super(
@@ -41,7 +41,7 @@ final class AnotherProvider extends $FunctionalProvider<void, void>
   Override overrideWithValue(void value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<void>(value),
+      providerOverride: $ValueProvider<void, void>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/listen_build/codegen.g.dart
+++ b/website/docs/concepts/reading/listen_build/codegen.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Counter extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/reading/listen_build/codegen_hooks.g.dart
+++ b/website/docs/concepts/reading/listen_build/codegen_hooks.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Counter extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/reading/provider/codegen.g.dart
+++ b/website/docs/concepts/reading/provider/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const repositoryProvider = RepositoryProvider._();
 
 final class RepositoryProvider
-    extends $FunctionalProvider<Repository, Repository>
+    extends $FunctionalProvider<Repository, Repository, Repository>
     with $Provider<Repository> {
   const RepositoryProvider._()
       : super(
@@ -42,7 +42,7 @@ final class RepositoryProvider
   Override overrideWithValue(Repository value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Repository>(value),
+      providerOverride: $ValueProvider<Repository, Repository>(value),
     );
   }
 }
@@ -52,7 +52,7 @@ String _$repositoryHash() => r'6f859a9d70c3112139aaf826ee2bd541a4c001cb';
 @ProviderFor(value)
 const valueProvider = ValueProvider._();
 
-final class ValueProvider extends $FunctionalProvider<String, String>
+final class ValueProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const ValueProvider._()
       : super(
@@ -82,7 +82,7 @@ final class ValueProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/read/codegen.g.dart
+++ b/website/docs/concepts/reading/read/codegen.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Counter extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/reading/read/codegen_hooks.g.dart
+++ b/website/docs/concepts/reading/read/codegen_hooks.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Counter extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/reading/read_build/codegen.g.dart
+++ b/website/docs/concepts/reading/read_build/codegen.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Counter extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/reading/read_notifier_build/codegen.g.dart
+++ b/website/docs/concepts/reading/read_notifier_build/codegen.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Counter extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/reading/watch/codegen.g.dart
+++ b/website/docs/concepts/reading/watch/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const filterTypeProvider = FilterTypeProvider._();
 
 final class FilterTypeProvider
-    extends $FunctionalProvider<FilterType, FilterType>
+    extends $FunctionalProvider<FilterType, FilterType, FilterType>
     with $Provider<FilterType> {
   const FilterTypeProvider._()
       : super(
@@ -42,7 +42,7 @@ final class FilterTypeProvider
   Override overrideWithValue(FilterType value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<FilterType>(value),
+      providerOverride: $ValueProvider<FilterType, FilterType>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }
@@ -94,7 +94,7 @@ abstract class _$Todos extends $Notifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<List<Todo>>;
+    final ref = this.ref as $Ref<List<Todo>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<List<Todo>, List<Todo>>, List<Todo>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -105,7 +105,7 @@ abstract class _$Todos extends $Notifier<List<Todo>> {
 const filteredTodoListProvider = FilteredTodoListProvider._();
 
 final class FilteredTodoListProvider
-    extends $FunctionalProvider<List<Todo>, List<Todo>>
+    extends $FunctionalProvider<List<Todo>, List<Todo>, List<Todo>>
     with $Provider<List<Todo>> {
   const FilteredTodoListProvider._()
       : super(
@@ -135,7 +135,7 @@ final class FilteredTodoListProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/watch_build/codegen.g.dart
+++ b/website/docs/concepts/reading/watch_build/codegen.g.dart
@@ -40,7 +40,7 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$TodoList extends $Notifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<List<Todo>>;
+    final ref = this.ref as $Ref<List<Todo>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<List<Todo>, List<Todo>>, List<Todo>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -63,7 +63,7 @@ abstract class _$TodoList extends $Notifier<List<Todo>> {
 @ProviderFor(counter)
 const counterProvider = CounterProvider._();
 
-final class CounterProvider extends $FunctionalProvider<int, int>
+final class CounterProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const CounterProvider._()
       : super(
@@ -93,7 +93,7 @@ final class CounterProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/watch_build/codegen_hooks.g.dart
+++ b/website/docs/concepts/reading/watch_build/codegen_hooks.g.dart
@@ -40,7 +40,7 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$TodoList extends $Notifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<List<Todo>>;
+    final ref = this.ref as $Ref<List<Todo>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<List<Todo>, List<Todo>>, List<Todo>, Object?, Object?>;
     element.handleValue(ref, created);
@@ -63,7 +63,7 @@ abstract class _$TodoList extends $Notifier<List<Todo>> {
 @ProviderFor(counter)
 const counterProvider = CounterProvider._();
 
-final class CounterProvider extends $FunctionalProvider<int, int>
+final class CounterProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const CounterProvider._()
       : super(
@@ -93,7 +93,7 @@ final class CounterProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/watch_notifier_build/codegen.g.dart
+++ b/website/docs/concepts/reading/watch_notifier_build/codegen.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Counter extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/concepts/why_immutability/codegen.g.dart
+++ b/website/docs/concepts/why_immutability/codegen.g.dart
@@ -41,7 +41,7 @@ final class ThemeNotifierProvider
   Override overrideWithValue(ThemeSettings value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<ThemeSettings>(value),
+      providerOverride: $ValueProvider<ThemeSettings, ThemeSettings>(value),
     );
   }
 }
@@ -54,7 +54,7 @@ abstract class _$ThemeNotifier extends $Notifier<ThemeSettings> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<ThemeSettings>;
+    final ref = this.ref as $Ref<ThemeSettings, ThemeSettings>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<ThemeSettings, ThemeSettings>,
         ThemeSettings,

--- a/website/docs/cookbooks/testing_override_info.dart
+++ b/website/docs/cookbooks/testing_override_info.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart' show ProviderBase, Override;
 
-extension on ProviderBase<Object?> {
+extension on ProviderBase<Object?, Object?> {
   // ignore: unused_element
   Override overrideWithValue(Object? value) => throw UnimplementedError();
 }

--- a/website/docs/essentials/auto_dispose/cache_for_usage/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/cache_for_usage/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider
-    extends $FunctionalProvider<AsyncValue<Object>, FutureOr<Object>>
+    extends $FunctionalProvider<AsyncValue<Object>, Object, FutureOr<Object>>
     with $FutureModifier<Object>, $FutureProvider<Object> {
   const ExampleProvider._()
       : super(

--- a/website/docs/essentials/auto_dispose/codegen_keep_alive.g.dart
+++ b/website/docs/essentials/auto_dispose/codegen_keep_alive.g.dart
@@ -11,7 +11,7 @@ part of 'codegen_keep_alive.dart';
 @ProviderFor(example)
 const exampleProvider = ExampleProvider._();
 
-final class ExampleProvider extends $FunctionalProvider<int, int>
+final class ExampleProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const ExampleProvider._()
       : super(
@@ -41,7 +41,7 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/website/docs/essentials/auto_dispose/invalidate_family_example/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/invalidate_family_example/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(label)
 const labelProvider = LabelFamily._();
 
-final class LabelProvider extends $FunctionalProvider<String, String>
+final class LabelProvider extends $FunctionalProvider<String, String, String>
     with $Provider<String> {
   const LabelProvider._(
       {required LabelFamily super.from, required String super.argument})
@@ -51,7 +51,7 @@ final class LabelProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 

--- a/website/docs/essentials/auto_dispose/keep_alive/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/keep_alive/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider
-    extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
   const ExampleProvider._()
       : super(

--- a/website/docs/essentials/auto_dispose/on_dispose_example/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/on_dispose_example/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(other)
 const otherProvider = OtherProvider._();
 
-final class OtherProvider extends $FunctionalProvider<int, int>
+final class OtherProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const OtherProvider._()
       : super(
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -52,7 +52,7 @@ String _$otherHash() => r'5d27b2b1b1c6bd17ba0844f74ade2088611be371';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider
-    extends $FunctionalProvider<AsyncValue<int>, Stream<int>>
+    extends $FunctionalProvider<AsyncValue<int>, int, Stream<int>>
     with $FutureModifier<int>, $StreamProvider<int> {
   const ExampleProvider._()
       : super(

--- a/website/docs/essentials/combining_requests/functional_ref/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/functional_ref/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(other)
 const otherProvider = OtherProvider._();
 
-final class OtherProvider extends $FunctionalProvider<int, int>
+final class OtherProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const OtherProvider._()
       : super(
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -51,7 +51,7 @@ String _$otherHash() => r'5d27b2b1b1c6bd17ba0844f74ade2088611be371';
 @ProviderFor(example)
 const exampleProvider = ExampleProvider._();
 
-final class ExampleProvider extends $FunctionalProvider<int, int>
+final class ExampleProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const ExampleProvider._()
       : super(
@@ -81,7 +81,7 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/website/docs/essentials/combining_requests/listen_example/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/listen_example/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(other)
 const otherProvider = OtherProvider._();
 
-final class OtherProvider extends $FunctionalProvider<int, int>
+final class OtherProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const OtherProvider._()
       : super(
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -51,7 +51,7 @@ String _$otherHash() => r'5d27b2b1b1c6bd17ba0844f74ade2088611be371';
 @ProviderFor(example)
 const exampleProvider = ExampleProvider._();
 
-final class ExampleProvider extends $FunctionalProvider<int, int>
+final class ExampleProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const ExampleProvider._()
       : super(
@@ -81,7 +81,7 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/website/docs/essentials/combining_requests/notifier_ref/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/notifier_ref/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(other)
 const otherProvider = OtherProvider._();
 
-final class OtherProvider extends $FunctionalProvider<int, int>
+final class OtherProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const OtherProvider._()
       : super(
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -80,7 +80,7 @@ final class ExampleProvider extends $NotifierProvider<Example, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -93,7 +93,7 @@ abstract class _$Example extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/essentials/combining_requests/read_example/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/read_example/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(other)
 const otherProvider = OtherProvider._();
 
-final class OtherProvider extends $FunctionalProvider<int, int>
+final class OtherProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const OtherProvider._()
       : super(
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -80,7 +80,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -93,7 +93,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/essentials/combining_requests/watch_example/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/watch_example/codegen.g.dart
@@ -13,6 +13,7 @@ const locationProvider = LocationProvider._();
 
 final class LocationProvider extends $FunctionalProvider<
         AsyncValue<({double longitude, double latitude})>,
+        ({double longitude, double latitude}),
         Stream<({double longitude, double latitude})>>
     with
         $FutureModifier<({double longitude, double latitude})>,
@@ -49,7 +50,7 @@ String _$locationHash() => r'39328e5d0ec2b97acec14f1aba6c8db3f24f46a8';
 const restaurantsNearMeProvider = RestaurantsNearMeProvider._();
 
 final class RestaurantsNearMeProvider extends $FunctionalProvider<
-        AsyncValue<List<String>>, FutureOr<List<String>>>
+        AsyncValue<List<String>>, List<String>, FutureOr<List<String>>>
     with $FutureModifier<List<String>>, $FutureProvider<List<String>> {
   const RestaurantsNearMeProvider._()
       : super(

--- a/website/docs/essentials/combining_requests/watch_placement/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/watch_placement/codegen.g.dart
@@ -11,7 +11,7 @@ part of 'codegen.dart';
 @ProviderFor(other)
 const otherProvider = OtherProvider._();
 
-final class OtherProvider extends $FunctionalProvider<int, int>
+final class OtherProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const OtherProvider._()
       : super(
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -51,7 +51,7 @@ String _$otherHash() => r'5d27b2b1b1c6bd17ba0844f74ade2088611be371';
 @ProviderFor(example)
 const exampleProvider = ExampleProvider._();
 
-final class ExampleProvider extends $FunctionalProvider<int, int>
+final class ExampleProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const ExampleProvider._()
       : super(
@@ -81,7 +81,7 @@ final class ExampleProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -120,7 +120,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -133,7 +133,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/essentials/eager_initialization/require_value/codegen.g.dart
+++ b/website/docs/essentials/eager_initialization/require_value/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider
-    extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
   const ExampleProvider._()
       : super(

--- a/website/docs/essentials/first_request/codegen/provider.g.dart
+++ b/website/docs/essentials/first_request/codegen/provider.g.dart
@@ -17,8 +17,8 @@ const activityProvider = ActivityProvider._();
 /// This will create a provider named `activityProvider`
 /// which will cache the result of this function.
 // {@endtemplate}
-final class ActivityProvider
-    extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
+final class ActivityProvider extends $FunctionalProvider<AsyncValue<Activity>,
+        Activity, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
   /// This will create a provider named `activityProvider`
   /// which will cache the result of this function.

--- a/website/docs/essentials/passing_args/family/codegen.g.dart
+++ b/website/docs/essentials/passing_args/family/codegen.g.dart
@@ -11,8 +11,8 @@ part of 'codegen.dart';
 @ProviderFor(activity)
 const activityProvider = ActivityFamily._();
 
-final class ActivityProvider
-    extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
+final class ActivityProvider extends $FunctionalProvider<AsyncValue<Activity>,
+        Activity, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
   const ActivityProvider._(
       {required ActivityFamily super.from, required String super.argument})
@@ -165,7 +165,7 @@ abstract class _$ActivityNotifier2 extends $AsyncNotifier<Activity> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<Activity>>;
+    final ref = this.ref as $Ref<AsyncValue<Activity>, Activity>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<Activity>, Activity>,
         AsyncValue<Activity>,

--- a/website/docs/essentials/passing_args/no_arg_provider/codegen.g.dart
+++ b/website/docs/essentials/passing_args/no_arg_provider/codegen.g.dart
@@ -11,8 +11,8 @@ part of 'codegen.dart';
 @ProviderFor(activity)
 const activityProvider = ActivityProvider._();
 
-final class ActivityProvider
-    extends $FunctionalProvider<AsyncValue<Activity>, FutureOr<Activity>>
+final class ActivityProvider extends $FunctionalProvider<AsyncValue<Activity>,
+        Activity, FutureOr<Activity>>
     with $FutureModifier<Activity>, $FutureProvider<Activity> {
   const ActivityProvider._()
       : super(
@@ -79,7 +79,7 @@ abstract class _$ActivityNotifier2 extends $AsyncNotifier<Activity> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<Activity>>;
+    final ref = this.ref as $Ref<AsyncValue<Activity>, Activity>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<Activity>, Activity>,
         AsyncValue<Activity>,

--- a/website/docs/essentials/side_effects/codegen/todo_list_notifier.g.dart
+++ b/website/docs/essentials/side_effects/codegen/todo_list_notifier.g.dart
@@ -60,7 +60,7 @@ abstract class _$TodoList extends $AsyncNotifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<Todo>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<Todo>>, List<Todo>>,
         AsyncValue<List<Todo>>,

--- a/website/docs/essentials/side_effects/codegen/todo_list_notifier_add_todo.g.dart
+++ b/website/docs/essentials/side_effects/codegen/todo_list_notifier_add_todo.g.dart
@@ -46,7 +46,7 @@ abstract class _$TodoList extends $AsyncNotifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<Todo>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<Todo>>, List<Todo>>,
         AsyncValue<List<Todo>>,

--- a/website/docs/essentials/side_effects/codegen/todo_list_provider.g.dart
+++ b/website/docs/essentials/side_effects/codegen/todo_list_provider.g.dart
@@ -11,8 +11,8 @@ part of 'todo_list_provider.dart';
 @ProviderFor(todoList)
 const todoListProvider = TodoListProvider._();
 
-final class TodoListProvider
-    extends $FunctionalProvider<AsyncValue<List<Todo>>, FutureOr<List<Todo>>>
+final class TodoListProvider extends $FunctionalProvider<AsyncValue<List<Todo>>,
+        List<Todo>, FutureOr<List<Todo>>>
     with $FutureModifier<List<Todo>>, $FutureProvider<List<Todo>> {
   const TodoListProvider._()
       : super(

--- a/website/docs/essentials/testing/notifier_mock/codegen.g.dart
+++ b/website/docs/essentials/testing/notifier_mock/codegen.g.dart
@@ -40,7 +40,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/essentials/testing/provider_to_mock/codegen.g.dart
+++ b/website/docs/essentials/testing/provider_to_mock/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const exampleProvider = ExampleProvider._();
 
 final class ExampleProvider
-    extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
   const ExampleProvider._()
       : super(

--- a/website/docs/essentials/websockets_sync/pipe_change_notifier.g.dart
+++ b/website/docs/essentials/websockets_sync/pipe_change_notifier.g.dart
@@ -19,6 +19,7 @@ const myListenableProvider = MyListenableProvider._();
 // {@endtemplate}
 final class MyListenableProvider extends $FunctionalProvider<
     Raw<ValueNotifier<int>>,
+    Raw<ValueNotifier<int>>,
     Raw<ValueNotifier<int>>> with $Provider<Raw<ValueNotifier<int>>> {
   /// A provider which creates a ValueNotifier and update its listeners
   /// whenever the value changes.
@@ -52,7 +53,9 @@ final class MyListenableProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<ValueNotifier<int>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<ValueNotifier<int>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<ValueNotifier<int>>, Raw<ValueNotifier<int>>>(
+              value),
     );
   }
 }

--- a/website/docs/essentials/websockets_sync/raw_usage.g.dart
+++ b/website/docs/essentials/websockets_sync/raw_usage.g.dart
@@ -11,9 +11,8 @@ part of 'raw_usage.dart';
 @ProviderFor(rawStream)
 const rawStreamProvider = RawStreamProvider._();
 
-final class RawStreamProvider
-    extends $FunctionalProvider<Raw<Stream<int>>, Raw<Stream<int>>>
-    with $Provider<Raw<Stream<int>>> {
+final class RawStreamProvider extends $FunctionalProvider<Raw<Stream<int>>,
+    Raw<Stream<int>>, Raw<Stream<int>>> with $Provider<Raw<Stream<int>>> {
   const RawStreamProvider._()
       : super(
           from: null,
@@ -42,7 +41,8 @@ final class RawStreamProvider
   Override overrideWithValue(Raw<Stream<int>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Stream<int>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<Stream<int>>, Raw<Stream<int>>>(value),
     );
   }
 }

--- a/website/docs/essentials/websockets_sync/shared_pipe_change_notifier.g.dart
+++ b/website/docs/essentials/websockets_sync/shared_pipe_change_notifier.g.dart
@@ -13,6 +13,7 @@ const myListenableProvider = MyListenableProvider._();
 
 final class MyListenableProvider extends $FunctionalProvider<
     Raw<ValueNotifier<int>>,
+    Raw<ValueNotifier<int>>,
     Raw<ValueNotifier<int>>> with $Provider<Raw<ValueNotifier<int>>> {
   const MyListenableProvider._()
       : super(
@@ -43,7 +44,9 @@ final class MyListenableProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<ValueNotifier<int>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<ValueNotifier<int>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<ValueNotifier<int>>, Raw<ValueNotifier<int>>>(
+              value),
     );
   }
 }
@@ -54,6 +57,7 @@ String _$myListenableHash() => r'a28ce39430582e0d7be5f8303a31477569153193';
 const anotherListenableProvider = AnotherListenableProvider._();
 
 final class AnotherListenableProvider extends $FunctionalProvider<
+    Raw<ValueNotifier<int>>,
     Raw<ValueNotifier<int>>,
     Raw<ValueNotifier<int>>> with $Provider<Raw<ValueNotifier<int>>> {
   const AnotherListenableProvider._()
@@ -85,7 +89,9 @@ final class AnotherListenableProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<ValueNotifier<int>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<ValueNotifier<int>>>(value),
+      providerOverride:
+          $ValueProvider<Raw<ValueNotifier<int>>, Raw<ValueNotifier<int>>>(
+              value),
     );
   }
 }

--- a/website/docs/essentials/websockets_sync/stream_provider/codegen.g.dart
+++ b/website/docs/essentials/websockets_sync/stream_provider/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const streamExampleProvider = StreamExampleProvider._();
 
 final class StreamExampleProvider
-    extends $FunctionalProvider<AsyncValue<int>, Stream<int>>
+    extends $FunctionalProvider<AsyncValue<int>, int, Stream<int>>
     with $FutureModifier<int>, $StreamProvider<int> {
   const StreamExampleProvider._()
       : super(

--- a/website/docs/essentials/websockets_sync/sync_definition/codegen.g.dart
+++ b/website/docs/essentials/websockets_sync/sync_definition/codegen.g.dart
@@ -11,8 +11,8 @@ part of 'codegen.dart';
 @ProviderFor(synchronousExample)
 const synchronousExampleProvider = SynchronousExampleProvider._();
 
-final class SynchronousExampleProvider extends $FunctionalProvider<int, int>
-    with $Provider<int> {
+final class SynchronousExampleProvider
+    extends $FunctionalProvider<int, int, int> with $Provider<int> {
   const SynchronousExampleProvider._()
       : super(
           from: null,
@@ -41,7 +41,7 @@ final class SynchronousExampleProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/website/docs/from_provider/family/family.g.dart
+++ b/website/docs/from_provider/family/family.g.dart
@@ -11,7 +11,7 @@ part of 'family.dart';
 @ProviderFor(random)
 const randomProvider = RandomFamily._();
 
-final class RandomProvider extends $FunctionalProvider<int, int>
+final class RandomProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const RandomProvider._(
       {required RandomFamily super.from,
@@ -60,7 +60,7 @@ final class RandomProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 

--- a/website/docs/from_provider/motivation/async_values/async_values.g.dart
+++ b/website/docs/from_provider/motivation/async_values/async_values.g.dart
@@ -11,8 +11,8 @@ part of 'async_values.dart';
 @ProviderFor(itemsApi)
 const itemsApiProvider = ItemsApiProvider._();
 
-final class ItemsApiProvider
-    extends $FunctionalProvider<AsyncValue<List<Item>>, FutureOr<List<Item>>>
+final class ItemsApiProvider extends $FunctionalProvider<AsyncValue<List<Item>>,
+        List<Item>, FutureOr<List<Item>>>
     with $FutureModifier<List<Item>>, $FutureProvider<List<Item>> {
   const ItemsApiProvider._()
       : super(
@@ -45,7 +45,7 @@ String _$itemsApiHash() => r'fa5a8f7e93ac048d9bd5dfc1744749995cf154af';
 const evenItemsProvider = EvenItemsProvider._();
 
 final class EvenItemsProvider
-    extends $FunctionalProvider<List<Item>, List<Item>>
+    extends $FunctionalProvider<List<Item>, List<Item>, List<Item>>
     with $Provider<List<Item>> {
   const EvenItemsProvider._()
       : super(
@@ -75,7 +75,7 @@ final class EvenItemsProvider
   Override overrideWithValue(List<Item> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Item>>(value),
+      providerOverride: $ValueProvider<List<Item>, List<Item>>(value),
     );
   }
 }

--- a/website/docs/from_provider/motivation/auto_dispose/auto_dispose.g.dart
+++ b/website/docs/from_provider/motivation/auto_dispose/auto_dispose.g.dart
@@ -11,7 +11,7 @@ part of 'auto_dispose.dart';
 @ProviderFor(diceRoll)
 const diceRollProvider = DiceRollProvider._();
 
-final class DiceRollProvider extends $FunctionalProvider<int, int>
+final class DiceRollProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const DiceRollProvider._()
       : super(
@@ -41,7 +41,7 @@ final class DiceRollProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -51,7 +51,7 @@ String _$diceRollHash() => r'58d43e5143bb64e855939d55a3be3ee81d66c518';
 @ProviderFor(cachedDiceRoll)
 const cachedDiceRollProvider = CachedDiceRollProvider._();
 
-final class CachedDiceRollProvider extends $FunctionalProvider<int, int>
+final class CachedDiceRollProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const CachedDiceRollProvider._()
       : super(
@@ -81,7 +81,7 @@ final class CachedDiceRollProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/website/docs/from_provider/motivation/combine/combine.g.dart
+++ b/website/docs/from_provider/motivation/combine/combine.g.dart
@@ -11,7 +11,7 @@ part of 'combine.dart';
 @ProviderFor(number)
 const numberProvider = NumberProvider._();
 
-final class NumberProvider extends $FunctionalProvider<int, int>
+final class NumberProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const NumberProvider._()
       : super(
@@ -41,7 +41,7 @@ final class NumberProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -51,7 +51,7 @@ String _$numberHash() => r'03ac91d5904c18f04321b140fd263ed6bc85d3c1';
 @ProviderFor(doubled)
 const doubledProvider = DoubledProvider._();
 
-final class DoubledProvider extends $FunctionalProvider<int, int>
+final class DoubledProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   const DoubledProvider._()
       : super(
@@ -81,7 +81,7 @@ final class DoubledProvider extends $FunctionalProvider<int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }

--- a/website/docs/from_provider/motivation/same_type/same_type.g.dart
+++ b/website/docs/from_provider/motivation/same_type/same_type.g.dart
@@ -11,7 +11,8 @@ part of 'same_type.dart';
 @ProviderFor(items)
 const itemsProvider = ItemsProvider._();
 
-final class ItemsProvider extends $FunctionalProvider<List<Item>, List<Item>>
+final class ItemsProvider
+    extends $FunctionalProvider<List<Item>, List<Item>, List<Item>>
     with $Provider<List<Item>> {
   const ItemsProvider._()
       : super(
@@ -41,7 +42,7 @@ final class ItemsProvider extends $FunctionalProvider<List<Item>, List<Item>>
   Override overrideWithValue(List<Item> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Item>>(value),
+      providerOverride: $ValueProvider<List<Item>, List<Item>>(value),
     );
   }
 }
@@ -52,7 +53,7 @@ String _$itemsHash() => r'8dafed1afc3fc52651c24445640d8b57ff080f66';
 const evenItemsProvider = EvenItemsProvider._();
 
 final class EvenItemsProvider
-    extends $FunctionalProvider<List<Item>, List<Item>>
+    extends $FunctionalProvider<List<Item>, List<Item>, List<Item>>
     with $Provider<List<Item>> {
   const EvenItemsProvider._()
       : super(
@@ -82,7 +83,7 @@ final class EvenItemsProvider
   Override overrideWithValue(List<Item> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Item>>(value),
+      providerOverride: $ValueProvider<List<Item>, List<Item>>(value),
     );
   }
 }

--- a/website/docs/introduction/getting_started/dart_hello_world/main.g.dart
+++ b/website/docs/introduction/getting_started/dart_hello_world/main.g.dart
@@ -11,8 +11,8 @@ part of 'main.dart';
 @ProviderFor(helloWorld)
 const helloWorldProvider = HelloWorldProvider._();
 
-final class HelloWorldProvider extends $FunctionalProvider<String, String>
-    with $Provider<String> {
+final class HelloWorldProvider
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const HelloWorldProvider._()
       : super(
           from: null,
@@ -41,7 +41,7 @@ final class HelloWorldProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }

--- a/website/docs/introduction/getting_started/hello_world/hooks_codegen/main.g.dart
+++ b/website/docs/introduction/getting_started/hello_world/hooks_codegen/main.g.dart
@@ -11,8 +11,8 @@ part of 'main.dart';
 @ProviderFor(helloWorld)
 const helloWorldProvider = HelloWorldProvider._();
 
-final class HelloWorldProvider extends $FunctionalProvider<String, String>
-    with $Provider<String> {
+final class HelloWorldProvider
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const HelloWorldProvider._()
       : super(
           from: null,
@@ -41,7 +41,7 @@ final class HelloWorldProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }

--- a/website/docs/introduction/getting_started/hello_world/main.g.dart
+++ b/website/docs/introduction/getting_started/hello_world/main.g.dart
@@ -11,8 +11,8 @@ part of 'main.dart';
 @ProviderFor(helloWorld)
 const helloWorldProvider = HelloWorldProvider._();
 
-final class HelloWorldProvider extends $FunctionalProvider<String, String>
-    with $Provider<String> {
+final class HelloWorldProvider
+    extends $FunctionalProvider<String, String, String> with $Provider<String> {
   const HelloWorldProvider._()
       : super(
           from: null,
@@ -41,7 +41,7 @@ final class HelloWorldProvider extends $FunctionalProvider<String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String>(value),
+      providerOverride: $ValueProvider<String, String>(value),
     );
   }
 }

--- a/website/docs/introduction/why_riverpod/codegen.g.dart
+++ b/website/docs/introduction/why_riverpod/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const fetchPackagesProvider = FetchPackagesFamily._();
 
 final class FetchPackagesProvider extends $FunctionalProvider<
-        AsyncValue<List<Package>>, FutureOr<List<Package>>>
+        AsyncValue<List<Package>>, List<Package>, FutureOr<List<Package>>>
     with $FutureModifier<List<Package>>, $FutureProvider<List<Package>> {
   const FetchPackagesProvider._(
       {required FetchPackagesFamily super.from,

--- a/website/docs/migration/from_change_notifier/declaration/declaration.g.dart
+++ b/website/docs/migration/from_change_notifier/declaration/declaration.g.dart
@@ -46,7 +46,7 @@ abstract class _$MyNotifier extends $AsyncNotifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<Todo>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<Todo>>, List<Todo>>,
         AsyncValue<List<Todo>>,

--- a/website/docs/migration/from_change_notifier/initialization/initialization.g.dart
+++ b/website/docs/migration/from_change_notifier/initialization/initialization.g.dart
@@ -46,7 +46,7 @@ abstract class _$MyNotifier extends $AsyncNotifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<Todo>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<Todo>>, List<Todo>>,
         AsyncValue<List<Todo>>,

--- a/website/docs/migration/from_change_notifier/migrated/migrated.g.dart
+++ b/website/docs/migration/from_change_notifier/migrated/migrated.g.dart
@@ -46,7 +46,7 @@ abstract class _$MyNotifier extends $AsyncNotifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<Todo>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<Todo>>, List<Todo>>,
         AsyncValue<List<Todo>>,

--- a/website/docs/migration/from_state_notifier/add_listener/add_listener.g.dart
+++ b/website/docs/migration/from_state_notifier/add_listener/add_listener.g.dart
@@ -40,7 +40,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/migration/from_state_notifier/async_notifier/async_notifier.g.dart
+++ b/website/docs/migration/from_state_notifier/async_notifier/async_notifier.g.dart
@@ -47,7 +47,7 @@ abstract class _$AsyncTodosNotifier extends $AsyncNotifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<Todo>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<Todo>>, List<Todo>>,
         AsyncValue<List<Todo>>,

--- a/website/docs/migration/from_state_notifier/build_init/build_init.g.dart
+++ b/website/docs/migration/from_state_notifier/build_init/build_init.g.dart
@@ -41,7 +41,7 @@ final class CounterNotifierProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -54,7 +54,7 @@ abstract class _$CounterNotifier extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
+++ b/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
@@ -11,9 +11,8 @@ part of 'family_and_dispose.dart';
 @ProviderFor(taskTracker)
 const taskTrackerProvider = TaskTrackerProvider._();
 
-final class TaskTrackerProvider
-    extends $FunctionalProvider<TaskTrackerRepo, TaskTrackerRepo>
-    with $Provider<TaskTrackerRepo> {
+final class TaskTrackerProvider extends $FunctionalProvider<TaskTrackerRepo,
+    TaskTrackerRepo, TaskTrackerRepo> with $Provider<TaskTrackerRepo> {
   const TaskTrackerProvider._()
       : super(
           from: null,
@@ -42,7 +41,7 @@ final class TaskTrackerProvider
   Override overrideWithValue(TaskTrackerRepo value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<TaskTrackerRepo>(value),
+      providerOverride: $ValueProvider<TaskTrackerRepo, TaskTrackerRepo>(value),
     );
   }
 }
@@ -135,7 +134,7 @@ abstract class _$BugsEncounteredNotifier extends $AsyncNotifier<int> {
     final created = build(
       _$args,
     );
-    final ref = this.ref as $Ref<AsyncValue<int>>;
+    final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<int>, int>, AsyncValue<int>, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/migration/from_state_notifier/from_state_provider/from_state_provider.g.dart
+++ b/website/docs/migration/from_state_notifier/from_state_provider/from_state_provider.g.dart
@@ -41,7 +41,7 @@ final class CounterNotifierProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -54,7 +54,7 @@ abstract class _$CounterNotifier extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/migration/from_state_notifier/old_lifecycles/old_lifecycles.g.dart
+++ b/website/docs/migration/from_state_notifier/old_lifecycles/old_lifecycles.g.dart
@@ -40,7 +40,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/migration/from_state_notifier/old_lifecycles_final/old_lifecycles_final.g.dart
+++ b/website/docs/migration/from_state_notifier/old_lifecycles_final/old_lifecycles_final.g.dart
@@ -11,7 +11,8 @@ part of 'old_lifecycles_final.dart';
 @ProviderFor(duration)
 const durationProvider = DurationProvider._();
 
-final class DurationProvider extends $FunctionalProvider<Duration, Duration>
+final class DurationProvider
+    extends $FunctionalProvider<Duration, Duration, Duration>
     with $Provider<Duration> {
   const DurationProvider._()
       : super(
@@ -41,7 +42,7 @@ final class DurationProvider extends $FunctionalProvider<Duration, Duration>
   Override overrideWithValue(Duration value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Duration>(value),
+      providerOverride: $ValueProvider<Duration, Duration>(value),
     );
   }
 }
@@ -51,7 +52,8 @@ String _$durationHash() => r'997cacfb78da8107053428dfc5515497354b50c6';
 @ProviderFor(repository)
 const repositoryProvider = RepositoryProvider._();
 
-final class RepositoryProvider extends $FunctionalProvider<_MyRepo, _MyRepo>
+final class RepositoryProvider
+    extends $FunctionalProvider<_MyRepo, _MyRepo, _MyRepo>
     with $Provider<_MyRepo> {
   const RepositoryProvider._()
       : super(
@@ -81,7 +83,7 @@ final class RepositoryProvider extends $FunctionalProvider<_MyRepo, _MyRepo>
   Override overrideWithValue(_MyRepo value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<_MyRepo>(value),
+      providerOverride: $ValueProvider<_MyRepo, _MyRepo>(value),
     );
   }
 }
@@ -120,7 +122,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -133,7 +135,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/providers/future_provider/config_provider/codegen.g.dart
+++ b/website/docs/providers/future_provider/config_provider/codegen.g.dart
@@ -12,7 +12,7 @@ part of 'codegen.dart';
 const fetchConfigurationProvider = FetchConfigurationProvider._();
 
 final class FetchConfigurationProvider extends $FunctionalProvider<
-        AsyncValue<Configuration>, FutureOr<Configuration>>
+        AsyncValue<Configuration>, Configuration, FutureOr<Configuration>>
     with $FutureModifier<Configuration>, $FutureProvider<Configuration> {
   const FetchConfigurationProvider._()
       : super(

--- a/website/docs/providers/notifier_provider/remote_todos/codegen.g.dart
+++ b/website/docs/providers/notifier_provider/remote_todos/codegen.g.dart
@@ -62,7 +62,7 @@ abstract class _$AsyncTodos extends $AsyncNotifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<AsyncValue<List<Todo>>>;
+    final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<Todo>>, List<Todo>>,
         AsyncValue<List<Todo>>,

--- a/website/docs/providers/notifier_provider/todos/codegen.g.dart
+++ b/website/docs/providers/notifier_provider/todos/codegen.g.dart
@@ -40,7 +40,7 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Todos extends $Notifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<List<Todo>>;
+    final ref = this.ref as $Ref<List<Todo>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<List<Todo>, List<Todo>>, List<Todo>, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/providers/provider/completed_todos/completed_todos.g.dart
+++ b/website/docs/providers/provider/completed_todos/completed_todos.g.dart
@@ -12,7 +12,7 @@ part of 'completed_todos.dart';
 const completedTodosProvider = CompletedTodosProvider._();
 
 final class CompletedTodosProvider
-    extends $FunctionalProvider<List<Todo>, List<Todo>>
+    extends $FunctionalProvider<List<Todo>, List<Todo>, List<Todo>>
     with $Provider<List<Todo>> {
   const CompletedTodosProvider._()
       : super(
@@ -42,7 +42,7 @@ final class CompletedTodosProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }

--- a/website/docs/providers/provider/optimized_previous_button/optimized_previous_button.g.dart
+++ b/website/docs/providers/provider/optimized_previous_button/optimized_previous_button.g.dart
@@ -40,7 +40,7 @@ final class PageIndexProvider extends $NotifierProvider<PageIndex, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$PageIndex extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);
@@ -63,8 +63,8 @@ abstract class _$PageIndex extends $Notifier<int> {
 @ProviderFor(canGoToPreviousPage)
 const canGoToPreviousPageProvider = CanGoToPreviousPageProvider._();
 
-final class CanGoToPreviousPageProvider extends $FunctionalProvider<bool, bool>
-    with $Provider<bool> {
+final class CanGoToPreviousPageProvider
+    extends $FunctionalProvider<bool, bool, bool> with $Provider<bool> {
   const CanGoToPreviousPageProvider._()
       : super(
           from: null,
@@ -93,7 +93,7 @@ final class CanGoToPreviousPageProvider extends $FunctionalProvider<bool, bool>
   Override overrideWithValue(bool value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<bool>(value),
+      providerOverride: $ValueProvider<bool, bool>(value),
     );
   }
 }

--- a/website/docs/providers/provider/todo/todo.g.dart
+++ b/website/docs/providers/provider/todo/todo.g.dart
@@ -40,7 +40,7 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Todos extends $Notifier<List<Todo>> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<List<Todo>>;
+    final ref = this.ref as $Ref<List<Todo>, List<Todo>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<List<Todo>, List<Todo>>, List<Todo>, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/providers/provider/unoptimized_previous_button/unoptimized_previous_button.g.dart
+++ b/website/docs/providers/provider/unoptimized_previous_button/unoptimized_previous_button.g.dart
@@ -40,7 +40,7 @@ final class PageIndexProvider extends $NotifierProvider<PageIndex, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$PageIndex extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);

--- a/website/docs/providers/stream_provider/live_stream_chat_provider/codegen.g.dart
+++ b/website/docs/providers/stream_provider/live_stream_chat_provider/codegen.g.dart
@@ -11,8 +11,8 @@ part of 'codegen.dart';
 @ProviderFor(chat)
 const chatProvider = ChatProvider._();
 
-final class ChatProvider
-    extends $FunctionalProvider<AsyncValue<List<String>>, Stream<List<String>>>
+final class ChatProvider extends $FunctionalProvider<AsyncValue<List<String>>,
+        List<String>, Stream<List<String>>>
     with $FutureModifier<List<String>>, $StreamProvider<List<String>> {
   const ChatProvider._()
       : super(

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
@@ -11,7 +11,7 @@ import 'package:flutter_riverpod/legacy.dart';
 class Logger extends ProviderObserver {
   @override
   void didUpdateProvider(
-    ProviderBase<Object?> provider,
+    ProviderBase<Object?, Object?> provider,
     Object? previousValue,
     Object? newValue,
     ProviderContainer container,

--- a/website/i18n/de/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
+++ b/website/i18n/de/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-extension on ProviderBase<Object?> {
+extension on ProviderBase<Object?, Object?> {
   // ignore: unused_element
   Override overrideWithValue(Object? value) => throw UnimplementedError();
 }

--- a/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
+++ b/website/i18n/fr/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
@@ -11,7 +11,7 @@ import 'package:flutter_riverpod/legacy.dart';
 class Logger extends ProviderObserver {
   @override
   void didUpdateProvider(
-    ProviderBase<Object?> provider,
+    ProviderBase<Object?, Object?> provider,
     Object? previousValue,
     Object? newValue,
     ProviderContainer container,

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
@@ -11,7 +11,7 @@ import 'package:flutter_riverpod/legacy.dart';
 class Logger extends ProviderObserver {
   @override
   void didUpdateProvider(
-    ProviderBase<Object?> provider,
+    ProviderBase<Object?, Object?> provider,
     Object? previousValue,
     Object? newValue,
     ProviderContainer container,

--- a/website/i18n/it/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
+++ b/website/i18n/it/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-extension on ProviderBase<Object?> {
+extension on ProviderBase<Object?, Object?> {
   // ignore: unused_element
   Override overrideWithValue(Object? value) => throw UnimplementedError();
 }

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
@@ -11,7 +11,7 @@ import 'package:flutter_riverpod/legacy.dart';
 class Logger extends ProviderObserver {
   @override
   void didUpdateProvider(
-    ProviderBase<Object?> provider,
+    ProviderBase<Object?, Object?> provider,
     Object? previousValue,
     Object? newValue,
     ProviderContainer container,

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-extension on ProviderBase<Object?> {
+extension on ProviderBase<Object?, Object?> {
   // ignore: unused_element
   Override overrideWithValue(Object? value) => throw UnimplementedError();
 }

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
@@ -11,7 +11,7 @@ import 'package:flutter_riverpod/legacy.dart';
 class Logger extends ProviderObserver {
   @override
   void didUpdateProvider(
-    ProviderBase<Object?> provider,
+    ProviderBase<Object?, Object?> provider,
     Object? previousValue,
     Object? newValue,
     ProviderContainer container,

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-extension on ProviderBase<Object?> {
+extension on ProviderBase<Object?, Object?> {
   // ignore: unused_element
   Override overrideWithValue(Object? value) => throw UnimplementedError();
 }

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/concepts/provider_observer_logger.dart
@@ -11,7 +11,7 @@ import 'package:flutter_riverpod/legacy.dart';
 class Logger extends ProviderObserver {
   @override
   void didUpdateProvider(
-    ProviderBase<Object?> provider,
+    ProviderBase<Object?, Object?> provider,
     Object? previousValue,
     Object? newValue,
     ProviderContainer container,

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/cookbooks/testing_override_info.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-extension on ProviderBase<Object?> {
+extension on ProviderBase<Object?, Object?> {
   // ignore: unused_element
   Override overrideWithValue(Object? value) => throw UnimplementedError();
 }

--- a/website/static/snippets/async.g.dart
+++ b/website/static/snippets/async.g.dart
@@ -12,7 +12,7 @@ part of 'async.dart';
 const configurationsProvider = ConfigurationsProvider._();
 
 final class ConfigurationsProvider extends $FunctionalProvider<
-        AsyncValue<Configuration>, FutureOr<Configuration>>
+        AsyncValue<Configuration>, Configuration, FutureOr<Configuration>>
     with $FutureModifier<Configuration>, $FutureProvider<Configuration> {
   const ConfigurationsProvider._()
       : super(

--- a/website/static/snippets/combine.g.dart
+++ b/website/static/snippets/combine.g.dart
@@ -11,7 +11,8 @@ part of 'combine.dart';
 @ProviderFor(todos)
 const todosProvider = TodosProvider._();
 
-final class TodosProvider extends $FunctionalProvider<List<Todo>, List<Todo>>
+final class TodosProvider
+    extends $FunctionalProvider<List<Todo>, List<Todo>, List<Todo>>
     with $Provider<List<Todo>> {
   const TodosProvider._()
       : super(
@@ -41,7 +42,7 @@ final class TodosProvider extends $FunctionalProvider<List<Todo>, List<Todo>>
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }
@@ -51,7 +52,7 @@ String _$todosHash() => r'ed255140669430745a7779b542a1209dc182ce0c';
 @ProviderFor(filter)
 const filterProvider = FilterProvider._();
 
-final class FilterProvider extends $FunctionalProvider<Filter, Filter>
+final class FilterProvider extends $FunctionalProvider<Filter, Filter, Filter>
     with $Provider<Filter> {
   const FilterProvider._()
       : super(
@@ -81,7 +82,7 @@ final class FilterProvider extends $FunctionalProvider<Filter, Filter>
   Override overrideWithValue(Filter value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Filter>(value),
+      providerOverride: $ValueProvider<Filter, Filter>(value),
     );
   }
 }
@@ -92,7 +93,7 @@ String _$filterHash() => r'38c5f61dc2d4b44e9be37bb724487d265cc0a645';
 const filteredTodosProvider = FilteredTodosProvider._();
 
 final class FilteredTodosProvider
-    extends $FunctionalProvider<List<Todo>, List<Todo>>
+    extends $FunctionalProvider<List<Todo>, List<Todo>, List<Todo>>
     with $Provider<List<Todo>> {
   const FilteredTodosProvider._()
       : super(
@@ -122,7 +123,7 @@ final class FilteredTodosProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>>(value),
+      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
     );
   }
 }

--- a/website/static/snippets/create.g.dart
+++ b/website/static/snippets/create.g.dart
@@ -12,7 +12,7 @@ part of 'create.dart';
 const boredSuggestionProvider = BoredSuggestionProvider._();
 
 final class BoredSuggestionProvider
-    extends $FunctionalProvider<AsyncValue<String>, FutureOr<String>>
+    extends $FunctionalProvider<AsyncValue<String>, String, FutureOr<String>>
     with $FutureModifier<String>, $FutureProvider<String> {
   const BoredSuggestionProvider._()
       : super(

--- a/website/static/snippets/declare.g.dart
+++ b/website/static/snippets/declare.g.dart
@@ -40,7 +40,7 @@ final class CountProvider extends $NotifierProvider<Count, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int>(value),
+      providerOverride: $ValueProvider<int, int>(value),
     );
   }
 }
@@ -53,7 +53,7 @@ abstract class _$Count extends $Notifier<int> {
   @override
   void runBuild() {
     final created = build();
-    final ref = this.ref as $Ref<int>;
+    final ref = this.ref as $Ref<int, int>;
     final element = ref.element
         as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
     element.handleValue(ref, created);


### PR DESCRIPTION
- Add a generic to ProviderBase
- Add .notifier/.future to ProviderBase directly
- Make the internal state be an AsyncValue
- expose AnyNotiifer.value where it is an AsyncValue, even inside synchronous notifiers