### PR TITLE
Use AsyncValue as internal state for everything

### DIFF
--- a/examples/counter/lib/main.g.dart
+++ b/examples/counter/lib/main.g.dart
@@ -50,7 +50,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/examples/pub/lib/detail.g.dart
+++ b/examples/pub/lib/detail.g.dart
@@ -151,7 +151,7 @@ final class PubRepositoryProvider
   Override overrideWithValue(PubRepository value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<PubRepository, PubRepository>(value),
+      providerOverride: $SyncValueProvider<PubRepository>(value),
     );
   }
 }

--- a/examples/stackoverflow/lib/common.g.dart
+++ b/examples/stackoverflow/lib/common.g.dart
@@ -54,7 +54,7 @@ final class ThemeProvider
   Override overrideWithValue(ThemeData value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<ThemeData, ThemeData>(value),
+      providerOverride: $SyncValueProvider<ThemeData>(value),
     );
   }
 }

--- a/examples/stackoverflow/lib/question.g.dart
+++ b/examples/stackoverflow/lib/question.g.dart
@@ -93,7 +93,7 @@ final class QuestionThemeProvider
   Override overrideWithValue(QuestionTheme value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<QuestionTheme, QuestionTheme>(value),
+      providerOverride: $SyncValueProvider<QuestionTheme>(value),
     );
   }
 }
@@ -172,8 +172,7 @@ final class CurrentQuestionProvider extends $FunctionalProvider<
   Override overrideWithValue(AsyncValue<Question> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<AsyncValue<Question>, AsyncValue<Question>>(value),
+      providerOverride: $SyncValueProvider<AsyncValue<Question>>(value),
     );
   }
 }

--- a/examples/stackoverflow/lib/tag.g.dart
+++ b/examples/stackoverflow/lib/tag.g.dart
@@ -46,7 +46,7 @@ final class TagThemeProvider
   Override overrideWithValue(TagTheme value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<TagTheme, TagTheme>(value),
+      providerOverride: $SyncValueProvider<TagTheme>(value),
     );
   }
 }

--- a/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
+++ b/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
@@ -146,7 +146,8 @@ final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
 
 /// The element of [ChangeNotifierProvider].
 class _ChangeNotifierProviderElement<NotifierT extends ChangeNotifier?>
