### PR TITLE
Simplify fireImmediately handling

### DIFF
--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -884,16 +884,28 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     // Not part of the public "Ref" API
     void Function()? onDependencyMayHaveChanged,
   }) {
+    assert(
+      !fireImmediately || !weak,
+      'Cannot use fireImmediately with weak listeners',
+    );
+
     final ref = this.ref!;
     ref._throwIfInvalidUsage();
 
     final sub = listenable._addListener(
       this,
       listener,
-      fireImmediately: fireImmediately,
       onError: onError ?? container.defaultOnError,
       weak: weak,
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
+    );
+
+    _handleFireImmediately(
+      container,
+      sub,
+      fireImmediately: fireImmediately,
+      listener: listener,
+      onError: onError,
     );
 
     switch (sub) {

--- a/packages/riverpod/lib/src/core/foundation.dart
+++ b/packages/riverpod/lib/src/core/foundation.dart
@@ -186,7 +186,6 @@ base mixin ProviderListenableWithOrigin<OutT, OriginStateT, OriginValueT>
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
-    required bool fireImmediately,
     required bool weak,
   });
 
@@ -217,7 +216,6 @@ base mixin ProviderListenable<StateT> implements ProviderListenableOrFamily {
     void Function(StateT? previous, StateT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
-    required bool fireImmediately,
     required bool weak,
   });
 

--- a/packages/riverpod/lib/src/core/modifiers/select.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select.dart
@@ -63,7 +63,6 @@ final class _ProviderSelector<InputT, OutputT, OriginStateT, OriginValueT>
     void Function(OutputT? previous, OutputT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
-    required bool fireImmediately,
     required bool weak,
   }) {
     late final ProviderSubscriptionView<OutputT, OriginStateT, OriginValueT>
@@ -80,7 +79,6 @@ final class _ProviderSelector<InputT, OutputT, OriginStateT, OriginValueT>
           onChange: (newState) => lastSelectedValue = newState,
         );
       },
-      fireImmediately: false,
       weak: weak,
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
       onError: onError,
@@ -99,7 +97,8 @@ final class _ProviderSelector<InputT, OutputT, OriginStateT, OriginValueT>
       );
     }
 
-    providerSub = ProviderSubscriptionView<OutputT, OriginStateT, OriginValueT>(
+    return providerSub =
+        ProviderSubscriptionView<OutputT, OriginStateT, OriginValueT>(
       innerSubscription: sub,
       listener: listener,
       onError: onError,
@@ -112,16 +111,5 @@ final class _ProviderSelector<InputT, OutputT, OriginStateT, OriginValueT>
         return lastSelectedValue!.requireState;
       },
     );
-
-    if (fireImmediately) {
-      _handleFireImmediately(
-        node.container,
-        lastSelectedValue!,
-        listener: providerSub._notifyData,
-        onError: providerSub._notifyError,
-      );
-    }
-
-    return providerSub;
   }
 }

--- a/packages/riverpod/lib/src/core/modifiers/select_async.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select_async.dart
@@ -43,7 +43,6 @@ final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
     void Function(Future<OutputT>? previous, Future<OutputT> next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
-    required bool fireImmediately,
     required bool weak,
   }) {
     late final ProviderSubscriptionView<Future<OutputT>, OriginStateT,
@@ -151,14 +150,9 @@ final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
       weak: weak,
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
       onError: onError,
-      fireImmediately: false,
     );
 
     playValue(sub.read(), callListeners: false);
-
-    if (fireImmediately) {
-      listener(null, selectedFuture!);
-    }
 
     return providerSub =
         ProviderSubscriptionView<Future<OutputT>, OriginStateT, OriginValueT>(
@@ -179,7 +173,6 @@ final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
             weak: weak,
             onDependencyMayHaveChanged: () {},
             onError: onError,
-            fireImmediately: false,
           );
 
           sub.read().then((v) => _select(v).requireState).then(

--- a/packages/riverpod/lib/src/core/provider/provider.dart
+++ b/packages/riverpod/lib/src/core/provider/provider.dart
@@ -108,26 +108,11 @@ abstract final class $ProviderBaseImpl<StateT, ValueT>
     void Function(StateT? previous, StateT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
-    required bool fireImmediately,
     required bool weak,
   }) {
-    assert(
-      !fireImmediately || !weak,
-      'Cannot use fireImmediately with weak listeners',
-    );
-
     final element = source.readProviderElement(this);
 
     if (!weak) element.flush();
-
-    if (fireImmediately) {
-      _handleFireImmediately(
-        source.container,
-        element.stateResult()!,
-        listener: listener,
-        onError: onError,
-      );
-    }
 
     return ProviderStateSubscription<StateT, ValueT>(
       source: source,

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -939,13 +939,24 @@ final class ProviderContainer implements Node {
     bool weak = false,
     void Function(Object error, StackTrace stackTrace)? onError,
   }) {
+    assert(
+      !(weak && fireImmediately),
+      'Cannot specify both weak and fireImmediately',
+    );
+
     final sub = provider._addListener(
       this,
       listener,
-      fireImmediately: fireImmediately,
       weak: weak,
       onError: onError ?? defaultOnError,
       onDependencyMayHaveChanged: null,
+    );
+    _handleFireImmediately(
+      container,
+      sub,
+      fireImmediately: fireImmediately,
+      listener: listener,
+      onError: onError,
     );
 
     switch (sub) {

--- a/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
+++ b/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
@@ -19,23 +19,11 @@ final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
-    required bool fireImmediately,
     required bool weak,
   }) {
     final element = source.readProviderElement(provider);
 
     final listenable = _lense(element);
-    if (fireImmediately) {
-      switch (listenable.result) {
-        case null:
-          break;
-        case final $ResultData<OutT> data:
-          source.container.runBinaryGuarded(listener, null, data.value);
-        case final $ResultError<OutT> error:
-          source.container
-              .runBinaryGuarded(onError, error.error, error.stackTrace);
-      }
-    }
 
     late final ProviderSubscriptionImpl<OutT, OriginStateT, OriginValueT> sub;
     final removeListener = listenable.addListener(
@@ -114,7 +102,6 @@ final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
-    required bool fireImmediately,
     required bool weak,
   }) {
     final element = source.readProviderElement(provider);
@@ -128,24 +115,12 @@ final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
     final innerSub = provider._addListener(
       source,
       (prev, next) {},
-      fireImmediately: false,
       weak: weak,
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
       onError: (err, stack) {},
     );
 
     final notifier = _lense(element);
-    if (fireImmediately) {
-      switch (notifier.result) {
-        case null:
-          break;
-        case final $ResultData<OutT> data:
-          source.container.runBinaryGuarded(listener, null, data.value);
-        case final $ResultError<OutT> error:
-          source.container
-              .runBinaryGuarded(onError, error.error, error.stackTrace);
-      }
-    }
 
     late ProviderSubscriptionView<OutT, OriginStateT, OriginValueT> sub;
     final removeListener = notifier.addListener(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved listener behavior to prevent using both immediate firing and weak listeners at the same time, ensuring more predictable notifications.

- **Refactor**
  - Simplified how immediate listener notifications are handled, centralizing this logic for better consistency.
  - Removed the immediate firing option from several internal listener methods, streamlining the subscription process for advanced use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->