### PR TITLE
Remove useless generic type

### DIFF
--- a/packages/flutter_riverpod/lib/src/core/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/core/consumer.dart
@@ -550,11 +550,11 @@ base class ConsumerStatefulElement extends StatefulElement
       onError: onError,
       fireImmediately: fireImmediately,
       // ignore: invalid_use_of_internal_member, from riverpod
-    ) as ProviderSubscriptionWithOrigin<ValueT, Object?, Object?>;
+    ) as ProviderSubscriptionWithOrigin<ValueT, Object?>;
 
     // ignore: invalid_use_of_internal_member, from riverpod
-    late final ProviderSubscriptionView<ValueT, Object?, Object?> sub;
-    sub = ProviderSubscriptionView<ValueT, Object?, Object?>(
+    late final ProviderSubscriptionView<ValueT, Object?> sub;
+    sub = ProviderSubscriptionView<ValueT, Object?>(
       innerSubscription: innerSubscription,
       listener: (prev, next) {},
       onError: (error, stackTrace) {},

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -22,7 +22,7 @@ sealed class Refreshable<StateT> implements ProviderListenable<StateT> {}
 base mixin _ProviderRefreshable<OutT, OriginStateT, OriginValueT>
     implements
         Refreshable<OutT>,
-        ProviderListenableWithOrigin<OutT, OriginStateT, OriginValueT> {
+        ProviderListenableWithOrigin<OutT, OriginStateT> {
   $ProviderBaseImpl<OriginStateT, OriginValueT> get provider;
 }
 
@@ -415,7 +415,7 @@ abstract class ProviderElement<StateT, ValueT> implements Node {
   @visibleForTesting
   List<ProviderSubscription>? subscriptions;
   @visibleForTesting
-  List<ProviderSubscriptionWithOrigin<Object?, StateT, ValueT>>? dependents;
+  List<ProviderSubscriptionWithOrigin<Object?, StateT>>? dependents;
 
   /// "listen(weak: true)" pointing to this provider.
   ///
@@ -423,8 +423,7 @@ abstract class ProviderElement<StateT, ValueT> implements Node {
   /// - They do not count towards [ProviderElement.isActive].
   /// - They may be reused between two instances of a [ProviderElement].
   @visibleForTesting
-  final weakDependents =
-      <ProviderSubscriptionWithOrigin<Object?, StateT, ValueT>>[];
+  final weakDependents = <ProviderSubscriptionWithOrigin<Object?, StateT>>[];
 
   bool _mustRecomputeState = false;
   bool _dependencyMayHaveChanged = false;
@@ -909,7 +908,7 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     );
 
     switch (sub) {
-      case final ProviderSubscriptionImpl<Object?, Object?, Object?> sub:
+      case final ProviderSubscriptionImpl<Object?, Object?> sub:
         sub._listenedElement.addDependentSubscription(sub);
     }
 
@@ -937,7 +936,7 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
   }
 
   void addDependentSubscription(
-    ProviderSubscriptionImpl<Object?, StateT, ValueT> sub,
+    ProviderSubscriptionImpl<Object?, StateT> sub,
   ) {
     _onChangeSubscription(sub, () {
       if (sub.weak) {
@@ -1189,8 +1188,7 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     void Function(ProviderElement element) elementVisitor,
   ) {
     void lookup(
-      Iterable<ProviderSubscriptionWithOrigin<Object?, Object?, Object?>>
-          children,
+      Iterable<ProviderSubscriptionWithOrigin<Object?, Object?>> children,
     ) {
       for (final child in children) {
         switch (child.source) {
@@ -1227,7 +1225,7 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
         final sub = subscriptions[i];
 
         switch (sub) {
-          case final ProviderSubscriptionImpl<Object?, Object?, Object?> sub:
+          case final ProviderSubscriptionImpl<Object?, Object?> sub:
             visitor(sub._listenedElement);
         }
       }

--- a/packages/riverpod/lib/src/core/foundation.dart
+++ b/packages/riverpod/lib/src/core/foundation.dart
@@ -178,10 +178,10 @@ String shortHash(Object? object) {
 }
 
 @internal
-base mixin ProviderListenableWithOrigin<OutT, OriginStateT, OriginValueT>
+base mixin ProviderListenableWithOrigin<OutT, OriginStateT>
     on ProviderListenable<OutT> {
   @override
-  ProviderSubscriptionWithOrigin<OutT, OriginStateT, OriginValueT> _addListener(
+  ProviderSubscriptionWithOrigin<OutT, OriginStateT> _addListener(
     Node source,
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -193,7 +193,7 @@ base mixin ProviderListenableWithOrigin<OutT, OriginStateT, OriginValueT>
   ProviderListenable<Selected> select<Selected>(
     Selected Function(OutT value) selector,
   ) {
-    return _ProviderSelector<OutT, Selected, OriginStateT, OriginValueT>(
+    return _ProviderSelector<OutT, Selected, OriginStateT>(
       provider: this,
       selector: selector,
     );

--- a/packages/riverpod/lib/src/core/foundation.dart
+++ b/packages/riverpod/lib/src/core/foundation.dart
@@ -179,7 +179,7 @@ String shortHash(Object? object) {
 
 @internal
 base mixin ProviderListenableWithOrigin<OutT, OriginStateT>
-    on ProviderListenable<OutT> {
+    implements ProviderListenable<OutT> {
   @override
   ProviderSubscriptionWithOrigin<OutT, OriginStateT> _addListener(
     Node source,
@@ -209,7 +209,8 @@ base mixin ProviderListenableWithOrigin<OutT, OriginStateT>
 @immutable
 @publicInCodegen
 @publicInMisc
-base mixin ProviderListenable<StateT> implements ProviderListenableOrFamily {
+abstract final class ProviderListenable<StateT>
+    implements ProviderListenableOrFamily {
   /// Starts listening to this transformer
   ProviderSubscription<StateT> _addListener(
     Node source,

--- a/packages/riverpod/lib/src/core/modifiers/select.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select.dart
@@ -2,9 +2,7 @@ part of '../../framework.dart';
 
 /// An internal class for `ProviderBase.select`.
 final class _ProviderSelector<InputT, OutputT, OriginStateT>
-    with
-        ProviderListenable<OutputT>,
-        ProviderListenableWithOrigin<OutputT, OriginStateT> {
+    with ProviderListenableWithOrigin<OutputT, OriginStateT> {
   /// An internal class for `ProviderBase.select`.
   _ProviderSelector({
     required this.provider,

--- a/packages/riverpod/lib/src/core/modifiers/select.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select.dart
@@ -1,10 +1,10 @@
 part of '../../framework.dart';
 
 /// An internal class for `ProviderBase.select`.
-final class _ProviderSelector<InputT, OutputT, OriginStateT, OriginValueT>
+final class _ProviderSelector<InputT, OutputT, OriginStateT>
     with
         ProviderListenable<OutputT>,
-        ProviderListenableWithOrigin<OutputT, OriginStateT, OriginValueT> {
+        ProviderListenableWithOrigin<OutputT, OriginStateT> {
   /// An internal class for `ProviderBase.select`.
   _ProviderSelector({
     required this.provider,
@@ -12,8 +12,7 @@ final class _ProviderSelector<InputT, OutputT, OriginStateT, OriginValueT>
   });
 
   /// The provider that was selected
-  final ProviderListenableWithOrigin<InputT, OriginStateT, OriginValueT>
-      provider;
+  final ProviderListenableWithOrigin<InputT, OriginStateT> provider;
 
   /// The selector applied
   final OutputT Function(InputT) selector;
@@ -57,16 +56,14 @@ final class _ProviderSelector<InputT, OutputT, OriginStateT, OriginValueT>
   }
 
   @override
-  ProviderSubscriptionWithOrigin<OutputT, OriginStateT, OriginValueT>
-      _addListener(
+  ProviderSubscriptionWithOrigin<OutputT, OriginStateT> _addListener(
     Node node,
     void Function(OutputT? previous, OutputT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
     required bool weak,
   }) {
-    late final ProviderSubscriptionView<OutputT, OriginStateT, OriginValueT>
-        providerSub;
+    late final ProviderSubscriptionView<OutputT, OriginStateT> providerSub;
     $Result<OutputT>? lastSelectedValue;
     final sub = provider._addListener(
       node,
@@ -97,8 +94,7 @@ final class _ProviderSelector<InputT, OutputT, OriginStateT, OriginValueT>
       );
     }
 
-    return providerSub =
-        ProviderSubscriptionView<OutputT, OriginStateT, OriginValueT>(
+    return providerSub = ProviderSubscriptionView<OutputT, OriginStateT>(
       innerSubscription: sub,
       listener: listener,
       onError: onError,

--- a/packages/riverpod/lib/src/core/modifiers/select_async.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select_async.dart
@@ -2,9 +2,7 @@ part of '../../framework.dart';
 
 /// An internal class for `ProviderBase.selectAsync`.
 final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
-    with
-        ProviderListenable<Future<OutputT>>,
-        ProviderListenableWithOrigin<Future<OutputT>, OriginStateT> {
+    with ProviderListenableWithOrigin<Future<OutputT>, OriginStateT> {
   /// An internal class for `ProviderBase.select`.
   _AsyncSelector({
     required this.provider,

--- a/packages/riverpod/lib/src/core/modifiers/select_async.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select_async.dart
@@ -4,8 +4,7 @@ part of '../../framework.dart';
 final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
     with
         ProviderListenable<Future<OutputT>>,
-        ProviderListenableWithOrigin<Future<OutputT>, OriginStateT,
-            OriginValueT> {
+        ProviderListenableWithOrigin<Future<OutputT>, OriginStateT> {
   /// An internal class for `ProviderBase.select`.
   _AsyncSelector({
     required this.provider,
@@ -14,12 +13,10 @@ final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
   });
 
   /// The provider that was selected
-  final ProviderListenableWithOrigin<AsyncValue<InputT>, OriginStateT,
-      OriginValueT> provider;
+  final ProviderListenableWithOrigin<AsyncValue<InputT>, OriginStateT> provider;
 
   /// The future associated to the listened provider
-  final ProviderListenableWithOrigin<Future<InputT>, OriginStateT, OriginValueT>
-      future;
+  final ProviderListenableWithOrigin<Future<InputT>, OriginStateT> future;
 
   /// The selector applied
   final OutputT Function(InputT) selector;
@@ -37,16 +34,15 @@ final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
   }
 
   @override
-  ProviderSubscriptionWithOrigin<Future<OutputT>, OriginStateT, OriginValueT>
-      _addListener(
+  ProviderSubscriptionWithOrigin<Future<OutputT>, OriginStateT> _addListener(
     Node node,
     void Function(Future<OutputT>? previous, Future<OutputT> next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
     required bool weak,
   }) {
-    late final ProviderSubscriptionView<Future<OutputT>, OriginStateT,
-        OriginValueT> providerSub;
+    late final ProviderSubscriptionView<Future<OutputT>, OriginStateT>
+        providerSub;
 
     $Result<OutputT>? lastSelectedValue;
     Completer<OutputT>? selectedCompleter;
@@ -155,7 +151,7 @@ final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
     playValue(sub.read(), callListeners: false);
 
     return providerSub =
-        ProviderSubscriptionView<Future<OutputT>, OriginStateT, OriginValueT>(
+        ProviderSubscriptionView<Future<OutputT>, OriginStateT>(
       innerSubscription: sub,
       listener: listener,
       onError: onError,

--- a/packages/riverpod/lib/src/core/provider/provider.dart
+++ b/packages/riverpod/lib/src/core/provider/provider.dart
@@ -90,7 +90,7 @@ sealed class ProviderBase<StateT> extends ProviderOrFamily
 @internal
 abstract final class $ProviderBaseImpl<StateT, ValueT>
     extends ProviderBase<StateT>
-    with ProviderListenableWithOrigin<StateT, StateT, ValueT> {
+    with ProviderListenableWithOrigin<StateT, StateT> {
   /// A base class for _all_ providers.
   const $ProviderBaseImpl({
     required super.name,
@@ -103,7 +103,7 @@ abstract final class $ProviderBaseImpl<StateT, ValueT>
   });
 
   @override
-  ProviderSubscriptionWithOrigin<StateT, StateT, ValueT> _addListener(
+  ProviderSubscriptionWithOrigin<StateT, StateT> _addListener(
     Node source,
     void Function(StateT? previous, StateT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,

--- a/packages/riverpod/lib/src/core/provider/provider.dart
+++ b/packages/riverpod/lib/src/core/provider/provider.dart
@@ -23,8 +23,10 @@ typedef OnError = void Function(Object error, StackTrace stackTrace);
 @immutable
 @publicInMisc
 sealed class ProviderBase<StateT> extends ProviderOrFamily
-    with ProviderListenable<StateT>
-    implements Refreshable<StateT>, _ProviderOverride {
+    implements
+        ProviderListenable<StateT>,
+        Refreshable<StateT>,
+        _ProviderOverride {
   /// A base class for _all_ providers.
   const ProviderBase({
     required super.name,

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -960,7 +960,7 @@ final class ProviderContainer implements Node {
     );
 
     switch (sub) {
-      case final ProviderSubscriptionImpl<Object?, Object?, Object?> sub:
+      case final ProviderSubscriptionImpl<Object?, Object?> sub:
         sub._listenedElement.addDependentSubscription(sub);
     }
 

--- a/packages/riverpod/lib/src/core/provider_subscription.dart
+++ b/packages/riverpod/lib/src/core/provider_subscription.dart
@@ -52,10 +52,10 @@ sealed class ProviderSubscription<OutT> {
 }
 
 @internal
-sealed class ProviderSubscriptionWithOrigin<OutT, StateT, ValueT>
+sealed class ProviderSubscriptionWithOrigin<OutT, StateT>
     extends ProviderSubscription<OutT> implements Pausable {
   ProviderBase<StateT> get origin;
-  ProviderElement<StateT, ValueT> get _listenedElement;
+  ProviderElement<StateT, Object?> get _listenedElement;
 
   void _onOriginData(StateT? prev, StateT next);
   void _onOriginError(Object error, StackTrace stackTrace);
@@ -77,9 +77,8 @@ sealed class ProviderSubscriptionWithOrigin<OutT, StateT, ValueT>
 }
 
 @internal
-abstract base class ProviderSubscriptionImpl<OutT, OriginT, ValueT>
-    extends ProviderSubscriptionWithOrigin<OutT, OriginT, ValueT>
-    with _OnPauseMixin {
+abstract base class ProviderSubscriptionImpl<OutT, OriginT>
+    extends ProviderSubscriptionWithOrigin<OutT, OriginT> with _OnPauseMixin {
   @override
   bool get isPaused => _isPaused;
 
@@ -196,8 +195,8 @@ mixin _OnPauseMixin on Pausable {
 }
 
 @internal
-base class ProviderSubscriptionView<OutT, OriginStateT, OriginValueT>
-    extends ProviderSubscriptionImpl<OutT, OriginStateT, OriginValueT> {
+base class ProviderSubscriptionView<OutT, OriginStateT>
+    extends ProviderSubscriptionImpl<OutT, OriginStateT> {
   ProviderSubscriptionView({
     required this.innerSubscription,
     required OutT Function() read,
@@ -210,8 +209,7 @@ base class ProviderSubscriptionView<OutT, OriginStateT, OriginValueT>
         _errorListener = onError ??
             innerSubscription._listenedElement.container.defaultOnError;
 
-  final ProviderSubscriptionWithOrigin<Object?, OriginStateT, OriginValueT>
-      innerSubscription;
+  final ProviderSubscriptionWithOrigin<Object?, OriginStateT> innerSubscription;
   final OutT Function() _read;
   final void Function()? _onClose;
 
@@ -225,7 +223,7 @@ base class ProviderSubscriptionView<OutT, OriginStateT, OriginValueT>
   ProviderBase<OriginStateT> get origin => innerSubscription.origin;
 
   @override
-  ProviderElement<OriginStateT, OriginValueT> get _listenedElement =>
+  ProviderElement<OriginStateT, Object?> get _listenedElement =>
       innerSubscription._listenedElement;
 
   @override
@@ -277,8 +275,7 @@ base class ProviderSubscriptionView<OutT, OriginStateT, OriginValueT>
 
 @internal
 final class DelegatingProviderSubscription<OutT, InT, OriginStateT,
-        OriginValueT>
-    extends ProviderSubscriptionImpl<OutT, OriginStateT, OriginValueT> {
+    OriginValueT> extends ProviderSubscriptionImpl<OutT, OriginStateT> {
   DelegatingProviderSubscription({
     required this.origin,
     required this.source,
@@ -338,7 +335,7 @@ final class DelegatingProviderSubscription<OutT, InT, OriginStateT,
 /// When a provider listens to another provider using `listen`
 @internal
 final class ProviderStateSubscription<StateT, ValueT>
-    extends ProviderSubscriptionImpl<StateT, StateT, ValueT> {
+    extends ProviderSubscriptionImpl<StateT, StateT> {
   ProviderStateSubscription({
     required this.source,
     required this.weak,

--- a/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
+++ b/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
@@ -5,7 +5,7 @@ part of '../framework.dart';
 final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
     with
         ProviderListenable<OutT>,
-        ProviderListenableWithOrigin<OutT, OriginStateT, OriginValueT> {
+        ProviderListenableWithOrigin<OutT, OriginStateT> {
   $LazyProxyListenable(this.provider, this._lense);
 
   final $ProviderBaseImpl<OriginStateT, OriginValueT> provider;
@@ -14,7 +14,7 @@ final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
   ) _lense;
 
   @override
-  ProviderSubscriptionWithOrigin<OutT, OriginStateT, OriginValueT> _addListener(
+  ProviderSubscriptionWithOrigin<OutT, OriginStateT> _addListener(
     Node source,
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -25,7 +25,7 @@ final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
 
     final listenable = _lense(element);
 
-    late final ProviderSubscriptionImpl<OutT, OriginStateT, OriginValueT> sub;
+    late final ProviderSubscriptionImpl<OutT, OriginStateT> sub;
     final removeListener = listenable.addListener(
       (a, b) => sub._notifyData(a, b),
       onError: onError,
@@ -65,7 +65,7 @@ final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
 final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
     with
         ProviderListenable<OutT>,
-        ProviderListenableWithOrigin<OutT, OriginStateT, OriginValueT>,
+        ProviderListenableWithOrigin<OutT, OriginStateT>,
         _ProviderRefreshable<OutT, OriginStateT, OriginValueT> {
   /// An internal utility for reading alternate values of a provider.
   ///
@@ -97,7 +97,7 @@ final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
   ) _lense;
 
   @override
-  ProviderSubscriptionWithOrigin<OutT, OriginStateT, OriginValueT> _addListener(
+  ProviderSubscriptionWithOrigin<OutT, OriginStateT> _addListener(
     Node source,
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -122,14 +122,14 @@ final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
 
     final notifier = _lense(element);
 
-    late ProviderSubscriptionView<OutT, OriginStateT, OriginValueT> sub;
+    late ProviderSubscriptionView<OutT, OriginStateT> sub;
     final removeListener = notifier.addListener(
       (prev, next) => sub._notifyData(prev, next),
       onError: onError,
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
     );
 
-    return sub = ProviderSubscriptionView<OutT, OriginStateT, OriginValueT>(
+    return sub = ProviderSubscriptionView<OutT, OriginStateT>(
       innerSubscription: innerSub,
       onClose: removeListener,
       listener: listener,

--- a/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
+++ b/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
@@ -3,9 +3,7 @@ part of '../framework.dart';
 @internal
 @publicInCodegen
 final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
-    with
-        ProviderListenable<OutT>,
-        ProviderListenableWithOrigin<OutT, OriginStateT> {
+    with ProviderListenableWithOrigin<OutT, OriginStateT> {
   $LazyProxyListenable(this.provider, this._lense);
 
   final $ProviderBaseImpl<OriginStateT, OriginValueT> provider;
@@ -64,7 +62,6 @@ final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
 @internal
 final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
     with
-        ProviderListenable<OutT>,
         ProviderListenableWithOrigin<OutT, OriginStateT>,
         _ProviderRefreshable<OutT, OriginStateT, OriginValueT> {
   /// An internal utility for reading alternate values of a provider.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and unified generic type parameters across provider-related classes and methods, reducing complexity in the public API.
  - Updated type signatures for various provider subscription and listenable classes to remove unnecessary generic parameters.
  - No changes to runtime behavior or user-facing functionality. Existing usage of providers remains unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->