-    extends $FunctionalProviderElement<NotifierT, NotifierT, NotifierT> {
+    extends $FunctionalProviderElement<NotifierT, NotifierT, NotifierT>
+    with SyncProviderElement<NotifierT> {
   _ChangeNotifierProviderElement._(super.pointer);
 
   final _notifierNotifier = $ElementLense<NotifierT>();
@@ -161,7 +162,7 @@ class _ChangeNotifierProviderElement<NotifierT extends ChangeNotifier?>
 
     final notifier = notifierResult.requireState;
 
-    setStateResult($ResultData(notifier));
+    value = AsyncData(notifier);
 
     if (notifier != null) {
       void listener() => ref.notifyListeners();

--- a/packages/riverpod/lib/src/core/modifiers/future.dart
+++ b/packages/riverpod/lib/src/core/modifiers/future.dart
@@ -186,10 +186,12 @@ mixin FutureModifierElement<ValueT>
   }
 
   @override
-  void mount() {
-    _stateResult = $ResultData(AsyncLoading<ValueT>());
-    super.mount();
+  $Result<AsyncValue<ValueT>> resultForValue(AsyncValue<ValueT> value) {
+    return $ResultData(value);
   }
+
+  @override
+  void setValueFromState(AsyncValue<ValueT> state) => value = state;
 
   /// Internal utility for transitioning an [AsyncValue] after a provider refresh.
   ///
@@ -200,25 +202,16 @@ mixin FutureModifierElement<ValueT>
     AsyncValue<ValueT> newState, {
     required bool seamless,
   }) {
-    final previous = stateResult?.requireState;
+    final previous = value;
 
-    if (previous == null) {
-      super.setStateResult($ResultData(newState));
-    } else {
-      super.setStateResult(
-        $ResultData(
-          newState
-              .cast<ValueT>()
-              .copyWithPrevious(previous, isRefresh: seamless),
-        ),
-      );
-    }
+    super.value =
+        newState.cast<ValueT>().copyWithPrevious(previous, isRefresh: seamless);
   }
 
   @override
   @protected
-  void setStateResult($Result<AsyncValue<ValueT>> newState) {
-    newState.requireState.map(
+  set value(AsyncValue<ValueT> newState) {
+    newState.map(
       loading: onLoading,
       error: onError,
       data: onData,

--- a/packages/riverpod/lib/src/core/override.dart
+++ b/packages/riverpod/lib/src/core/override.dart
@@ -70,7 +70,7 @@ class $ProviderOverride implements _ProviderOverride {
   @override
   String toString() {
     switch (providerOverride) {
-      case $ValueProvider(:final _value):
+      case _ValueProvider(:final _value):
         return '$origin.overrideWithValue($_value)';
       default:
         return '$origin.overrideWith(...)';

--- a/packages/riverpod/lib/src/core/override_with_value.dart
+++ b/packages/riverpod/lib/src/core/override_with_value.dart
@@ -1,14 +1,11 @@
 part of '../framework.dart';
 
-/// A provider that is driven by a value instead of a function.
-///
-/// This is an implementation detail of `overrideWithValue`.
-@publicInCodegen
-final class $ValueProvider<StateT, ValueT>
+@reopen
+abstract base class _ValueProvider<StateT, ValueT>
     extends $ProviderBaseImpl<StateT, ValueT>
     with LegacyProviderMixin<StateT, ValueT> {
-  /// Creates a [$ValueProvider].
-  const $ValueProvider(this._value)
+  /// Creates a [_ValueProvider].
+  const _ValueProvider(this._value)
       : super(
           name: null,
           from: null,
@@ -33,15 +30,39 @@ final class $ValueProvider<StateT, ValueT>
   // ignore: library_private_types_in_public_api, not public API
   _ValueProviderElement<StateT, ValueT> $createElement(
     $ProviderPointer pointer,
+  );
+}
+
+/// A provider that is driven by a value instead of a function.
+///
+/// This is an implementation detail of `overrideWithValue`.
+@publicInCodegen
+@internal
+final class $SyncValueProvider<ValueT> extends _ValueProvider<ValueT, ValueT> {
+  /// Creates a [$SyncValueProvider].
+  const $SyncValueProvider(super._value);
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => null;
+
+  @override
+  Set<ProviderOrFamily>? get $allTransitiveDependencies => null;
+
+  /// @nodoc
+  @internal
+  @override
+  // ignore: library_private_types_in_public_api, not public API
+  _SyncValueProviderElement<ValueT> $createElement(
+    $ProviderPointer pointer,
   ) {
-    return _ValueProviderElement(this, pointer);
+    return _SyncValueProviderElement(this, pointer);
   }
 }
 
-/// The [ProviderElement] of a [$ValueProvider]
-class _ValueProviderElement<StateT, ValueT>
+/// The [ProviderElement] of a [_ValueProvider]
+abstract class _ValueProviderElement<StateT, ValueT>
     extends ProviderElement<StateT, ValueT> {
-  /// The [ProviderElement] of a [$ValueProvider]
+  /// The [ProviderElement] of a [_ValueProvider]
   _ValueProviderElement(this.provider, super.pointer);
 
   /// A custom listener called when `overrideWithValue` changes
@@ -49,16 +70,16 @@ class _ValueProviderElement<StateT, ValueT>
   void Function(StateT value)? onChange;
 
   @override
-  $ValueProvider<StateT, ValueT> provider;
+  _ValueProvider<StateT, ValueT> provider;
 
   @override
-  void update(covariant $ValueProvider<StateT, ValueT> newProvider) {
+  void update(covariant _ValueProvider<StateT, ValueT> newProvider) {
     super.update(newProvider);
     provider = newProvider;
     final newValue = provider._value;
 
     // `getState` will never be in error/loading state since there is no "create"
-    final previousState = stateResult! as $ResultData<StateT>;
+    final previousState = stateResult()! as $ResultData<StateT>;
 
     if (newValue != previousState.value) {
       // Asserts would otherwise prevent a provider rebuild from updating
@@ -75,7 +96,7 @@ class _ValueProviderElement<StateT, ValueT>
     }
   }
 
-  void _setValue(StateT value) => setStateResult($ResultData(value));
+  void _setValue(StateT value);
 
   @override
   WhenComplete create(Ref ref) {
@@ -85,9 +106,24 @@ class _ValueProviderElement<StateT, ValueT>
   }
 }
 
+class _SyncValueProviderElement<ValueT>
+    extends _ValueProviderElement<ValueT, ValueT>
+    with SyncProviderElement<ValueT> {
+  _SyncValueProviderElement(super.provider, super.pointer);
+
+  @override
+  void _setValue(ValueT value) {
+    this.value = AsyncData(value);
+  }
+}
+
+/// A provider that is driven by a value instead of a function.
+///
+/// This is an implementation detail of `overrideWithValue`.
 @internal
 final class $AsyncValueProvider<ValueT>
-    extends $ValueProvider<AsyncValue<ValueT>, ValueT> {
+    extends _ValueProvider<AsyncValue<ValueT>, ValueT> {
+  /// Creates a [$AsyncValueProvider].
   const $AsyncValueProvider(super._value);
 
   /// @nodoc

--- a/packages/riverpod/lib/src/core/provider/provider.dart
+++ b/packages/riverpod/lib/src/core/provider/provider.dart
@@ -123,7 +123,7 @@ abstract final class $ProviderBaseImpl<StateT, ValueT>
     if (fireImmediately) {
       _handleFireImmediately(
         source.container,
-        element.stateResult!,
+        element.stateResult()!,
         listener: listener,
         onError: onError,
       );

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -300,15 +300,12 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   void notifyListeners() {
     _throwIfInvalidUsage();
 
-    final currentResult = _element.stateResult;
-    // If `notifyListeners` is used during `build`, the result will be null.
-    // Throwing would be unnecessarily inconvenient, so we simply skip it.
-    if (currentResult == null) return;
+    final currentValue = _element.value;
 
     if (_element._didBuild) {
       _element._notifyListeners(
-        currentResult,
-        currentResult,
+        currentValue,
+        currentValue,
         checkUpdateShouldNotify: false,
       );
     }
@@ -716,7 +713,7 @@ class $Ref<StateT, ValueT> extends Ref {
   set state(StateT newState) {
     _throwIfInvalidUsage();
 
-    _element.setStateResult($ResultData(newState));
+    _element.setValueFromState(newState);
   }
 
   /// Listens to changes on the value exposed by this provider.

--- a/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
@@ -148,8 +148,9 @@ final class StateNotifierProvider< //
 }
 
 /// The element of [StateNotifierProvider].
-class _StateNotifierProviderElement<NotifierT extends StateNotifier<StateT>,
-    StateT> extends $FunctionalProviderElement<StateT, StateT, NotifierT> {
+class _StateNotifierProviderElement<NotifierT extends StateNotifier<ValueT>,
+        ValueT> extends $FunctionalProviderElement<ValueT, ValueT, NotifierT>
+    with SyncProviderElement<ValueT> {
   _StateNotifierProviderElement._(super.pointer);
 
   final _notifierNotifier = $ElementLense<NotifierT>();
@@ -163,7 +164,7 @@ class _StateNotifierProviderElement<NotifierT extends StateNotifier<StateT>,
     );
 
     _removeListener = notifier.requireState.addListener(
-      (newState) => setStateResult($ResultData(newState)),
+      (newState) => value = AsyncData(newState),
       fireImmediately: true,
     );
 
@@ -171,7 +172,7 @@ class _StateNotifierProviderElement<NotifierT extends StateNotifier<StateT>,
   }
 
   @override
-  bool updateShouldNotify(StateT previous, StateT next) {
+  bool updateShouldNotify(ValueT previous, ValueT next) {
     return _notifierNotifier.result!.requireState
         // ignore: invalid_use_of_protected_member
         .updateShouldNotify(previous, next);

--- a/packages/riverpod/lib/src/providers/legacy/state_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_provider.dart
@@ -102,7 +102,8 @@ final class StateProvider<ValueT>
 
 /// The element of [StateProvider].
 class _StateProviderElement<ValueT>
-    extends $FunctionalProviderElement<ValueT, ValueT, ValueT> {
+    extends $FunctionalProviderElement<ValueT, ValueT, ValueT>
+    with SyncProviderElement<ValueT> {
   _StateProviderElement._(super.pointer);
 
   final _controllerNotifier = $ElementLense<StateController<ValueT>>();
@@ -122,7 +123,7 @@ class _StateProviderElement<ValueT>
       fireImmediately: true,
       (state) {
         _stateNotifier.result = _controllerNotifier.result;
-        setStateResult($ResultData(state));
+        value = AsyncData(state);
       },
     );
 

--- a/packages/riverpod/lib/src/providers/notifier.dart
+++ b/packages/riverpod/lib/src/providers/notifier.dart
@@ -2,7 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../builder.dart';
 import '../common/internal_lints.dart';
-import '../common/result.dart';
+import '../core/async_value.dart';
 import '../framework.dart';
 import 'async_notifier.dart';
 import 'provider.dart';
@@ -35,7 +35,7 @@ abstract class $Notifier<StateT> extends $SyncNotifierBase<StateT> {
     final element = requireElement();
 
     element.flush();
-    return element.stateResult?.value;
+    return element.stateResult()?.value;
   }
 }
 
@@ -73,22 +73,21 @@ abstract base class $NotifierProvider //
 @internal
 @publicInCodegen
 class $NotifierProviderElement< //
-        NotifierT extends $Notifier<StateT>,
-        StateT> //
+        NotifierT extends $Notifier<ValueT>,
+        ValueT> //
     extends $ClassProviderElement< //
         NotifierT,
-        StateT,
-        StateT,
-        StateT> {
+        ValueT,
+        ValueT,
+        ValueT> with SyncProviderElement<ValueT> {
   /// An implementation detail of `riverpod_generator`.
   /// Do not use.
   $NotifierProviderElement(super.pointer);
 
   @override
   void handleError(Ref ref, Object error, StackTrace stackTrace) =>
-      setStateResult($ResultError<StateT>(error, stackTrace));
+      value = AsyncError<ValueT>(error, stackTrace);
 
   @override
-  void handleValue(Ref ref, StateT created) =>
-      setStateResult($ResultData(created));
+  void handleValue(Ref ref, ValueT created) => value = AsyncData(created);
 }

--- a/packages/riverpod/lib/src/providers/provider.dart
+++ b/packages/riverpod/lib/src/providers/provider.dart
@@ -2,7 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../builder.dart';
 import '../common/internal_lints.dart';
-import '../common/result.dart';
+import '../core/async_value.dart';
 import '../framework.dart';
 import 'legacy/state_notifier_provider.dart' show StateNotifierProvider;
 import 'stream_provider.dart' show StreamProvider;
@@ -114,7 +114,7 @@ final class Provider<ValueT> extends $FunctionalProvider<ValueT, ValueT, ValueT>
   Override overrideWithValue(ValueT value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<ValueT, ValueT>(value),
+      providerOverride: $SyncValueProvider<ValueT>(value),
     );
   }
 }
@@ -332,20 +332,21 @@ final class Provider<ValueT> extends $FunctionalProvider<ValueT, ValueT, ValueT>
 /// @nodoc
 @internal
 @publicInCodegen
-class $ProviderElement<StateT>
-    extends $FunctionalProviderElement<StateT, StateT, StateT> {
+class $ProviderElement<ValueT>
+    extends $FunctionalProviderElement<ValueT, ValueT, ValueT>
+    with SyncProviderElement<ValueT> {
   /// A [ProviderElement] for [Provider]
   $ProviderElement(super.pointer);
 
   @override
   WhenComplete create(Ref ref) {
-    setStateResult($ResultData(provider.create(ref)));
+    value = AsyncData(provider.create(ref));
 
     return null;
   }
 
   @override
-  bool updateShouldNotify(StateT previous, StateT next) => previous != next;
+  bool updateShouldNotify(ValueT previous, ValueT next) => previous != next;
 }
 
 /// The [Family] of [Provider]

--- a/packages/riverpod/test/old/framework/provider_container_test.dart
+++ b/packages/riverpod/test/old/framework/provider_container_test.dart
@@ -164,9 +164,10 @@ void main() {
     test(
         'flushes listened-to providers even if they have no external listeners (with ProviderListenable)',
         () async {
-      final dep = StateProvider((ref) => 0);
-      final provider = Provider((ref) => ref.watch(dep));
+      final dep = StateProvider(name: 'dep', (ref) => 0);
+      final provider = Provider(name: 'provider', (ref) => ref.watch(dep));
       final another = NotifierProvider<Notifier<int>, int>(
+        name: 'another',
         () => DeferredNotifier((ref, self) {
           ref.listen(provider, (prev, value) => self.state++);
           return 0;

--- a/packages/riverpod/test/old/framework/ref_watch_test.dart
+++ b/packages/riverpod/test/old/framework/ref_watch_test.dart
@@ -59,10 +59,10 @@ void main() {
 
   test('can listen multiple providers at once', () async {
     final container = ProviderContainer.test();
-    final count = StateProvider((ref) => 0);
-    final count2 = StateProvider((ref) => 0);
+    final count = StateProvider((ref) => 0, name: 'count');
+    final count2 = StateProvider((ref) => 0, name: 'count2');
 
-    final provider = Provider((ref) {
+    final provider = Provider(name: 'provider', (ref) {
       final first = ref.watch(count);
       final second = ref.watch(count2);
 

--- a/packages/riverpod/test/src/core/auto_dispose_test.dart
+++ b/packages/riverpod/test/src/core/auto_dispose_test.dart
@@ -36,10 +36,10 @@ void main() {
 
       expect(buildCount, 1);
       expect(container.readProviderElement(provider), same(element));
-      expect(element.stateResult, null);
+      expect(element.stateResult(), null);
 
       expect(sub.read(), 0);
-      expect(element.stateResult, $ResultData(0));
+      expect(element.stateResult(), $ResultData(0));
       expect(buildCount, 2);
     });
 

--- a/packages/riverpod/test/src/core/ref_test.dart
+++ b/packages/riverpod/test/src/core/ref_test.dart
@@ -934,7 +934,7 @@ void main() {
           expect(
             container.pointerManager.orphanPointers.pointers[dep]!.element,
             isA<ProviderElement>()
-                .having((e) => e.stateResult, 'stateResult', null),
+                .having((e) => e.stateResult(), 'stateResult', null),
           );
         });
 

--- a/packages/riverpod_annotation/lib/riverpod_annotation.dart
+++ b/packages/riverpod_annotation/lib/riverpod_annotation.dart
@@ -22,7 +22,7 @@ export './src/internal.dart'
         AnyNotifier,
         $AsyncClassModifier,
         $ClassProvider,
-        $ValueProvider,
+        $SyncValueProvider,
         $ProviderOverride,
         $RefArg,
         $ProviderPointer,

--- a/packages/riverpod_generator/integration/build_yaml/lib/dependencies.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/dependencies.g.dart
@@ -65,7 +65,7 @@ final class Calc2Provider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
@@ -39,7 +39,7 @@ final class CountProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -145,7 +145,7 @@ final class CountNotifierProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -300,7 +300,7 @@ final class Count2Provider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -522,7 +522,7 @@ final class CountNotifier2Provider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 

--- a/packages/riverpod_generator/lib/src/templates/provider.dart
+++ b/packages/riverpod_generator/lib/src/templates/provider.dart
@@ -191,7 +191,7 @@ ${provider.doc} final class $name$_genericsDefinition
   Override overrideWithValue(${provider.exposedTypeDisplayString} value) {
     return \$ProviderOverride(
       origin: this,
-      providerOverride: \$ValueProvider<${provider.exposedTypeDisplayString}, ${provider.valueTypeDisplayString}>(value),
+      providerOverride: \$SyncValueProvider<${provider.valueTypeDisplayString}>(value),
     );
   }
 ''');

--- a/packages/riverpod_generator/test/integration/annotated.g.dart
+++ b/packages/riverpod_generator/test/integration/annotated.g.dart
@@ -52,7 +52,7 @@ final class FunctionalProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -130,7 +130,7 @@ final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -234,7 +234,7 @@ final class FamilyProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -304,7 +304,7 @@ final class NotCopiedFunctionalProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -345,7 +345,7 @@ final class NotCopiedClassBasedProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -409,7 +409,7 @@ final class NotCopiedFamilyProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/integration/async.g.dart
+++ b/packages/riverpod_generator/test/integration/async.g.dart
@@ -958,7 +958,7 @@ final class Regression3490Provider<Model, Sort, Cursor>
   Override overrideWithValue(void value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<void, void>(value),
+      providerOverride: $SyncValueProvider<void>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/integration/auto_dispose.g.dart
+++ b/packages/riverpod_generator/test/integration/auto_dispose.g.dart
@@ -39,7 +39,7 @@ final class KeepAliveProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -79,7 +79,7 @@ final class NotKeepAliveProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -119,7 +119,7 @@ final class DefaultKeepAliveProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -169,7 +169,7 @@ final class KeepAliveFamilyProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -250,7 +250,7 @@ final class NotKeepAliveFamilyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -332,7 +332,7 @@ final class DefaultKeepAliveFamilyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/integration/dependencies.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies.g.dart
@@ -39,7 +39,7 @@ final class DepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -89,7 +89,7 @@ final class FamilyProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -158,7 +158,7 @@ final class Dep2Provider extends $NotifierProvider<Dep2, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -216,7 +216,7 @@ final class Family2Provider extends $NotifierProvider<Family2, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -321,7 +321,7 @@ final class ProviderProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -376,7 +376,7 @@ final class Provider2Provider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -430,7 +430,7 @@ final class Provider3Provider extends $NotifierProvider<Provider3, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -493,7 +493,7 @@ final class Provider4Provider extends $NotifierProvider<Provider4, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -609,7 +609,7 @@ final class TransitiveDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -663,7 +663,7 @@ final class SmallTransitiveDependencyCountProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -705,7 +705,7 @@ final class EmptyDependenciesFunctionalProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -747,7 +747,7 @@ final class EmptyDependenciesClassBasedProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -810,7 +810,7 @@ final class ProviderWithDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -851,7 +851,7 @@ final class _PrivateDepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -891,7 +891,7 @@ final class PublicDepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -937,7 +937,7 @@ final class DuplicateDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -987,7 +987,7 @@ final class DuplicateDependencies2Provider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -1050,7 +1050,7 @@ final class TransitiveDuplicateDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_generator/test/integration/dependencies2.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies2.g.dart
@@ -57,7 +57,7 @@ final class ProviderWithDependencies2Provider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -117,7 +117,7 @@ final class FamilyWithDependencies2Provider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -217,7 +217,7 @@ final class NotifierWithDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -287,7 +287,7 @@ final class NotifierFamilyWithDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -391,7 +391,7 @@ final class _Private2Provider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -431,7 +431,7 @@ final class Public2Provider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_generator/test/integration/documented.g.dart
+++ b/packages/riverpod_generator/test/integration/documented.g.dart
@@ -45,7 +45,7 @@ final class FunctionalProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -90,7 +90,7 @@ final class ClassBasedProvider extends $NotifierProvider<ClassBased, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -159,7 +159,7 @@ final class FamilyProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -245,7 +245,7 @@ final class ClassFamilyBasedProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/integration/generated.g.dart
+++ b/packages/riverpod_generator/test/integration/generated.g.dart
@@ -39,7 +39,7 @@ final class GeneratedProvider extends $FunctionalProvider<_Test, _Test, _Test>
   Override overrideWithValue(_Test value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<_Test, _Test>(value),
+      providerOverride: $SyncValueProvider<_Test>(value),
     );
   }
 }
@@ -90,7 +90,7 @@ final class GeneratedFamilyProvider
   Override overrideWithValue(_Test value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<_Test, _Test>(value),
+      providerOverride: $SyncValueProvider<_Test>(value),
     );
   }
 
@@ -160,7 +160,7 @@ final class GeneratedClassProvider
   Override overrideWithValue(_Test value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<_Test, _Test>(value),
+      providerOverride: $SyncValueProvider<_Test>(value),
     );
   }
 }
@@ -220,7 +220,7 @@ final class GeneratedClassFamilyProvider
   Override overrideWithValue(_Test value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<_Test, _Test>(value),
+      providerOverride: $SyncValueProvider<_Test>(value),
     );
   }
 
@@ -313,7 +313,7 @@ final class $DynamicProvider
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?, Object?>(value),
+      providerOverride: $SyncValueProvider<Object?>(value),
     );
   }
 }
@@ -365,7 +365,7 @@ final class $DynamicFamilyProvider
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?, Object?>(value),
+      providerOverride: $SyncValueProvider<Object?>(value),
     );
   }
 
@@ -435,7 +435,7 @@ final class $DynamicClassProvider
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?, Object?>(value),
+      providerOverride: $SyncValueProvider<Object?>(value),
     );
   }
 }
@@ -495,7 +495,7 @@ final class $DynamicClassFamilyProvider
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?, Object?>(value),
+      providerOverride: $SyncValueProvider<Object?>(value),
     );
   }
 
@@ -599,7 +599,7 @@ final class _DynamicProvider
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?, Object?>(value),
+      providerOverride: $SyncValueProvider<Object?>(value),
     );
   }
 
@@ -669,7 +669,7 @@ final class AliasProvider extends $FunctionalProvider<AsyncValue<int>,
   Override overrideWithValue(AsyncValue<int> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>, AsyncValue<int>>(value),
+      providerOverride: $SyncValueProvider<AsyncValue<int>>(value),
     );
   }
 }
@@ -720,7 +720,7 @@ final class AliasFamilyProvider extends $FunctionalProvider<AsyncValue<int>,
   Override overrideWithValue(AsyncValue<int> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>, AsyncValue<int>>(value),
+      providerOverride: $SyncValueProvider<AsyncValue<int>>(value),
     );
   }
 
@@ -790,7 +790,7 @@ final class AliasClassProvider
   Override overrideWithValue(AsyncValue<int> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>, AsyncValue<int>>(value),
+      providerOverride: $SyncValueProvider<AsyncValue<int>>(value),
     );
   }
 }
@@ -853,7 +853,7 @@ final class AliasClassFamilyProvider
   Override overrideWithValue(AsyncValue<int> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<AsyncValue<int>, AsyncValue<int>>(value),
+      providerOverride: $SyncValueProvider<AsyncValue<int>>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/integration/hash/hash1.g.dart
+++ b/packages/riverpod_generator/test/integration/hash/hash1.g.dart
@@ -39,7 +39,7 @@ final class SimpleProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -79,7 +79,7 @@ final class Simple2Provider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -118,7 +118,7 @@ final class SimpleClassProvider extends $NotifierProvider<SimpleClass, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/packages/riverpod_generator/test/integration/hash/retry.g.dart
+++ b/packages/riverpod_generator/test/integration/hash/retry.g.dart
@@ -39,7 +39,7 @@ final class AProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -88,7 +88,7 @@ final class BProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/integration/mutation.g.dart
+++ b/packages/riverpod_generator/test/integration/mutation.g.dart
@@ -58,7 +58,7 @@ final class SyncTodoListProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }
@@ -447,7 +447,7 @@ final class SimpleProvider extends $NotifierProvider<Simple, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -692,7 +692,7 @@ final class SimpleFamilyProvider extends $NotifierProvider<SimpleFamily, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -1570,7 +1570,7 @@ final class FailingCtorProvider extends $NotifierProvider<FailingCtor, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -1699,7 +1699,7 @@ final class TypedProvider extends $NotifierProvider<Typed, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/packages/riverpod_generator/test/integration/scopes.g.dart
+++ b/packages/riverpod_generator/test/integration/scopes.g.dart
@@ -38,7 +38,7 @@ final class ScopedClassProvider extends $NotifierProvider<ScopedClass, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -98,7 +98,7 @@ final class ScopedClassFamilyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/integration/split.g.dart
+++ b/packages/riverpod_generator/test/integration/split.g.dart
@@ -39,7 +39,7 @@ final class Counter2Provider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -79,7 +79,7 @@ final class CounterProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_generator/test/integration/sync.g.dart
+++ b/packages/riverpod_generator/test/integration/sync.g.dart
@@ -50,7 +50,7 @@ final class GenericProvider<T extends num>
   Override overrideWithValue(List<T> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<T>, List<T>>(value),
+      providerOverride: $SyncValueProvider<List<T>>(value),
     );
   }
 
@@ -155,7 +155,7 @@ final class ComplexGenericProvider<T extends num, Foo extends String?>
   Override overrideWithValue(List<T> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<T>, List<T>>(value),
+      providerOverride: $SyncValueProvider<List<T>>(value),
     );
   }
 
@@ -266,7 +266,7 @@ final class GenericClassProvider<T extends num>
   Override overrideWithValue(List<T> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<T>, List<T>>(value),
+      providerOverride: $SyncValueProvider<List<T>>(value),
     );
   }
 
@@ -379,8 +379,7 @@ final class RawFutureProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<Future<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<Future<String>>, Raw<Future<String>>>(value),
+      providerOverride: $SyncValueProvider<Raw<Future<String>>>(value),
     );
   }
 }
@@ -423,8 +422,7 @@ final class RawStreamProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<Stream<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<Stream<String>>, Raw<Stream<String>>>(value),
+      providerOverride: $SyncValueProvider<Raw<Stream<String>>>(value),
     );
   }
 }
@@ -464,8 +462,7 @@ final class RawFutureClassProvider
   Override overrideWithValue(Raw<Future<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<Future<String>>, Raw<Future<String>>>(value),
+      providerOverride: $SyncValueProvider<Raw<Future<String>>>(value),
     );
   }
 }
@@ -521,8 +518,7 @@ final class RawStreamClassProvider
   Override overrideWithValue(Raw<Stream<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<Stream<String>>, Raw<Stream<String>>>(value),
+      providerOverride: $SyncValueProvider<Raw<Stream<String>>>(value),
     );
   }
 }
@@ -591,8 +587,7 @@ final class RawFamilyFutureProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<Future<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<Future<String>>, Raw<Future<String>>>(value),
+      providerOverride: $SyncValueProvider<Raw<Future<String>>>(value),
     );
   }
 
@@ -675,8 +670,7 @@ final class RawFamilyStreamProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<Stream<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<Stream<String>>, Raw<Stream<String>>>(value),
+      providerOverride: $SyncValueProvider<Raw<Stream<String>>>(value),
     );
   }
 
@@ -753,8 +747,7 @@ final class RawFamilyFutureClassProvider
   Override overrideWithValue(Raw<Future<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<Future<String>>, Raw<Future<String>>>(value),
+      providerOverride: $SyncValueProvider<Raw<Future<String>>>(value),
     );
   }
 
@@ -857,8 +850,7 @@ final class RawFamilyStreamClassProvider
   Override overrideWithValue(Raw<Stream<String>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<Stream<String>>, Raw<Stream<String>>>(value),
+      providerOverride: $SyncValueProvider<Raw<Stream<String>>>(value),
     );
   }
 
@@ -957,7 +949,7 @@ final class PublicProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -997,7 +989,7 @@ final class Supports$inNamesProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -1068,7 +1060,7 @@ final class FamilyProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -1159,7 +1151,7 @@ final class _PrivateProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -1201,7 +1193,7 @@ final class PublicClassProvider extends $NotifierProvider<PublicClass, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -1254,7 +1246,7 @@ final class _PrivateClassProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -1323,7 +1315,7 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -1466,7 +1458,7 @@ final class Supports$InFnNameProvider<And$InT>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -1575,7 +1567,7 @@ final class Supports$InFnNameFamilyProvider<And$InT>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -1691,7 +1683,7 @@ final class Supports$InClassNameProvider<And$InT>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -1823,7 +1815,7 @@ final class Supports$InClassFamilyNameProvider<And$InT>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -1965,7 +1957,7 @@ final class GeneratedProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -2016,7 +2008,7 @@ final class UnnecessaryCastProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -2093,7 +2085,7 @@ final class UnnecessaryCastClassProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 

--- a/packages/riverpod_generator/test/mutation_test.dart
+++ b/packages/riverpod_generator/test/mutation_test.dart
@@ -257,7 +257,7 @@ void main() {
 
     final element = container.readProviderElement(simpleProvider);
 
-    expect(element.stateResult, null);
+    expect(element.stateResult(), null);
 
     await sub.read().call(2);
 

--- a/packages/riverpod_graph/test/integration/generated/golden/lib/sync.g.dart
+++ b/packages/riverpod_graph/test/integration/generated/golden/lib/sync.g.dart
@@ -42,7 +42,7 @@ final class PublicProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -85,7 +85,7 @@ final class Supports$inNamesProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -156,7 +156,7 @@ final class FamilyProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -247,7 +247,7 @@ final class _PrivateProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -289,7 +289,7 @@ final class PublicClassProvider extends $NotifierProvider<PublicClass, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -342,7 +342,7 @@ final class _PrivateClassProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -411,7 +411,7 @@ final class FamilyClassProvider extends $NotifierProvider<FamilyClass, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 
@@ -546,7 +546,7 @@ final class Supports$InClassNameProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional/convert_class_based_provider_to_functional.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional/convert_class_based_provider_to_functional.g.dart
@@ -41,7 +41,7 @@ final class ExampleProvider extends $NotifierProvider<Example, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -108,7 +108,7 @@ final class ExampleFamilyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -229,7 +229,7 @@ final class GenericProvider<A, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based/convert_functional_provider_to_class_based.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based/convert_functional_provider_to_class_based.g.dart
@@ -42,7 +42,7 @@ final class ExampleProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -104,7 +104,7 @@ final class ExampleFamilyProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/avoid_build_context_in_providers.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/avoid_build_context_in_providers.g.dart
@@ -58,7 +58,7 @@ final class FnProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -148,7 +148,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -258,7 +258,7 @@ final class Regression2959Provider
   Override overrideWithValue(void value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<void, void>(value),
+      providerOverride: $SyncValueProvider<void>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/avoid_public_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/avoid_public_notifier_properties.g.dart
@@ -46,7 +46,7 @@ final class GeneratedNotifierProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/functional_ref/functional_ref.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/functional_ref/functional_ref.g.dart
@@ -39,7 +39,7 @@ final class NamelessProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -89,7 +89,7 @@ final class GenericsProvider<A extends num, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -172,7 +172,7 @@ final class ValidProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.g.dart
@@ -38,7 +38,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -91,7 +91,7 @@ final class _PrivateClassProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -154,7 +154,7 @@ final class GenericsProvider<A extends num, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -276,7 +276,7 @@ final class NoGenericsProvider<A extends num, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -398,7 +398,7 @@ final class MissingGenericsProvider<A, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -519,7 +519,7 @@ final class WrongOrderProvider<A, B>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/only_use_keep_alive_inside_keep_alive.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/only_use_keep_alive_inside_keep_alive.g.dart
@@ -39,7 +39,7 @@ final class KeepAliveProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -79,7 +79,7 @@ final class KeepAliveClassProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -132,7 +132,7 @@ final class AutoDisposeProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -172,7 +172,7 @@ final class AutoDisposeClassProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -225,7 +225,7 @@ final class FnProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
@@ -37,7 +37,7 @@ final class AProvider extends $NotifierProvider<A, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -88,7 +88,7 @@ final class A2Provider extends $NotifierProvider<A2, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -145,7 +145,7 @@ final class A3Provider extends $NotifierProvider<A3, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -239,7 +239,7 @@ final class A4Provider extends $NotifierProvider<A4, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -675,7 +675,7 @@ final class BProvider extends $NotifierProvider<B, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -726,7 +726,7 @@ final class B2Provider extends $NotifierProvider<B2, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/another.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/another.g.dart
@@ -39,7 +39,7 @@ final class BProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -79,7 +79,7 @@ final class AnotherScopedProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -123,7 +123,7 @@ final class AnotherNonEmptyScopedProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies.g.dart
@@ -39,7 +39,7 @@ final class DepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -83,7 +83,7 @@ final class TransitiveDepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -123,7 +123,7 @@ final class Dep2Provider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -173,7 +173,7 @@ final class DepFamilyProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -249,7 +249,7 @@ final class PlainAnnotationProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -289,7 +289,7 @@ final class CustomAnnotationProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -331,7 +331,7 @@ final class CustomAnnotationWithTrailingCommaProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -372,7 +372,7 @@ final class ExistingDepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -412,7 +412,7 @@ final class MultipleDepsProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -458,7 +458,7 @@ final class ProviderWithDartDocProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.g.dart
@@ -39,7 +39,7 @@ final class DepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -79,7 +79,7 @@ final class GeneratedScopedProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -119,7 +119,7 @@ final class GeneratedRootProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -160,7 +160,7 @@ final class WatchScopedButNoDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -203,7 +203,7 @@ final class WatchGeneratedScopedButNoDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -245,7 +245,7 @@ final class WatchRootButNoDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -288,7 +288,7 @@ final class WatchGeneratedRootButNoDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -330,7 +330,7 @@ final class WatchScopedButEmptyDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -373,7 +373,7 @@ final class WatchGeneratedScopedButEmptyDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -415,7 +415,7 @@ final class WatchRootButEmptyDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -458,7 +458,7 @@ final class WatchGeneratedRootButEmptyDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -506,7 +506,7 @@ final class WatchScopedButMissingDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -554,7 +554,7 @@ final class WatchGeneratedScopedButMissingDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -600,7 +600,7 @@ final class WatchRootButMissingDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -648,7 +648,7 @@ final class WatchGeneratedRootButMissingDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -696,7 +696,7 @@ final class WatchGeneratedScopedAndContainsDependencyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -744,7 +744,7 @@ final class WatchGeneratedRootAndContainsDependencyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -795,7 +795,7 @@ final class SpecifiedDependencyButNeverUsedProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -840,7 +840,7 @@ final class ClassWatchGeneratedRootButMissingDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -899,7 +899,7 @@ final class Regression2348Provider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -943,7 +943,7 @@ final class Regression2417Provider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -1008,7 +1008,7 @@ final class FamilyDepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -1094,7 +1094,7 @@ final class FamilyDep2Provider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 
@@ -1167,7 +1167,7 @@ final class AliasProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -1206,7 +1206,7 @@ final class AliasClassProvider extends $NotifierProvider<AliasClass, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -1263,7 +1263,7 @@ final class RiverpodDependenciesProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -1317,7 +1317,7 @@ final class FooProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -1357,7 +1357,7 @@ final class CrossFileDependencyProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/unused_dependency.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/unused_dependency.g.dart
@@ -39,7 +39,7 @@ final class RootProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -79,7 +79,7 @@ final class DepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -119,7 +119,7 @@ final class Dep2Provider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -168,7 +168,7 @@ final class ExtraDepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -212,7 +212,7 @@ final class NoDepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -257,7 +257,7 @@ final class DependenciesFirstThenKeepAliveProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -302,7 +302,7 @@ final class NoDepNoParamProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -346,7 +346,7 @@ final class NoDepWithoutCommaProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -390,7 +390,7 @@ final class RootDepProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.g.dart
@@ -49,7 +49,7 @@ final class GeneratorProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/scoped_providers_should_specify_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/scoped_providers_should_specify_dependencies.g.dart
@@ -39,7 +39,7 @@ final class UnimplementedScopedProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -93,7 +93,7 @@ final class ScopedProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -133,7 +133,7 @@ final class RootProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/unsupported_provider_value.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/unsupported_provider_value.g.dart
@@ -39,7 +39,7 @@ final class IntegerProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -79,7 +79,7 @@ final class StateNotifierProvider extends $FunctionalProvider<MyStateNotifier,
   Override overrideWithValue(MyStateNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyStateNotifier, MyStateNotifier>(value),
+      providerOverride: $SyncValueProvider<MyStateNotifier>(value),
     );
   }
 }
@@ -154,7 +154,7 @@ final class StateNotifierClassProvider
   Override overrideWithValue(MyStateNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyStateNotifier, MyStateNotifier>(value),
+      providerOverride: $SyncValueProvider<MyStateNotifier>(value),
     );
   }
 }
@@ -294,8 +294,7 @@ final class SyncSelfNotifierProvider
   Override overrideWithValue(SyncSelfNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<SyncSelfNotifier, SyncSelfNotifier>(value),
+      providerOverride: $SyncValueProvider<SyncSelfNotifier>(value),
     );
   }
 }
@@ -452,8 +451,7 @@ final class ChangeNotifierProvider extends $FunctionalProvider<MyChangeNotifier,
   Override overrideWithValue(MyChangeNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<MyChangeNotifier, MyChangeNotifier>(value),
+      providerOverride: $SyncValueProvider<MyChangeNotifier>(value),
     );
   }
 }
@@ -493,8 +491,7 @@ final class ChangeNotifierClassProvider
   Override overrideWithValue(MyChangeNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<MyChangeNotifier, MyChangeNotifier>(value),
+      providerOverride: $SyncValueProvider<MyChangeNotifier>(value),
     );
   }
 }
@@ -552,7 +549,7 @@ final class NotifierProvider
   Override overrideWithValue(MyNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyNotifier, MyNotifier>(value),
+      providerOverride: $SyncValueProvider<MyNotifier>(value),
     );
   }
 }
@@ -595,8 +592,7 @@ final class AutoDisposeNotifierProvider extends $FunctionalProvider<
   Override overrideWithValue(MyAutoDisposeNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<MyAutoDisposeNotifier, MyAutoDisposeNotifier>(value),
+      providerOverride: $SyncValueProvider<MyAutoDisposeNotifier>(value),
     );
   }
 }
@@ -637,7 +633,7 @@ final class NotifierClassProvider
   Override overrideWithValue(MyNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyNotifier, MyNotifier>(value),
+      providerOverride: $SyncValueProvider<MyNotifier>(value),
     );
   }
 }
@@ -690,7 +686,7 @@ final class AsyncNotifierProvider extends $FunctionalProvider<MyAsyncNotifier,
   Override overrideWithValue(MyAsyncNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyAsyncNotifier, MyAsyncNotifier>(value),
+      providerOverride: $SyncValueProvider<MyAsyncNotifier>(value),
     );
   }
 }
@@ -730,7 +726,7 @@ final class AsyncNotifierClassProvider
   Override overrideWithValue(MyAsyncNotifier value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyAsyncNotifier, MyAsyncNotifier>(value),
+      providerOverride: $SyncValueProvider<MyAsyncNotifier>(value),
     );
   }
 }
@@ -790,8 +786,7 @@ final class RawNotifierProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<MyChangeNotifier> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<MyChangeNotifier>, Raw<MyChangeNotifier>>(value),
+      providerOverride: $SyncValueProvider<Raw<MyChangeNotifier>>(value),
     );
   }
 }
@@ -835,8 +830,8 @@ final class RawFutureNotifierProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<Future<MyChangeNotifier>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Future<MyChangeNotifier>>,
-          Raw<Future<MyChangeNotifier>>>(value),
+      providerOverride:
+          $SyncValueProvider<Raw<Future<MyChangeNotifier>>>(value),
     );
   }
 }
@@ -880,8 +875,8 @@ final class RawStreamNotifierProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<Stream<MyChangeNotifier>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Raw<Stream<MyChangeNotifier>>,
-          Raw<Stream<MyChangeNotifier>>>(value),
+      providerOverride:
+          $SyncValueProvider<Raw<Stream<MyChangeNotifier>>>(value),
     );
   }
 }

--- a/website/docs/advanced/select/select/codegen.g.dart
+++ b/website/docs/advanced/select/select/codegen.g.dart
@@ -41,7 +41,7 @@ final class ExampleProvider extends $FunctionalProvider<User, User, User>
   Override overrideWithValue(User value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<User, User>(value),
+      providerOverride: $SyncValueProvider<User>(value),
     );
   }
 }

--- a/website/docs/advanced/select/select_async/codegen.g.dart
+++ b/website/docs/advanced/select/select_async/codegen.g.dart
@@ -75,7 +75,7 @@ final class ExampleProvider
   Override overrideWithValue(Object? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Object?, Object?>(value),
+      providerOverride: $SyncValueProvider<Object?>(value),
     );
   }
 }

--- a/website/docs/concepts/about_codegen/provider_type/auto_dispose.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/auto_dispose.g.dart
@@ -41,7 +41,7 @@ final class Example1Provider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class Example2Provider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/concepts/about_codegen/provider_type/family.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family.g.dart
@@ -51,7 +51,7 @@ final class ExampleProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 

--- a/website/docs/concepts/about_codegen/provider_type/family_class.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_class.g.dart
@@ -51,7 +51,7 @@ final class ExampleProvider extends $NotifierProvider<Example, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 

--- a/website/docs/concepts/about_codegen/provider_type/family_fn.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_fn.g.dart
@@ -60,7 +60,7 @@ final class ExampleProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 

--- a/website/docs/concepts/about_codegen/provider_type/sync_class.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/sync_class.g.dart
@@ -40,7 +40,7 @@ final class ExampleProvider extends $NotifierProvider<Example, String> {
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/concepts/about_codegen/provider_type/sync_fn.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/sync_fn.g.dart
@@ -41,7 +41,7 @@ final class ExampleProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/concepts/combining_provider_states/characters_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/characters_provider/codegen.g.dart
@@ -41,7 +41,7 @@ final class SearchProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/concepts/combining_provider_states/city_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/city_provider/codegen.g.dart
@@ -41,7 +41,7 @@ final class CityProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/filtered_todo_list_provider/codegen.g.dart
@@ -41,7 +41,7 @@ final class FilterProvider extends $FunctionalProvider<Filter, Filter, Filter>
   Override overrideWithValue(Filter value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Filter, Filter>(value),
+      providerOverride: $SyncValueProvider<Filter>(value),
     );
   }
 }
@@ -82,7 +82,7 @@ final class FilteredTodoListProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }

--- a/website/docs/concepts/combining_provider_states/read_in_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/read_in_provider/codegen.g.dart
@@ -42,7 +42,7 @@ final class AnotherProvider
   Override overrideWithValue(MyValue value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyValue, MyValue>(value),
+      providerOverride: $SyncValueProvider<MyValue>(value),
     );
   }
 }
@@ -82,7 +82,7 @@ final class MyProvider extends $FunctionalProvider<MyValue, MyValue, MyValue>
   Override overrideWithValue(MyValue value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyValue, MyValue>(value),
+      providerOverride: $SyncValueProvider<MyValue>(value),
     );
   }
 }

--- a/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/todo_list_provider/codegen.g.dart
@@ -40,7 +40,7 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }

--- a/website/docs/concepts/combining_provider_states/weather_provider/codegen.g.dart
+++ b/website/docs/concepts/combining_provider_states/weather_provider/codegen.g.dart
@@ -41,7 +41,7 @@ final class CityProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/concepts/providers/creating_a_provider/codegen.g.dart
+++ b/website/docs/concepts/providers/creating_a_provider/codegen.g.dart
@@ -41,7 +41,7 @@ final class MyProvider extends $FunctionalProvider<MyValue, MyValue, MyValue>
   Override overrideWithValue(MyValue value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<MyValue, MyValue>(value),
+      providerOverride: $SyncValueProvider<MyValue>(value),
     );
   }
 }

--- a/website/docs/concepts/providers/declaring_many_providers/codegen.g.dart
+++ b/website/docs/concepts/providers/declaring_many_providers/codegen.g.dart
@@ -41,7 +41,7 @@ final class CityProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class CountryProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/counter/codegen.g.dart
+++ b/website/docs/concepts/reading/counter/codegen.g.dart
@@ -42,7 +42,7 @@ final class RepositoryProvider
   Override overrideWithValue(Repository value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Repository, Repository>(value),
+      providerOverride: $SyncValueProvider<Repository>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/listen/codegen.g.dart
+++ b/website/docs/concepts/reading/listen/codegen.g.dart
@@ -41,7 +41,7 @@ final class AnotherProvider extends $FunctionalProvider<void, void, void>
   Override overrideWithValue(void value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<void, void>(value),
+      providerOverride: $SyncValueProvider<void>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/listen_build/codegen.g.dart
+++ b/website/docs/concepts/reading/listen_build/codegen.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/listen_build/codegen_hooks.g.dart
+++ b/website/docs/concepts/reading/listen_build/codegen_hooks.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/provider/codegen.g.dart
+++ b/website/docs/concepts/reading/provider/codegen.g.dart
@@ -42,7 +42,7 @@ final class RepositoryProvider
   Override overrideWithValue(Repository value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Repository, Repository>(value),
+      providerOverride: $SyncValueProvider<Repository>(value),
     );
   }
 }
@@ -82,7 +82,7 @@ final class ValueProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/read/codegen.g.dart
+++ b/website/docs/concepts/reading/read/codegen.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/read/codegen_hooks.g.dart
+++ b/website/docs/concepts/reading/read/codegen_hooks.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/read_build/codegen.g.dart
+++ b/website/docs/concepts/reading/read_build/codegen.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/read_notifier_build/codegen.g.dart
+++ b/website/docs/concepts/reading/read_notifier_build/codegen.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/watch/codegen.g.dart
+++ b/website/docs/concepts/reading/watch/codegen.g.dart
@@ -42,7 +42,7 @@ final class FilterTypeProvider
   Override overrideWithValue(FilterType value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<FilterType, FilterType>(value),
+      providerOverride: $SyncValueProvider<FilterType>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }
@@ -135,7 +135,7 @@ final class FilteredTodoListProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/watch_build/codegen.g.dart
+++ b/website/docs/concepts/reading/watch_build/codegen.g.dart
@@ -40,7 +40,7 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }
@@ -93,7 +93,7 @@ final class CounterProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/watch_build/codegen_hooks.g.dart
+++ b/website/docs/concepts/reading/watch_build/codegen_hooks.g.dart
@@ -40,7 +40,7 @@ final class TodoListProvider extends $NotifierProvider<TodoList, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }
@@ -93,7 +93,7 @@ final class CounterProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/concepts/reading/watch_notifier_build/codegen.g.dart
+++ b/website/docs/concepts/reading/watch_notifier_build/codegen.g.dart
@@ -40,7 +40,7 @@ final class CounterProvider extends $NotifierProvider<Counter, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/concepts/why_immutability/codegen.g.dart
+++ b/website/docs/concepts/why_immutability/codegen.g.dart
@@ -41,7 +41,7 @@ final class ThemeNotifierProvider
   Override overrideWithValue(ThemeSettings value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<ThemeSettings, ThemeSettings>(value),
+      providerOverride: $SyncValueProvider<ThemeSettings>(value),
     );
   }
 }

--- a/website/docs/essentials/auto_dispose/codegen_keep_alive.g.dart
+++ b/website/docs/essentials/auto_dispose/codegen_keep_alive.g.dart
@@ -41,7 +41,7 @@ final class ExampleProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/essentials/auto_dispose/invalidate_family_example/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/invalidate_family_example/codegen.g.dart
@@ -51,7 +51,7 @@ final class LabelProvider extends $FunctionalProvider<String, String, String>
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 

--- a/website/docs/essentials/auto_dispose/on_dispose_example/codegen.g.dart
+++ b/website/docs/essentials/auto_dispose/on_dispose_example/codegen.g.dart
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/essentials/combining_requests/functional_ref/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/functional_ref/codegen.g.dart
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class ExampleProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/essentials/combining_requests/listen_example/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/listen_example/codegen.g.dart
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class ExampleProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/essentials/combining_requests/notifier_ref/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/notifier_ref/codegen.g.dart
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -80,7 +80,7 @@ final class ExampleProvider extends $NotifierProvider<Example, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/essentials/combining_requests/read_example/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/read_example/codegen.g.dart
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -80,7 +80,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/essentials/combining_requests/watch_placement/codegen.g.dart
+++ b/website/docs/essentials/combining_requests/watch_placement/codegen.g.dart
@@ -41,7 +41,7 @@ final class OtherProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class ExampleProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -120,7 +120,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/essentials/testing/notifier_mock/codegen.g.dart
+++ b/website/docs/essentials/testing/notifier_mock/codegen.g.dart
@@ -40,7 +40,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/essentials/websockets_sync/pipe_change_notifier.g.dart
+++ b/website/docs/essentials/websockets_sync/pipe_change_notifier.g.dart
@@ -53,9 +53,7 @@ final class MyListenableProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<ValueNotifier<int>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<ValueNotifier<int>>, Raw<ValueNotifier<int>>>(
-              value),
+      providerOverride: $SyncValueProvider<Raw<ValueNotifier<int>>>(value),
     );
   }
 }

--- a/website/docs/essentials/websockets_sync/raw_usage.g.dart
+++ b/website/docs/essentials/websockets_sync/raw_usage.g.dart
@@ -41,8 +41,7 @@ final class RawStreamProvider extends $FunctionalProvider<Raw<Stream<int>>,
   Override overrideWithValue(Raw<Stream<int>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<Stream<int>>, Raw<Stream<int>>>(value),
+      providerOverride: $SyncValueProvider<Raw<Stream<int>>>(value),
     );
   }
 }

--- a/website/docs/essentials/websockets_sync/shared_pipe_change_notifier.g.dart
+++ b/website/docs/essentials/websockets_sync/shared_pipe_change_notifier.g.dart
@@ -44,9 +44,7 @@ final class MyListenableProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<ValueNotifier<int>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<ValueNotifier<int>>, Raw<ValueNotifier<int>>>(
-              value),
+      providerOverride: $SyncValueProvider<Raw<ValueNotifier<int>>>(value),
     );
   }
 }
@@ -89,9 +87,7 @@ final class AnotherListenableProvider extends $FunctionalProvider<
   Override overrideWithValue(Raw<ValueNotifier<int>> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride:
-          $ValueProvider<Raw<ValueNotifier<int>>, Raw<ValueNotifier<int>>>(
-              value),
+      providerOverride: $SyncValueProvider<Raw<ValueNotifier<int>>>(value),
     );
   }
 }

--- a/website/docs/essentials/websockets_sync/sync_definition/codegen.g.dart
+++ b/website/docs/essentials/websockets_sync/sync_definition/codegen.g.dart
@@ -41,7 +41,7 @@ final class SynchronousExampleProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/from_provider/family/family.g.dart
+++ b/website/docs/from_provider/family/family.g.dart
@@ -60,7 +60,7 @@ final class RandomProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 

--- a/website/docs/from_provider/motivation/async_values/async_values.g.dart
+++ b/website/docs/from_provider/motivation/async_values/async_values.g.dart
@@ -75,7 +75,7 @@ final class EvenItemsProvider
   Override overrideWithValue(List<Item> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Item>, List<Item>>(value),
+      providerOverride: $SyncValueProvider<List<Item>>(value),
     );
   }
 }

--- a/website/docs/from_provider/motivation/auto_dispose/auto_dispose.g.dart
+++ b/website/docs/from_provider/motivation/auto_dispose/auto_dispose.g.dart
@@ -41,7 +41,7 @@ final class DiceRollProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class CachedDiceRollProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/from_provider/motivation/combine/combine.g.dart
+++ b/website/docs/from_provider/motivation/combine/combine.g.dart
@@ -41,7 +41,7 @@ final class NumberProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -81,7 +81,7 @@ final class DoubledProvider extends $FunctionalProvider<int, int, int>
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/from_provider/motivation/same_type/same_type.g.dart
+++ b/website/docs/from_provider/motivation/same_type/same_type.g.dart
@@ -42,7 +42,7 @@ final class ItemsProvider
   Override overrideWithValue(List<Item> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Item>, List<Item>>(value),
+      providerOverride: $SyncValueProvider<List<Item>>(value),
     );
   }
 }
@@ -83,7 +83,7 @@ final class EvenItemsProvider
   Override overrideWithValue(List<Item> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Item>, List<Item>>(value),
+      providerOverride: $SyncValueProvider<List<Item>>(value),
     );
   }
 }

--- a/website/docs/introduction/getting_started/dart_hello_world/main.g.dart
+++ b/website/docs/introduction/getting_started/dart_hello_world/main.g.dart
@@ -41,7 +41,7 @@ final class HelloWorldProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/introduction/getting_started/hello_world/hooks_codegen/main.g.dart
+++ b/website/docs/introduction/getting_started/hello_world/hooks_codegen/main.g.dart
@@ -41,7 +41,7 @@ final class HelloWorldProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/introduction/getting_started/hello_world/main.g.dart
+++ b/website/docs/introduction/getting_started/hello_world/main.g.dart
@@ -41,7 +41,7 @@ final class HelloWorldProvider
   Override overrideWithValue(String value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<String, String>(value),
+      providerOverride: $SyncValueProvider<String>(value),
     );
   }
 }

--- a/website/docs/migration/from_state_notifier/add_listener/add_listener.g.dart
+++ b/website/docs/migration/from_state_notifier/add_listener/add_listener.g.dart
@@ -40,7 +40,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/migration/from_state_notifier/build_init/build_init.g.dart
+++ b/website/docs/migration/from_state_notifier/build_init/build_init.g.dart
@@ -41,7 +41,7 @@ final class CounterNotifierProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
+++ b/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
@@ -41,7 +41,7 @@ final class TaskTrackerProvider extends $FunctionalProvider<TaskTrackerRepo,
   Override overrideWithValue(TaskTrackerRepo value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<TaskTrackerRepo, TaskTrackerRepo>(value),
+      providerOverride: $SyncValueProvider<TaskTrackerRepo>(value),
     );
   }
 }

--- a/website/docs/migration/from_state_notifier/from_state_provider/from_state_provider.g.dart
+++ b/website/docs/migration/from_state_notifier/from_state_provider/from_state_provider.g.dart
@@ -41,7 +41,7 @@ final class CounterNotifierProvider
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/migration/from_state_notifier/old_lifecycles/old_lifecycles.g.dart
+++ b/website/docs/migration/from_state_notifier/old_lifecycles/old_lifecycles.g.dart
@@ -40,7 +40,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/migration/from_state_notifier/old_lifecycles_final/old_lifecycles_final.g.dart
+++ b/website/docs/migration/from_state_notifier/old_lifecycles_final/old_lifecycles_final.g.dart
@@ -42,7 +42,7 @@ final class DurationProvider
   Override overrideWithValue(Duration value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Duration, Duration>(value),
+      providerOverride: $SyncValueProvider<Duration>(value),
     );
   }
 }
@@ -83,7 +83,7 @@ final class RepositoryProvider
   Override overrideWithValue(_MyRepo value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<_MyRepo, _MyRepo>(value),
+      providerOverride: $SyncValueProvider<_MyRepo>(value),
     );
   }
 }
@@ -122,7 +122,7 @@ final class MyNotifierProvider extends $NotifierProvider<MyNotifier, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/docs/providers/notifier_provider/todos/codegen.g.dart
+++ b/website/docs/providers/notifier_provider/todos/codegen.g.dart
@@ -40,7 +40,7 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }

--- a/website/docs/providers/provider/completed_todos/completed_todos.g.dart
+++ b/website/docs/providers/provider/completed_todos/completed_todos.g.dart
@@ -42,7 +42,7 @@ final class CompletedTodosProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }

--- a/website/docs/providers/provider/optimized_previous_button/optimized_previous_button.g.dart
+++ b/website/docs/providers/provider/optimized_previous_button/optimized_previous_button.g.dart
@@ -40,7 +40,7 @@ final class PageIndexProvider extends $NotifierProvider<PageIndex, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }
@@ -93,7 +93,7 @@ final class CanGoToPreviousPageProvider
   Override overrideWithValue(bool value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<bool, bool>(value),
+      providerOverride: $SyncValueProvider<bool>(value),
     );
   }
 }

--- a/website/docs/providers/provider/todo/todo.g.dart
+++ b/website/docs/providers/provider/todo/todo.g.dart
@@ -40,7 +40,7 @@ final class TodosProvider extends $NotifierProvider<Todos, List<Todo>> {
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }

--- a/website/docs/providers/provider/unoptimized_previous_button/unoptimized_previous_button.g.dart
+++ b/website/docs/providers/provider/unoptimized_previous_button/unoptimized_previous_button.g.dart
@@ -40,7 +40,7 @@ final class PageIndexProvider extends $NotifierProvider<PageIndex, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }

--- a/website/static/snippets/combine.g.dart
+++ b/website/static/snippets/combine.g.dart
@@ -42,7 +42,7 @@ final class TodosProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }
@@ -82,7 +82,7 @@ final class FilterProvider extends $FunctionalProvider<Filter, Filter, Filter>
   Override overrideWithValue(Filter value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<Filter, Filter>(value),
+      providerOverride: $SyncValueProvider<Filter>(value),
     );
   }
 }
@@ -123,7 +123,7 @@ final class FilteredTodosProvider
   Override overrideWithValue(List<Todo> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<List<Todo>, List<Todo>>(value),
+      providerOverride: $SyncValueProvider<List<Todo>>(value),
     );
   }
 }

--- a/website/static/snippets/declare.g.dart
+++ b/website/static/snippets/declare.g.dart
@@ -40,7 +40,7 @@ final class CountProvider extends $NotifierProvider<Count, int> {
   Override overrideWithValue(int value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $ValueProvider<int, int>(value),
+      providerOverride: $SyncValueProvider<int>(value),
     );
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified the provider override mechanism by replacing all uses of the generic value provider with a new synchronous value provider across the codebase and documentation.
  - Updated internal implementations of provider override methods to use the new synchronous value provider, improving consistency.
- **Documentation**
  - Reflected provider override changes in all relevant code examples and documentation.
- **Tests**
  - Adjusted test cases to align with the new provider override implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->