### PR TITLE
Simplify ProviderSubscription/ProviderListenable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         channel:
-          - stable
+          # - stable
           - master
         package_path:
           - examples/counter

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         channel:
-          # - stable
+          - stable
           - master
         package_path:
           - examples/counter
@@ -80,7 +80,8 @@ jobs:
             if grep -q flutter "pubspec.yaml"; then
               flutter test --coverage
             else
-              ${{github.workspace}}/scripts/coverage.sh
+              dart test
+              # ${{github.workspace}}/scripts/coverage.sh
             fi
           fi
 

--- a/packages/flutter_riverpod/lib/flutter_riverpod.dart
+++ b/packages/flutter_riverpod/lib/flutter_riverpod.dart
@@ -31,4 +31,5 @@ export 'src/internals.dart'
         WidgetRef,
         ProviderScope,
         UncontrolledProviderScope,
-        RiverpodWidgetTesterX;
+        RiverpodWidgetTesterX,
+        ProviderListenableSelect;

--- a/packages/flutter_riverpod/lib/src/core/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/core/consumer.dart
@@ -550,11 +550,11 @@ base class ConsumerStatefulElement extends StatefulElement
       onError: onError,
       fireImmediately: fireImmediately,
       // ignore: invalid_use_of_internal_member, from riverpod
-    ) as ProviderSubscriptionWithOrigin<ValueT, Object?>;
+    );
 
     // ignore: invalid_use_of_internal_member, from riverpod
-    late final ProviderSubscriptionView<ValueT, Object?> sub;
-    sub = ProviderSubscriptionView<ValueT, Object?>(
+    late final ExternalProviderSubscription<Object?, ValueT> sub;
+    sub = ExternalProviderSubscription<Object?, ValueT>(
       innerSubscription: innerSubscription,
       listener: (prev, next) {},
       onError: (error, stackTrace) {},

--- a/packages/flutter_riverpod/lib/src/core/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/core/consumer.dart
@@ -554,7 +554,7 @@ base class ConsumerStatefulElement extends StatefulElement
 
     // ignore: invalid_use_of_internal_member, from riverpod
     late final ExternalProviderSubscription<Object?, ValueT> sub;
-    sub = ExternalProviderSubscription<Object?, ValueT>(
+    sub = ExternalProviderSubscription<Object?, ValueT>.fromSub(
       innerSubscription: innerSubscription,
       listener: (prev, next) {},
       onError: (error, stackTrace) {},

--- a/packages/flutter_riverpod/lib/src/core/widget_ref.dart
+++ b/packages/flutter_riverpod/lib/src/core/widget_ref.dart
@@ -107,7 +107,7 @@ abstract final class WidgetRef {
   ///
   /// See also:
   ///
-  /// - [ProviderListenable.select], which allows a widget to filter rebuilds by
+  /// - [ProviderListenableSelect.select], which allows a widget to filter rebuilds by
   ///   observing only the selected properties.
   /// - [listen], to react to changes on a provider, such as for showing modals.
   T watch<T>(ProviderListenable<T> provider);

--- a/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
+++ b/packages/flutter_riverpod/lib/src/providers/legacy/change_notifier_provider.dart
@@ -70,7 +70,7 @@ import '../../builders.dart';
 @publicInLegacy
 final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
     extends $FunctionalProvider<NotifierT, NotifierT, NotifierT>
-    with LegacyProviderMixin<NotifierT, NotifierT> {
+    with LegacyProviderMixin<NotifierT> {
   /// {@macro riverpod.change_notifier_provider}
   ChangeNotifierProvider(
     this._createFn, {
@@ -121,7 +121,7 @@ final class ChangeNotifierProvider<NotifierT extends ChangeNotifier?>
   /// This may happen if the provider is refreshed or one of its dependencies
   /// has changes.
   Refreshable<NotifierT> get notifier =>
-      ProviderElementProxy<NotifierT, NotifierT, NotifierT>(
+      ProviderElementProxy<NotifierT, NotifierT>(
         this,
         (element) {
           return (element as _ChangeNotifierProviderElement<NotifierT>)

--- a/packages/hooks_riverpod/lib/hooks_riverpod.dart
+++ b/packages/hooks_riverpod/lib/hooks_riverpod.dart
@@ -33,4 +33,5 @@ export 'src/internals.dart'
         HookConsumerWidget,
         HookConsumer,
         StatefulHookConsumerWidget,
-        RiverpodWidgetTesterX;
+        RiverpodWidgetTesterX,
+        ProviderListenableSelect;

--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -22,4 +22,5 @@ export 'src/internals.dart'
         FamilyStreamNotifier,
         StreamNotifier,
         StreamNotifierProvider,
-        StreamProvider;
+        StreamProvider,
+        ProviderListenableSelect;

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -19,9 +19,9 @@ part of '../framework.dart';
 @publicInMisc
 sealed class Refreshable<StateT> implements ProviderListenable<StateT> {}
 
-base mixin _ProviderRefreshable<OutT, OriginStateT>
+base mixin _ProviderRefreshable<OutT, InT>
     implements Refreshable<OutT> {
-  $ProviderBaseImpl<OriginStateT> get provider;
+  $ProviderBaseImpl<InT> get provider;
 }
 
 /// A debug utility used by `flutter_riverpod`/`hooks_riverpod` to check

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -19,8 +19,7 @@ part of '../framework.dart';
 @publicInMisc
 sealed class Refreshable<StateT> implements ProviderListenable<StateT> {}
 
-base mixin _ProviderRefreshable<OutT, InT>
-    implements Refreshable<OutT> {
+base mixin _ProviderRefreshable<OutT, InT> implements Refreshable<OutT> {
   $ProviderBaseImpl<InT> get provider;
 }
 

--- a/packages/riverpod/lib/src/core/family.dart
+++ b/packages/riverpod/lib/src/core/family.dart
@@ -80,8 +80,8 @@ base class $Family extends Family {
 typedef SetupFamilyOverride<Arg> = void Function(
   Arg argument,
   void Function({
-    required $ProviderBaseImpl<Object?, Object?> origin,
-    required $ProviderBaseImpl<Object?, Object?> override,
+    required $ProviderBaseImpl<Object?> origin,
+    required $ProviderBaseImpl<Object?> override,
   }),
 );
 

--- a/packages/riverpod/lib/src/core/foundation.dart
+++ b/packages/riverpod/lib/src/core/foundation.dart
@@ -119,7 +119,7 @@ sealed class ProviderOrFamily implements ProviderListenableOrFamily {
 }
 
 extension on ProviderListenableOrFamily {
-  $ProviderBaseImpl<Object?, Object?>? get debugListenedProvider {
+  $ProviderBaseImpl<Object?>? get debugListenedProvider {
     final that = this;
     return switch (that) {
       $ProviderBaseImpl() => that,
@@ -177,29 +177,6 @@ String shortHash(Object? object) {
   return object.hashCode.toUnsigned(20).toRadixString(16).padLeft(5, '0');
 }
 
-@internal
-base mixin ProviderListenableWithOrigin<OutT, OriginStateT>
-    implements ProviderListenable<OutT> {
-  @override
-  ProviderSubscriptionWithOrigin<OutT, OriginStateT> _addListener(
-    Node source,
-    void Function(OutT? previous, OutT next) listener, {
-    required void Function(Object error, StackTrace stackTrace) onError,
-    required void Function()? onDependencyMayHaveChanged,
-    required bool weak,
-  });
-
-  @override
-  ProviderListenable<Selected> select<Selected>(
-    Selected Function(OutT value) selector,
-  ) {
-    return _ProviderSelector<OutT, Selected, OriginStateT>(
-      provider: this,
-      selector: selector,
-    );
-  }
-}
-
 /// A base class for all providers, used to consume a provider.
 ///
 /// It is used by [ProviderContainer.listen] and `ref.watch` to listen to
@@ -212,80 +189,11 @@ base mixin ProviderListenableWithOrigin<OutT, OriginStateT>
 abstract final class ProviderListenable<StateT>
     implements ProviderListenableOrFamily {
   /// Starts listening to this transformer
-  ProviderSubscription<StateT> _addListener(
+  ProviderSubscriptionImpl<StateT> _addListener(
     Node source,
     void Function(StateT? previous, StateT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
     required bool weak,
   });
-
-  /// Partially listen to a provider.
-  ///
-  /// The [select] function allows filtering unwanted rebuilds of a Widget
-  /// by reading only the properties that we care about.
-  ///
-  /// For example, consider the following `ChangeNotifier`:
-  ///
-  /// ```dart
-  /// class Person extends ChangeNotifier {
-  ///   int _age = 0;
-  ///   int get age => _age;
-  ///   set age(int age) {
-  ///     _age = age;
-  ///     notifyListeners();
-  ///   }
-  ///
-  ///   String _name = '';
-  ///   String get name => _name;
-  ///   set name(String name) {
-  ///     _name = name;
-  ///     notifyListeners();
-  ///   }
-  /// }
-  ///
-  /// final personProvider = ChangeNotifierProvider((_) => Person());
-  /// ```
-  ///
-  /// In this class, both `name` and `age` may change, but a widget may need
-  /// only `age`.
-  ///
-  /// If we used `ref.watch(`/`Consumer` as we normally would, this would cause
-  /// widgets that only use `age` to still rebuild when `name` changes, which
-  /// is inefficient.
-  ///
-  /// The method [select] can be used to fix this, by explicitly reading only
-  /// a specific part of the object.
-  ///
-  /// A typical usage would be:
-  ///
-  /// ```dart
-  /// @override
-  /// Widget build(BuildContext context, WidgetRef ref) {
-  ///   final age = ref.watch(personProvider.select((p) => p.age));
-  ///   return Text('$age');
-  /// }
-  /// ```
-  ///
-  /// This will cause our widget to rebuild **only** when `age` changes.
-  ///
-  ///
-  /// **NOTE**: The function passed to [select] can return complex computations
-  /// too.
-  ///
-  /// For example, instead of `age`, we could return a "isAdult" boolean:
-  ///
-  /// ```dart
-  /// @override
-  /// Widget build(BuildContext context, WidgetRef ref) {
-  ///   final isAdult = ref.watch(personProvider.select((p) => p.age >= 18));
-  ///   return Text('$isAdult');
-  /// }
-  /// ```
-  ///
-  /// This will further optimize our widget by rebuilding it only when "isAdult"
-  /// changed instead of whenever the age changes.
-  ProviderListenable<Selected> select<Selected>(
-    Selected Function(StateT value) selector,
-  );
 }

--- a/packages/riverpod/lib/src/core/modifiers/future.dart
+++ b/packages/riverpod/lib/src/core/modifiers/future.dart
@@ -78,8 +78,7 @@ mixin $AsyncClassModifier<ValueT, CreatedT>
 /// Do not use.
 @internal
 @publicInCodegen
-base mixin $FutureModifier<ValueT>
-    on $ProviderBaseImpl<AsyncValue<ValueT>, ValueT> {
+base mixin $FutureModifier<ValueT> on $ProviderBaseImpl<AsyncValue<ValueT>> {
   /// Obtains the [Future] representing this provider.
   ///
   /// The instance of [Future] obtained may change over time. This typically
@@ -102,8 +101,8 @@ base mixin $FutureModifier<ValueT>
   /// ```
   Refreshable<Future<ValueT>> get future => _future;
 
-  _ProviderRefreshable<Future<ValueT>, AsyncValue<ValueT>, ValueT> get _future {
-    return ProviderElementProxy<Future<ValueT>, AsyncValue<ValueT>, ValueT>(
+  _ProviderRefreshable<Future<ValueT>, AsyncValue<ValueT>> get _future {
+    return ProviderElementProxy<Future<ValueT>, AsyncValue<ValueT>>(
       this,
       (element) {
         element as FutureModifierElement<ValueT>;
@@ -145,7 +144,7 @@ base mixin $FutureModifier<ValueT>
   ProviderListenable<Future<Output>> selectAsync<Output>(
     Output Function(ValueT data) selector,
   ) {
-    return _AsyncSelector<ValueT, Output, AsyncValue<ValueT>, ValueT>(
+    return _AsyncSelector<ValueT, Output>(
       selector: selector,
       provider: this,
       future: _future,

--- a/packages/riverpod/lib/src/core/modifiers/select.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select.dart
@@ -169,7 +169,7 @@ final class _ProviderSelector<InputT, OutputT>
       );
     }
 
-    return providerSub = ExternalProviderSubscription<InputT, OutputT>(
+    return providerSub = ExternalProviderSubscription<InputT, OutputT>.fromSub(
       innerSubscription: sub,
       listener: listener,
       onError: onError,

--- a/packages/riverpod/lib/src/core/modifiers/select_async.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select_async.dart
@@ -1,8 +1,8 @@
 part of '../../framework.dart';
 
 /// An internal class for `ProviderBase.selectAsync`.
-final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
-    with ProviderListenableWithOrigin<Future<OutputT>, OriginStateT> {
+final class _AsyncSelector<InputT, OutputT>
+    implements ProviderListenable<Future<OutputT>> {
   /// An internal class for `ProviderBase.select`.
   _AsyncSelector({
     required this.provider,
@@ -11,10 +11,10 @@ final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
   });
 
   /// The provider that was selected
-  final ProviderListenableWithOrigin<AsyncValue<InputT>, OriginStateT> provider;
+  final ProviderListenable<AsyncValue<InputT>> provider;
 
   /// The future associated to the listened provider
-  final ProviderListenableWithOrigin<Future<InputT>, OriginStateT> future;
+  final ProviderListenable<Future<InputT>> future;
 
   /// The selector applied
   final OutputT Function(InputT) selector;
@@ -32,14 +32,14 @@ final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
   }
 
   @override
-  ProviderSubscriptionWithOrigin<Future<OutputT>, OriginStateT> _addListener(
+  ProviderSubscriptionImpl<Future<OutputT>> _addListener(
     Node node,
     void Function(Future<OutputT>? previous, Future<OutputT> next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
     required void Function()? onDependencyMayHaveChanged,
     required bool weak,
   }) {
-    late final ProviderSubscriptionView<Future<OutputT>, OriginStateT>
+    late final ExternalProviderSubscription<AsyncValue<InputT>, Future<OutputT>>
         providerSub;
 
     $Result<OutputT>? lastSelectedValue;
@@ -149,7 +149,7 @@ final class _AsyncSelector<InputT, OutputT, OriginStateT, OriginValueT>
     playValue(sub.read(), callListeners: false);
 
     return providerSub =
-        ProviderSubscriptionView<Future<OutputT>, OriginStateT>(
+        ExternalProviderSubscription<AsyncValue<InputT>, Future<OutputT>>(
       innerSubscription: sub,
       listener: listener,
       onError: onError,

--- a/packages/riverpod/lib/src/core/modifiers/select_async.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select_async.dart
@@ -148,8 +148,8 @@ final class _AsyncSelector<InputT, OutputT>
 
     playValue(sub.read(), callListeners: false);
 
-    return providerSub =
-        ExternalProviderSubscription<AsyncValue<InputT>, Future<OutputT>>(
+    return providerSub = ExternalProviderSubscription<AsyncValue<InputT>,
+        Future<OutputT>>.fromSub(
       innerSubscription: sub,
       listener: listener,
       onError: onError,

--- a/packages/riverpod/lib/src/core/override.dart
+++ b/packages/riverpod/lib/src/core/override.dart
@@ -12,7 +12,7 @@ sealed class _ProviderOverride implements Override {}
 
 extension on _ProviderOverride {
   /// The provider that is overridden.
-  $ProviderBaseImpl<Object?, Object?> get origin {
+  $ProviderBaseImpl<Object?> get origin {
     final that = this;
     return switch (that) {
       $ProviderBaseImpl() => that,
@@ -21,7 +21,7 @@ extension on _ProviderOverride {
   }
 
   /// The new provider behavior.
-  $ProviderBaseImpl<Object?, Object?> get providerOverride {
+  $ProviderBaseImpl<Object?> get providerOverride {
     final that = this;
     return switch (that) {
       $ProviderBaseImpl() => that,
@@ -61,10 +61,10 @@ class $ProviderOverride implements _ProviderOverride {
   });
 
   /// The provider that is overridden.
-  final $ProviderBaseImpl<Object?, Object?> origin;
+  final $ProviderBaseImpl<Object?> origin;
 
   /// The new provider behavior.
-  final $ProviderBaseImpl<Object?, Object?> providerOverride;
+  final $ProviderBaseImpl<Object?> providerOverride;
 
   @mustBeOverridden
   @override
@@ -84,10 +84,10 @@ class TransitiveProviderOverride implements $ProviderOverride {
   TransitiveProviderOverride(this.origin);
 
   @override
-  final $ProviderBaseImpl<Object?, Object?> origin;
+  final $ProviderBaseImpl<Object?> origin;
 
   @override
-  $ProviderBaseImpl<Object?, Object?> get providerOverride => origin;
+  $ProviderBaseImpl<Object?> get providerOverride => origin;
 
   @override
   String toString() => '$origin';

--- a/packages/riverpod/lib/src/core/override_with_value.dart
+++ b/packages/riverpod/lib/src/core/override_with_value.dart
@@ -2,8 +2,8 @@ part of '../framework.dart';
 
 @reopen
 abstract base class _ValueProvider<StateT, ValueT>
-    extends $ProviderBaseImpl<StateT, ValueT>
-    with LegacyProviderMixin<StateT, ValueT> {
+    extends $ProviderBaseImpl<StateT>
+    with LegacyProviderMixin<StateT> {
   /// Creates a [_ValueProvider].
   const _ValueProvider(this._value)
       : super(

--- a/packages/riverpod/lib/src/core/override_with_value.dart
+++ b/packages/riverpod/lib/src/core/override_with_value.dart
@@ -2,8 +2,7 @@ part of '../framework.dart';
 
 @reopen
 abstract base class _ValueProvider<StateT, ValueT>
-    extends $ProviderBaseImpl<StateT>
-    with LegacyProviderMixin<StateT> {
+    extends $ProviderBaseImpl<StateT> with LegacyProviderMixin<StateT> {
   /// Creates a [_ValueProvider].
   const _ValueProvider(this._value)
       : super(

--- a/packages/riverpod/lib/src/core/provider/functional_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/functional_provider.dart
@@ -9,7 +9,7 @@ abstract base class $FunctionalProvider< //
         StateT,
         ValueT,
         CreatedT> //
-    extends $ProviderBaseImpl<StateT, ValueT> {
+    extends $ProviderBaseImpl<StateT> {
   /// Implementation detail of `riverpod_generator`.
   /// Do not use, as this can be removed at any time.
   const $FunctionalProvider({

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -355,7 +355,7 @@ abstract base class $ClassProvider< //
     NotifierT extends AnyNotifier<StateT, ValueT>,
     StateT,
     ValueT,
-    CreatedT> extends $ProviderBaseImpl<StateT, ValueT> {
+    CreatedT> extends $ProviderBaseImpl<StateT> {
   const $ClassProvider({
     required super.name,
     required super.from,
@@ -367,7 +367,7 @@ abstract base class $ClassProvider< //
   });
 
   Refreshable<NotifierT> get notifier {
-    return ProviderElementProxy<NotifierT, StateT, ValueT>(
+    return ProviderElementProxy<NotifierT, StateT>(
       this,
       (element) => (element
               as $ClassProviderElement<NotifierT, StateT, ValueT, CreatedT>)

--- a/packages/riverpod/lib/src/core/provider/provider.dart
+++ b/packages/riverpod/lib/src/core/provider/provider.dart
@@ -90,9 +90,7 @@ sealed class ProviderBase<StateT> extends ProviderOrFamily
 /// A base class for _all_ providers.
 @immutable
 @internal
-abstract final class $ProviderBaseImpl<StateT, ValueT>
-    extends ProviderBase<StateT>
-    with ProviderListenableWithOrigin<StateT, StateT> {
+abstract final class $ProviderBaseImpl<StateT> extends ProviderBase<StateT> {
   /// A base class for _all_ providers.
   const $ProviderBaseImpl({
     required super.name,
@@ -105,7 +103,7 @@ abstract final class $ProviderBaseImpl<StateT, ValueT>
   });
 
   @override
-  ProviderSubscriptionWithOrigin<StateT, StateT> _addListener(
+  ProviderProviderSubscription<StateT> _addListener(
     Node source,
     void Function(StateT? previous, StateT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -116,7 +114,7 @@ abstract final class $ProviderBaseImpl<StateT, ValueT>
 
     if (!weak) element.flush();
 
-    return ProviderStateSubscription<StateT, ValueT>(
+    return ProviderProviderSubscription<StateT>(
       source: source,
       listenedElement: element,
       weak: weak,
@@ -127,13 +125,12 @@ abstract final class $ProviderBaseImpl<StateT, ValueT>
 
   @override
   @visibleForOverriding
-  ElementWithFuture<StateT, ValueT> $createElement($ProviderPointer pointer);
+  ElementWithFuture<StateT, Object?> $createElement($ProviderPointer pointer);
 }
 
 /// A mixin that implements some methods for non-generic providers.
 @internal
-base mixin LegacyProviderMixin<StateT, ValueT>
-    on $ProviderBaseImpl<StateT, ValueT> {
+base mixin LegacyProviderMixin<StateT> on $ProviderBaseImpl<StateT> {
   @override
   int get hashCode {
     if (from == null) return super.hashCode;
@@ -146,7 +143,7 @@ base mixin LegacyProviderMixin<StateT, ValueT>
     if (from == null) return identical(other, this);
 
     return other.runtimeType == runtimeType &&
-        other is $ProviderBaseImpl<StateT, ValueT> &&
+        other is $ProviderBaseImpl<StateT> &&
         other.from == from &&
         other.argument == argument;
   }

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -5,8 +5,8 @@ part of '../framework.dart';
 @internal
 sealed class Node {
   /// Obtain the [ProviderElement] of a provider, creating it if necessary.
-  ProviderElement<StateT, ValueT> _readProviderElement<StateT, ValueT>(
-    $ProviderBaseImpl<StateT, ValueT> provider,
+  ProviderElement<StateT, Object?> _readProviderElement<StateT>(
+    $ProviderBaseImpl<StateT> provider,
   );
 }
 
@@ -48,7 +48,7 @@ class $ProviderPointer implements _PointerBase {
   bool get isTransitiveOverride =>
       providerOverride is TransitiveProviderOverride;
 
-  final $ProviderBaseImpl<Object?, Object?> origin;
+  final $ProviderBaseImpl<Object?> origin;
 
   /// The override associated with this provider, if any.
   ///
@@ -150,7 +150,7 @@ class ProviderDirectory implements _PointerBase {
   /// This override may be implicitly created by [ProviderOrFamily.$allTransitiveDependencies].
   // ignore: library_private_types_in_public_api, not public API
   _FamilyOverride? familyOverride;
-  final HashMap<$ProviderBaseImpl<Object?, Object?>, $ProviderPointer> pointers;
+  final HashMap<$ProviderBaseImpl<Object?>, $ProviderPointer> pointers;
   @override
   ProviderContainer targetContainer;
 
@@ -169,7 +169,7 @@ class ProviderDirectory implements _PointerBase {
   }
 
   $ProviderPointer upsertPointer(
-    $ProviderBaseImpl<Object?, Object?> provider, {
+    $ProviderBaseImpl<Object?> provider, {
     required ProviderContainer currentContainer,
   }) {
     return pointers._upsert(
@@ -194,7 +194,7 @@ class ProviderDirectory implements _PointerBase {
   ///
   /// Non-overridden providers are mounted in the root container.
   $ProviderPointer mount(
-    $ProviderBaseImpl<Object?, Object?> origin, {
+    $ProviderBaseImpl<Object?> origin, {
     required ProviderContainer currentContainer,
   }) {
     final pointer = upsertPointer(
@@ -457,7 +457,7 @@ class ProviderPointerManager {
   }
 
   ProviderDirectory? readDirectory(
-    $ProviderBaseImpl<Object?, Object?> provider,
+    $ProviderBaseImpl<Object?> provider,
   ) {
     final from = provider.from;
 
@@ -468,16 +468,16 @@ class ProviderPointerManager {
     }
   }
 
-  $ProviderPointer? readPointer($ProviderBaseImpl<Object?, Object?> provider) {
+  $ProviderPointer? readPointer($ProviderBaseImpl<Object?> provider) {
     return readDirectory(provider)?.pointers[provider];
   }
 
-  ProviderElement? readElement($ProviderBaseImpl<Object?, Object?> provider) {
+  ProviderElement? readElement($ProviderBaseImpl<Object?> provider) {
     return readPointer(provider)?.element;
   }
 
   ProviderDirectory upsertDirectory(
-    $ProviderBaseImpl<Object?, Object?> provider,
+    $ProviderBaseImpl<Object?> provider,
   ) {
     final from = provider.from;
 
@@ -488,14 +488,14 @@ class ProviderPointerManager {
     }
   }
 
-  $ProviderPointer upsertPointer($ProviderBaseImpl<Object?, Object?> provider) {
+  $ProviderPointer upsertPointer($ProviderBaseImpl<Object?> provider) {
     return upsertDirectory(provider).mount(
       provider,
       currentContainer: container,
     );
   }
 
-  ProviderElement upsertElement($ProviderBaseImpl<Object?, Object?> provider) {
+  ProviderElement upsertElement($ProviderBaseImpl<Object?> provider) {
     return upsertPointer(provider).element!;
   }
 
@@ -523,7 +523,7 @@ class ProviderPointerManager {
   /// Noop if the provider is from an override or doesn't exist.
   ///
   /// Returns the associated pointer, even if it was not removed.
-  $ProviderPointer? remove($ProviderBaseImpl<Object?, Object?> provider) {
+  $ProviderPointer? remove($ProviderBaseImpl<Object?> provider) {
     final directory = readDirectory(provider);
     if (directory == null) return null;
 
@@ -732,8 +732,8 @@ extension InternalProviderContainer on ProviderContainer {
 
 @internal
 extension NodeInternal on Node {
-  ProviderElement<State, ValueT> readProviderElement<State, ValueT>(
-    $ProviderBaseImpl<State, ValueT> provider,
+  ProviderElement<State, Object?> readProviderElement<State>(
+    $ProviderBaseImpl<State> provider,
   ) =>
       _readProviderElement(provider);
 }
@@ -959,10 +959,7 @@ final class ProviderContainer implements Node {
       onError: onError,
     );
 
-    switch (sub) {
-      case final ProviderSubscriptionImpl<Object?, Object?> sub:
-        sub._listenedElement.addDependentSubscription(sub);
-    }
+    sub.impl._listenedElement.addDependentSubscription(sub.impl);
 
     return sub;
   }
@@ -973,7 +970,7 @@ final class ProviderContainer implements Node {
     bool asReload = false,
   }) {
     switch (provider) {
-      case $ProviderBaseImpl<Object?, Object?>():
+      case $ProviderBaseImpl<Object?>():
         _pointerManager
             .readElement(provider)
             ?.invalidateSelf(asReload: asReload);
@@ -987,9 +984,8 @@ final class ProviderContainer implements Node {
   /// {@macro riverpod.refresh}
   StateT refresh<StateT>(Refreshable<StateT> refreshable) {
     final providerToRefresh = switch (refreshable) {
-      final $ProviderBaseImpl<Object?, Object?> p => p,
-      _ProviderRefreshable<Object?, Object?, Object?>(:final provider) =>
-        provider
+      final $ProviderBaseImpl<Object?> p => p,
+      _ProviderRefreshable<Object?, Object?>(:final provider) => provider
     };
     invalidate(providerToRefresh);
 
@@ -997,7 +993,7 @@ final class ProviderContainer implements Node {
   }
 
   void _recursivePointerRemoval(
-    $ProviderBaseImpl<Object?, Object?> provider,
+    $ProviderBaseImpl<Object?> provider,
     $ProviderPointer pointer,
   ) {
     for (final child in _children) {
@@ -1013,7 +1009,7 @@ final class ProviderContainer implements Node {
     _pointerManager.remove(provider);
   }
 
-  void _disposeProvider($ProviderBaseImpl<Object?, Object?> provider) {
+  void _disposeProvider($ProviderBaseImpl<Object?> provider) {
     final pointer = _pointerManager.remove(provider);
     // The provider is already disposed, so we don't need to do anything
     if (pointer == null) return;
@@ -1098,8 +1094,8 @@ final class ProviderContainer implements Node {
   }
 
   @override
-  ProviderElement<StateT, ValueT> _readProviderElement<StateT, ValueT>(
-    $ProviderBaseImpl<StateT, ValueT> provider,
+  ProviderElement<StateT, Object?> _readProviderElement<StateT>(
+    $ProviderBaseImpl<StateT> provider,
   ) {
     if (_disposed) {
       throw StateError(
@@ -1109,7 +1105,7 @@ final class ProviderContainer implements Node {
 
     final element = _pointerManager.upsertElement(provider);
 
-    return element as ProviderElement<StateT, ValueT>;
+    return element as ProviderElement<StateT, Object?>;
   }
 
   void _dispose({
@@ -1331,8 +1327,8 @@ abstract class ProviderObserver {
 /// An implementation detail for the override mechanism of providers
 @internal
 typedef SetupOverride = void Function({
-  required $ProviderBaseImpl<Object?, Object?> origin,
-  required $ProviderBaseImpl<Object?, Object?> override,
+  required $ProviderBaseImpl<Object?> origin,
+  required $ProviderBaseImpl<Object?> override,
 });
 
 /// An error thrown when a call to [Ref.read]/[Ref.watch]

--- a/packages/riverpod/lib/src/core/provider_subscription.dart
+++ b/packages/riverpod/lib/src/core/provider_subscription.dart
@@ -205,7 +205,7 @@ final class ProviderProviderSubscription<StateT>
 @internal
 final class ExternalProviderSubscription<InT, OutT>
     extends ProviderSubscriptionImpl<OutT> {
-  ExternalProviderSubscription({
+  ExternalProviderSubscription.fromSub({
     required ProviderSubscription<InT> innerSubscription,
     required OutT Function() read,
     void Function()? onClose,

--- a/packages/riverpod/lib/src/core/provider_subscription.dart
+++ b/packages/riverpod/lib/src/core/provider_subscription.dart
@@ -51,34 +51,29 @@ sealed class ProviderSubscription<OutT> {
   void close();
 }
 
-@internal
-sealed class ProviderSubscriptionWithOrigin<OutT, StateT>
-    extends ProviderSubscription<OutT> implements Pausable {
-  ProviderBase<StateT> get origin;
-  ProviderElement<StateT, Object?> get _listenedElement;
-
-  void _onOriginData(StateT? prev, StateT next);
-  void _onOriginError(Object error, StackTrace stackTrace);
-
-  OutT _callRead();
-
-  @override
-  OutT read() {
-    if (closed) {
-      throw StateError(
-        'called ProviderSubscription.read on a subscription that was closed',
-      );
+extension<T> on ProviderSubscription<T> {
+  ProviderSubscriptionImpl<T> get impl {
+    final that = this;
+    switch (that) {
+      case ProviderSubscriptionImpl<T>():
+        return that;
     }
-    _listenedElement.mayNeedDispose();
-    _listenedElement.flush();
+  }
 
-    return _callRead();
+  ProviderProviderSubscription<Object?> get providerSub {
+    final that = impl;
+    switch (that) {
+      case final ProviderProviderSubscription<Object?> sub:
+        return sub;
+      case final ExternalProviderSubscription<Object?, Object?> sub:
+        return sub._source;
+    }
   }
 }
 
 @internal
-abstract base class ProviderSubscriptionImpl<OutT, OriginT>
-    extends ProviderSubscriptionWithOrigin<OutT, OriginT> with _OnPauseMixin {
+sealed class ProviderSubscriptionImpl<OutT> extends ProviderSubscription<OutT>
+    with _OnPauseMixin {
   @override
   bool get isPaused => _isPaused;
 
@@ -96,6 +91,24 @@ abstract base class ProviderSubscriptionImpl<OutT, OriginT>
   })? _missedCalled;
   void Function(OutT? prev, OutT next) get _listener;
   OnError get _errorListener;
+
+  // ProviderBase<StateT> get origin;
+  ProviderElement<Object?, Object?> get _listenedElement;
+
+  OutT _callRead();
+
+  @override
+  OutT read() {
+    if (closed) {
+      throw StateError(
+        'called ProviderSubscription.read on a subscription that was closed',
+      );
+    }
+    _listenedElement.mayNeedDispose();
+    _listenedElement.flush();
+
+    return _callRead();
+  }
 
   @override
   void onCancel() {
@@ -154,6 +167,117 @@ abstract base class ProviderSubscriptionImpl<OutT, OriginT>
   }
 }
 
+/// Subscriptions obtained from listening to a [ProviderBase]
+@internal
+final class ProviderProviderSubscription<StateT>
+    extends ProviderSubscriptionImpl<StateT> {
+  ProviderProviderSubscription({
+    required ProviderElement<StateT, Object?> listenedElement,
+    required OnError onError,
+    required this.source,
+    required this.weak,
+    required void Function(StateT? prev, StateT next) listener,
+  })  : _errorListener = onError,
+        _listener = listener,
+        _listenedElement = listenedElement;
+
+  @override
+  final OnError _errorListener;
+
+  @override
+  final void Function(StateT? prev, StateT next) _listener;
+
+  @override
+  final ProviderElement<StateT, Object?> _listenedElement;
+
+  @override
+  final Node source;
+
+  @override
+  final bool weak;
+
+  @override
+  StateT _callRead() => _listenedElement.readSelf();
+}
+
+/// Subscriptions obtained from listening to a [ProviderListenable]
+/// that is not a [ProviderBase].
+@internal
+final class ExternalProviderSubscription<InT, OutT>
+    extends ProviderSubscriptionImpl<OutT> {
+  ExternalProviderSubscription({
+    required ProviderSubscription<InT> innerSubscription,
+    required OutT Function() read,
+    void Function()? onClose,
+    required void Function(OutT? prev, OutT next) listener,
+    required OnError? onError,
+  })  : _read = read,
+        _innerSubscription = innerSubscription,
+        _onClose = onClose,
+        _listener = listener,
+        _source = switch (innerSubscription.impl) {
+          final ProviderProviderSubscription<Object?> sub => sub,
+          final ExternalProviderSubscription<Object?, Object?> sub =>
+            sub._source,
+        },
+        _errorListener = onError ??
+            innerSubscription.impl._listenedElement.container.defaultOnError;
+
+  final ProviderSubscription<InT> _innerSubscription;
+  final OutT Function() _read;
+  final void Function()? _onClose;
+  final ProviderProviderSubscription<Object?> _source;
+
+  @override
+  final OnError _errorListener;
+
+  @override
+  final void Function(OutT? prev, OutT next) _listener;
+
+  // @override
+  // ProviderBase<OriginStateT> get origin => _innerSubscription.origin;
+
+  @override
+  ProviderElement<Object?, Object?> get _listenedElement =>
+      _innerSubscription.impl._listenedElement;
+
+  @override
+  bool get weak => _innerSubscription.weak;
+
+  @override
+  Node get source => _innerSubscription.source;
+
+  @override
+  void onCancel() {}
+
+  @override
+  void onResume() {}
+
+  @override
+  void pause() {
+    super.pause();
+    _innerSubscription.pause();
+  }
+
+  @override
+  void resume() {
+    super.resume();
+    _innerSubscription.resume();
+  }
+
+  @override
+  void close() {
+    if (_closed) return;
+
+    _onClose?.call();
+    super.close();
+    _innerSubscription.close();
+  }
+
+  @override
+  OutT _callRead() => _read();
+}
+
 @internal
 abstract class Pausable {
   bool get isPaused;
@@ -165,7 +289,7 @@ abstract class Pausable {
   void onResume();
 }
 
-mixin _OnPauseMixin on Pausable {
+mixin _OnPauseMixin implements Pausable {
   bool get _isPaused => _pauseCount > 0;
   var _pauseCount = 0;
 
@@ -192,185 +316,6 @@ mixin _OnPauseMixin on Pausable {
 
   @override
   void onCancel();
-}
-
-@internal
-base class ProviderSubscriptionView<OutT, OriginStateT>
-    extends ProviderSubscriptionImpl<OutT, OriginStateT> {
-  ProviderSubscriptionView({
-    required this.innerSubscription,
-    required OutT Function() read,
-    void Function()? onClose,
-    required void Function(OutT? prev, OutT next) listener,
-    required OnError? onError,
-  })  : _read = read,
-        _onClose = onClose,
-        _listener = listener,
-        _errorListener = onError ??
-            innerSubscription._listenedElement.container.defaultOnError;
-
-  final ProviderSubscriptionWithOrigin<Object?, OriginStateT> innerSubscription;
-  final OutT Function() _read;
-  final void Function()? _onClose;
-
-  @override
-  final OnError _errorListener;
-
-  @override
-  final void Function(OutT? prev, OutT next) _listener;
-
-  @override
-  ProviderBase<OriginStateT> get origin => innerSubscription.origin;
-
-  @override
-  ProviderElement<OriginStateT, Object?> get _listenedElement =>
-      innerSubscription._listenedElement;
-
-  @override
-  bool get weak => innerSubscription.weak;
-
-  @override
-  Node get source => innerSubscription.source;
-
-  @override
-  void _onOriginData(OriginStateT? prev, OriginStateT next) {
-    innerSubscription._onOriginData(prev, next);
-  }
-
-  @override
-  void _onOriginError(Object error, StackTrace stackTrace) {
-    innerSubscription._onOriginError(error, stackTrace);
-  }
-
-  @override
-  void onCancel() {}
-
-  @override
-  void onResume() {}
-
-  @override
-  void pause() {
-    super.pause();
-    innerSubscription.pause();
-  }
-
-  @override
-  void resume() {
-    super.resume();
-    innerSubscription.resume();
-  }
-
-  @override
-  void close() {
-    if (_closed) return;
-
-    _onClose?.call();
-    super.close();
-    innerSubscription.close();
-  }
-
-  @override
-  OutT _callRead() => _read();
-}
-
-@internal
-final class DelegatingProviderSubscription<OutT, InT, OriginStateT,
-    OriginValueT> extends ProviderSubscriptionImpl<OutT, OriginStateT> {
-  DelegatingProviderSubscription({
-    required this.origin,
-    required this.source,
-    required this.weak,
-    required OnError? errorListener,
-    required ProviderElement<OriginStateT, OriginValueT> listenedElement,
-    required void Function(OutT? prev, OutT next) listener,
-    void Function(OriginStateT? prev, OriginStateT next)? onOriginData,
-    void Function(Object error, StackTrace stackTrace)? onOriginError,
-    required OutT Function() read,
-    required void Function()? onClose,
-  })  : _errorListener = errorListener ?? source.container.defaultOnError,
-        _listenedElement = listenedElement,
-        _listener = listener,
-        _onOriginDataCb = onOriginData,
-        _onOriginErrorCb = onOriginError,
-        _readCb = read,
-        _onCloseCb = onClose;
-
-  @override
-  final $ProviderBaseImpl<OriginStateT, OriginValueT> origin;
-  @override
-  final Node source;
-  @override
-  final bool weak;
-  @override
-  final OnError _errorListener;
-  @override
-  final ProviderElement<OriginStateT, OriginValueT> _listenedElement;
-  @override
-  final void Function(OutT? prev, OutT next) _listener;
-  final void Function(OriginStateT? prev, OriginStateT next)? _onOriginDataCb;
-  final void Function(Object error, StackTrace stackTrace)? _onOriginErrorCb;
-  final OutT Function() _readCb;
-  final void Function()? _onCloseCb;
-
-  @override
-  void _onOriginData(OriginStateT? prev, OriginStateT next) =>
-      _onOriginDataCb?.call(prev, next);
-
-  @override
-  void _onOriginError(Object error, StackTrace stackTrace) =>
-      _onOriginErrorCb?.call(error, stackTrace);
-
-  @override
-  OutT _callRead() => _readCb();
-
-  @override
-  void close() {
-    if (_closed) return;
-
-    _onCloseCb?.call();
-    super.close();
-  }
-}
-
-/// When a provider listens to another provider using `listen`
-@internal
-final class ProviderStateSubscription<StateT, ValueT>
-    extends ProviderSubscriptionImpl<StateT, StateT> {
-  ProviderStateSubscription({
-    required this.source,
-    required this.weak,
-    required ProviderElement<StateT, ValueT> listenedElement,
-    required void Function(StateT? prev, StateT next) listener,
-    required OnError onError,
-  })  : _listenedElement = listenedElement,
-        _listener = listener,
-        _errorListener = onError;
-
-  @override
-  ProviderBase<StateT> get origin => _listenedElement.origin;
-
-  @override
-  final Node source;
-  @override
-  final ProviderElement<StateT, ValueT> _listenedElement;
-  @override
-  final bool weak;
-
-  // Why can't this be typed correctly?
-  @override
-  final void Function(StateT? prev, StateT next) _listener;
-  @override
-  final OnError _errorListener;
-
-  @override
-  StateT _callRead() => _listenedElement.readSelf();
-
-  @override
-  void _onOriginData(StateT? prev, StateT next) => _notifyData(prev, next);
-
-  @override
-  void _onOriginError(Object error, StackTrace stackTrace) =>
-      _notifyError(error, stackTrace);
 }
 
 /// Deals with the internals of synchronously calling the listeners

--- a/packages/riverpod/lib/src/core/provider_subscription.dart
+++ b/packages/riverpod/lib/src/core/provider_subscription.dart
@@ -235,7 +235,7 @@ final class ExternalProviderSubscription<InT, OutT>
   final void Function(OutT? prev, OutT next) _listener;
 
   // @override
-  // ProviderBase<OriginStateT> get origin => _innerSubscription.origin;
+  // ProviderBase<InT> get origin => _innerSubscription.origin;
 
   @override
   ProviderElement<Object?, Object?> get _listenedElement =>

--- a/packages/riverpod/lib/src/core/provider_subscription.dart
+++ b/packages/riverpod/lib/src/core/provider_subscription.dart
@@ -234,9 +234,6 @@ final class ExternalProviderSubscription<InT, OutT>
   @override
   final void Function(OutT? prev, OutT next) _listener;
 
-  // @override
-  // ProviderBase<InT> get origin => _innerSubscription.origin;
-
   @override
   ProviderElement<Object?, Object?> get _listenedElement =>
       _innerSubscription.impl._listenedElement;

--- a/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
+++ b/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
@@ -2,17 +2,17 @@ part of '../framework.dart';
 
 @internal
 @publicInCodegen
-final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
-    with ProviderListenableWithOrigin<OutT, OriginStateT> {
+final class $LazyProxyListenable<OutT, OriginStateT>
+    implements ProviderListenable<OutT> {
   $LazyProxyListenable(this.provider, this._lense);
 
-  final $ProviderBaseImpl<OriginStateT, OriginValueT> provider;
+  final $ProviderBaseImpl<OriginStateT> provider;
   final $Observable<OutT> Function(
-    ProviderElement<OriginStateT, OriginValueT> element,
+    ProviderElement<OriginStateT, Object?> element,
   ) _lense;
 
   @override
-  ProviderSubscriptionWithOrigin<OutT, OriginStateT> _addListener(
+  ProviderSubscriptionImpl<OutT> _addListener(
     Node source,
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -21,23 +21,21 @@ final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
   }) {
     final element = source.readProviderElement(provider);
 
+    final innerSub = source.container.listen(provider, (a, b) {});
+
     final listenable = _lense(element);
 
-    late final ProviderSubscriptionImpl<OutT, OriginStateT> sub;
+    late final ProviderSubscriptionImpl<OutT> sub;
     final removeListener = listenable.addListener(
       (a, b) => sub._notifyData(a, b),
       onError: onError,
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
     );
 
-    return sub = DelegatingProviderSubscription<OutT, OriginStateT,
-        OriginStateT, OriginValueT>(
-      listenedElement: element,
-      source: source,
-      weak: weak,
-      origin: provider,
+    return sub = ExternalProviderSubscription<OriginStateT, OutT>(
+      innerSubscription: innerSub,
       onClose: removeListener,
-      errorListener: onError,
+      onError: onError,
       listener: listener,
       read: () => listenable.value,
     );
@@ -60,10 +58,8 @@ final class $LazyProxyListenable<OutT, OriginStateT, OriginValueT>
 ///
 /// This API is not meant for public consumption.
 @internal
-final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
-    with
-        ProviderListenableWithOrigin<OutT, OriginStateT>,
-        _ProviderRefreshable<OutT, OriginStateT, OriginValueT> {
+final class ProviderElementProxy<OutT, OriginStateT>
+    with _ProviderRefreshable<OutT, OriginStateT> {
   /// An internal utility for reading alternate values of a provider.
   ///
   /// For example, this is used by [FutureProvider] to differentiate:
@@ -88,13 +84,13 @@ final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
   final bool flushElement;
 
   @override
-  final $ProviderBaseImpl<OriginStateT, OriginValueT> provider;
+  final $ProviderBaseImpl<OriginStateT> provider;
   final $Observable<OutT> Function(
-    ProviderElement<OriginStateT, OriginValueT> element,
+    ProviderElement<OriginStateT, Object?> element,
   ) _lense;
 
   @override
-  ProviderSubscriptionWithOrigin<OutT, OriginStateT> _addListener(
+  ProviderSubscriptionImpl<OutT> _addListener(
     Node source,
     void Function(OutT? previous, OutT next) listener, {
     required void Function(Object error, StackTrace stackTrace) onError,
@@ -119,14 +115,14 @@ final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
 
     final notifier = _lense(element);
 
-    late ProviderSubscriptionView<OutT, OriginStateT> sub;
+    late ExternalProviderSubscription<OriginStateT, OutT> sub;
     final removeListener = notifier.addListener(
       (prev, next) => sub._notifyData(prev, next),
       onError: onError,
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
     );
 
-    return sub = ProviderSubscriptionView<OutT, OriginStateT>(
+    return sub = ExternalProviderSubscription<OriginStateT, OutT>(
       innerSubscription: innerSub,
       onClose: removeListener,
       listener: listener,
@@ -143,7 +139,7 @@ final class ProviderElementProxy<OutT, OriginStateT, OriginValueT>
 
   @override
   bool operator ==(Object other) =>
-      other is ProviderElementProxy<OutT, OriginStateT, OriginValueT> &&
+      other is ProviderElementProxy<OutT, OriginStateT> &&
       other.provider == provider;
 
   @override

--- a/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
+++ b/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
@@ -2,13 +2,13 @@ part of '../framework.dart';
 
 @internal
 @publicInCodegen
-final class $LazyProxyListenable<OutT, OriginStateT>
+final class $LazyProxyListenable<OutT, InT>
     implements ProviderListenable<OutT> {
   $LazyProxyListenable(this.provider, this._lense);
 
-  final $ProviderBaseImpl<OriginStateT> provider;
+  final $ProviderBaseImpl<InT> provider;
   final $Observable<OutT> Function(
-    ProviderElement<OriginStateT, Object?> element,
+    ProviderElement<InT, Object?> element,
   ) _lense;
 
   @override
@@ -32,7 +32,7 @@ final class $LazyProxyListenable<OutT, OriginStateT>
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
     );
 
-    return sub = ExternalProviderSubscription<OriginStateT, OutT>(
+    return sub = ExternalProviderSubscription<InT, OutT>(
       innerSubscription: innerSub,
       onClose: removeListener,
       onError: onError,
@@ -58,8 +58,8 @@ final class $LazyProxyListenable<OutT, OriginStateT>
 ///
 /// This API is not meant for public consumption.
 @internal
-final class ProviderElementProxy<OutT, OriginStateT>
-    with _ProviderRefreshable<OutT, OriginStateT> {
+final class ProviderElementProxy<OutT, InT>
+    with _ProviderRefreshable<OutT, InT> {
   /// An internal utility for reading alternate values of a provider.
   ///
   /// For example, this is used by [FutureProvider] to differentiate:
@@ -84,9 +84,9 @@ final class ProviderElementProxy<OutT, OriginStateT>
   final bool flushElement;
 
   @override
-  final $ProviderBaseImpl<OriginStateT> provider;
+  final $ProviderBaseImpl<InT> provider;
   final $Observable<OutT> Function(
-    ProviderElement<OriginStateT, Object?> element,
+    ProviderElement<InT, Object?> element,
   ) _lense;
 
   @override
@@ -115,14 +115,14 @@ final class ProviderElementProxy<OutT, OriginStateT>
 
     final notifier = _lense(element);
 
-    late ExternalProviderSubscription<OriginStateT, OutT> sub;
+    late ExternalProviderSubscription<InT, OutT> sub;
     final removeListener = notifier.addListener(
       (prev, next) => sub._notifyData(prev, next),
       onError: onError,
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
     );
 
-    return sub = ExternalProviderSubscription<OriginStateT, OutT>(
+    return sub = ExternalProviderSubscription<InT, OutT>(
       innerSubscription: innerSub,
       onClose: removeListener,
       listener: listener,
@@ -139,7 +139,7 @@ final class ProviderElementProxy<OutT, OriginStateT>
 
   @override
   bool operator ==(Object other) =>
-      other is ProviderElementProxy<OutT, OriginStateT> &&
+      other is ProviderElementProxy<OutT, InT> &&
       other.provider == provider;
 
   @override

--- a/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
+++ b/packages/riverpod/lib/src/core/proxy_provider_listenable.dart
@@ -32,7 +32,7 @@ final class $LazyProxyListenable<OutT, InT>
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
     );
 
-    return sub = ExternalProviderSubscription<InT, OutT>(
+    return sub = ExternalProviderSubscription<InT, OutT>.fromSub(
       innerSubscription: innerSub,
       onClose: removeListener,
       onError: onError,
@@ -122,7 +122,7 @@ final class ProviderElementProxy<OutT, InT>
       onDependencyMayHaveChanged: onDependencyMayHaveChanged,
     );
 
-    return sub = ExternalProviderSubscription<InT, OutT>(
+    return sub = ExternalProviderSubscription<InT, OutT>.fromSub(
       innerSubscription: innerSub,
       onClose: removeListener,
       listener: listener,
@@ -139,8 +139,7 @@ final class ProviderElementProxy<OutT, InT>
 
   @override
   bool operator ==(Object other) =>
-      other is ProviderElementProxy<OutT, InT> &&
-      other.provider == provider;
+      other is ProviderElementProxy<OutT, InT> && other.provider == provider;
 
   @override
   int get hashCode => provider.hashCode;

--- a/packages/riverpod/lib/src/providers/async_notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/family.dart
@@ -67,7 +67,7 @@ final class FamilyAsyncNotifierProvider< //
         ValueT,
         ArgT> //
     extends $AsyncNotifierProvider<NotifierT, ValueT>
-    with LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
+    with LegacyProviderMixin<AsyncValue<ValueT>> {
   /// An implementation detail of Riverpod
   const FamilyAsyncNotifierProvider._(
     this._createNotifier, {

--- a/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
@@ -63,7 +63,7 @@ final class AsyncNotifierProvider< //
         NotifierT extends AsyncNotifier<ValueT>,
         ValueT> //
     extends $AsyncNotifierProvider<NotifierT, ValueT>
-    with LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
+    with LegacyProviderMixin<AsyncValue<ValueT>> {
   /// {@macro riverpod.async_notifier_provider}
   ///
   /// {@macro riverpod.async_notifier_provider_modifier}

--- a/packages/riverpod/lib/src/providers/future_provider.dart
+++ b/packages/riverpod/lib/src/providers/future_provider.dart
@@ -99,7 +99,7 @@ final class FutureProvider<ValueT>
     with
         $FutureModifier<ValueT>,
         $FutureProvider<ValueT>,
-        LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
+        LegacyProviderMixin<AsyncValue<ValueT>> {
   /// {@macro riverpod.future_provider}
   FutureProvider(
     this._create, {

--- a/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
@@ -73,7 +73,7 @@ final class StateNotifierProvider< //
     extends $FunctionalProvider< //
         ValueT,
         ValueT,
-        NotifierT> with LegacyProviderMixin<ValueT, ValueT> {
+        NotifierT> with LegacyProviderMixin<ValueT> {
   /// {@macro riverpod.state_notifier_provider}
   StateNotifierProvider(
     this._create, {
@@ -128,7 +128,7 @@ final class StateNotifierProvider< //
   /// This may happen if the provider is refreshed or one of its dependencies
   /// has changes.
   Refreshable<NotifierT> get notifier =>
-      ProviderElementProxy<NotifierT, ValueT, ValueT>(
+      ProviderElementProxy<NotifierT, ValueT>(
         this,
         (element) {
           return (element as _StateNotifierProviderElement<NotifierT, ValueT>)

--- a/packages/riverpod/lib/src/providers/legacy/state_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_provider.dart
@@ -38,7 +38,7 @@ import '../../internals.dart';
 @publicInLegacy
 final class StateProvider<ValueT>
     extends $FunctionalProvider<ValueT, ValueT, ValueT>
-    with LegacyProviderMixin<ValueT, ValueT> {
+    with LegacyProviderMixin<ValueT> {
   /// {@macro riverpod.state_provider}
   StateProvider(
     this._createFn, {
@@ -82,7 +82,7 @@ final class StateProvider<ValueT>
   /// The value obtained may change if the provider is refreshed (such as using
   /// [Ref.watch] or [Ref.refresh]).
   Refreshable<StateController<ValueT>> get notifier =>
-      ProviderElementProxy<StateController<ValueT>, ValueT, ValueT>(
+      ProviderElementProxy<StateController<ValueT>, ValueT>(
         this,
         (element) {
           return (element as _StateProviderElement<ValueT>)._controllerNotifier;

--- a/packages/riverpod/lib/src/providers/notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/notifier/family.dart
@@ -24,7 +24,7 @@ abstract class FamilyNotifier<ValueT, ArgT> extends $Notifier<ValueT> {
 final class FamilyNotifierProvider //
     <NotifierT extends $Notifier<ValueT>, ValueT, ArgT>
     extends $NotifierProvider<NotifierT, ValueT>
-    with LegacyProviderMixin<ValueT, ValueT> {
+    with LegacyProviderMixin<ValueT> {
   /// An implementation detail of Riverpod
   const FamilyNotifierProvider._(
     this._createNotifier, {

--- a/packages/riverpod/lib/src/providers/notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/notifier/orphan.dart
@@ -85,7 +85,7 @@ abstract class Notifier<ValueT> extends $Notifier<ValueT> {
 /// {@category Providers}
 final class NotifierProvider<NotifierT extends Notifier<ValueT>, ValueT>
     extends $NotifierProvider<NotifierT, ValueT>
-    with LegacyProviderMixin<ValueT, ValueT> {
+    with LegacyProviderMixin<ValueT> {
   /// {@macro riverpod.notifier_provider}
   ///
   /// {@macro riverpod.notifier_provider_modifier}

--- a/packages/riverpod/lib/src/providers/provider.dart
+++ b/packages/riverpod/lib/src/providers/provider.dart
@@ -16,7 +16,7 @@ base mixin $Provider<ValueT> on $FunctionalProvider<ValueT, ValueT, ValueT> {}
 /// {@macro riverpod.provider}
 /// {@category Providers}
 final class Provider<ValueT> extends $FunctionalProvider<ValueT, ValueT, ValueT>
-    with $Provider<ValueT>, LegacyProviderMixin<ValueT, ValueT> {
+    with $Provider<ValueT>, LegacyProviderMixin<ValueT> {
   /// {@macro riverpod.provider}
   Provider(
     this._create, {

--- a/packages/riverpod/lib/src/providers/stream_notifier/family.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier/family.dart
@@ -37,7 +37,7 @@ final class FamilyStreamNotifierProvider< //
         ValueT,
         ArgT> //
     extends $StreamNotifierProvider<NotifierT, ValueT>
-    with LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
+    with LegacyProviderMixin<AsyncValue<ValueT>> {
   /// An implementation detail of Riverpod
   const FamilyStreamNotifierProvider._(
     this._createNotifier, {

--- a/packages/riverpod/lib/src/providers/stream_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier/orphan.dart
@@ -50,7 +50,7 @@ final class StreamNotifierProvider< //
         NotifierT extends StreamNotifier<ValueT>,
         ValueT> //
     extends $StreamNotifierProvider<NotifierT, ValueT>
-    with LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
+    with LegacyProviderMixin<AsyncValue<ValueT>> {
   /// {@macro riverpod.stream_notifier_provider}
   ///
   /// {@macro riverpod.async_notifier_provider_modifier}

--- a/packages/riverpod/lib/src/providers/stream_provider.dart
+++ b/packages/riverpod/lib/src/providers/stream_provider.dart
@@ -88,7 +88,7 @@ final class StreamProvider<ValueT>
     with
         $FutureModifier<ValueT>,
         $StreamProvider<ValueT>,
-        LegacyProviderMixin<AsyncValue<ValueT>, ValueT> {
+        LegacyProviderMixin<AsyncValue<ValueT>> {
   /// {@macro riverpod.stream_provider}
   StreamProvider(
     this._create, {

--- a/packages/riverpod_generator/lib/src/templates/provider.dart
+++ b/packages/riverpod_generator/lib/src/templates/provider.dart
@@ -165,7 +165,7 @@ ${provider.doc} final class $name$_genericsDefinition
         for (final mutation in mutations) {
           buffer.writeln('''
   ProviderListenable<${mutation.generatedMutationInterfaceName}> get ${mutation.name}
-    => \$LazyProxyListenable<${mutation.generatedMutationInterfaceName}, ${provider.exposedTypeDisplayString}, ${provider.valueTypeDisplayString}>(
+    => \$LazyProxyListenable<${mutation.generatedMutationInterfaceName}, ${provider.exposedTypeDisplayString}>(
       this,
       (element) {
         element as ${provider.generatedElementName}$_generics;

--- a/packages/riverpod_generator/test/integration/mutation.g.dart
+++ b/packages/riverpod_generator/test/integration/mutation.g.dart
@@ -35,7 +35,7 @@ final class SyncTodoListProvider
       _$SyncTodoListElement(pointer);
 
   ProviderListenable<SyncTodoList$AddSync> get addSync =>
-      $LazyProxyListenable<SyncTodoList$AddSync, List<Todo>, List<Todo>>(
+      $LazyProxyListenable<SyncTodoList$AddSync, List<Todo>>(
         this,
         (element) {
           element as _$SyncTodoListElement;
@@ -45,7 +45,7 @@ final class SyncTodoListProvider
       );
 
   ProviderListenable<SyncTodoList$AddAsync> get addAsync =>
-      $LazyProxyListenable<SyncTodoList$AddAsync, List<Todo>, List<Todo>>(
+      $LazyProxyListenable<SyncTodoList$AddAsync, List<Todo>>(
         this,
         (element) {
           element as _$SyncTodoListElement;
@@ -226,8 +226,8 @@ final class AsyncTodoListProvider
   _$AsyncTodoListElement $createElement($ProviderPointer pointer) =>
       _$AsyncTodoListElement(pointer);
 
-  ProviderListenable<AsyncTodoList$AddSync> get addSync => $LazyProxyListenable<
-          AsyncTodoList$AddSync, AsyncValue<List<Todo>>, List<Todo>>(
+  ProviderListenable<AsyncTodoList$AddSync> get addSync =>
+      $LazyProxyListenable<AsyncTodoList$AddSync, AsyncValue<List<Todo>>>(
         this,
         (element) {
           element as _$AsyncTodoListElement;
@@ -237,8 +237,7 @@ final class AsyncTodoListProvider
       );
 
   ProviderListenable<AsyncTodoList$AddAsync> get addAsync =>
-      $LazyProxyListenable<AsyncTodoList$AddAsync, AsyncValue<List<Todo>>,
-          List<Todo>>(
+      $LazyProxyListenable<AsyncTodoList$AddAsync, AsyncValue<List<Todo>>>(
         this,
         (element) {
           element as _$AsyncTodoListElement;
@@ -414,7 +413,7 @@ final class SimpleProvider extends $NotifierProvider<Simple, int> {
       _$SimpleElement(pointer);
 
   ProviderListenable<Simple$Increment> get increment =>
-      $LazyProxyListenable<Simple$Increment, int, int>(
+      $LazyProxyListenable<Simple$Increment, int>(
         this,
         (element) {
           element as _$SimpleElement;
@@ -424,7 +423,7 @@ final class SimpleProvider extends $NotifierProvider<Simple, int> {
       );
 
   ProviderListenable<Simple$IncrementOr> get incrementOr =>
-      $LazyProxyListenable<Simple$IncrementOr, int, int>(
+      $LazyProxyListenable<Simple$IncrementOr, int>(
         this,
         (element) {
           element as _$SimpleElement;
@@ -434,7 +433,7 @@ final class SimpleProvider extends $NotifierProvider<Simple, int> {
       );
 
   ProviderListenable<Simple$Delegated> get delegated =>
-      $LazyProxyListenable<Simple$Delegated, int, int>(
+      $LazyProxyListenable<Simple$Delegated, int>(
         this,
         (element) {
           element as _$SimpleElement;
@@ -669,7 +668,7 @@ final class SimpleFamilyProvider extends $NotifierProvider<SimpleFamily, int> {
       _$SimpleFamilyElement(pointer);
 
   ProviderListenable<SimpleFamily$Increment> get increment =>
-      $LazyProxyListenable<SimpleFamily$Increment, int, int>(
+      $LazyProxyListenable<SimpleFamily$Increment, int>(
         this,
         (element) {
           element as _$SimpleFamilyElement;
@@ -679,7 +678,7 @@ final class SimpleFamilyProvider extends $NotifierProvider<SimpleFamily, int> {
       );
 
   ProviderListenable<SimpleFamily$IncrementOr> get incrementOr =>
-      $LazyProxyListenable<SimpleFamily$IncrementOr, int, int>(
+      $LazyProxyListenable<SimpleFamily$IncrementOr, int>(
         this,
         (element) {
           element as _$SimpleFamilyElement;
@@ -898,7 +897,7 @@ final class SimpleAsyncProvider
       _$SimpleAsyncElement(pointer);
 
   ProviderListenable<SimpleAsync$Increment> get increment =>
-      $LazyProxyListenable<SimpleAsync$Increment, AsyncValue<int>, int>(
+      $LazyProxyListenable<SimpleAsync$Increment, AsyncValue<int>>(
         this,
         (element) {
           element as _$SimpleAsyncElement;
@@ -908,7 +907,7 @@ final class SimpleAsyncProvider
       );
 
   ProviderListenable<SimpleAsync$Delegated> get delegated =>
-      $LazyProxyListenable<SimpleAsync$Delegated, AsyncValue<int>, int>(
+      $LazyProxyListenable<SimpleAsync$Delegated, AsyncValue<int>>(
         this,
         (element) {
           element as _$SimpleAsyncElement;
@@ -1088,7 +1087,7 @@ final class SimpleAsync2Provider
       _$SimpleAsync2Element(pointer);
 
   ProviderListenable<SimpleAsync2$Increment> get increment =>
-      $LazyProxyListenable<SimpleAsync2$Increment, AsyncValue<int>, int>(
+      $LazyProxyListenable<SimpleAsync2$Increment, AsyncValue<int>>(
         this,
         (element) {
           element as _$SimpleAsync2Element;
@@ -1254,7 +1253,7 @@ final class GenericProvider<T extends num>
       _$GenericElement(pointer);
 
   ProviderListenable<Generic$Increment> get increment =>
-      $LazyProxyListenable<Generic$Increment, AsyncValue<int>, int>(
+      $LazyProxyListenable<Generic$Increment, AsyncValue<int>>(
         this,
         (element) {
           element as _$GenericElement<T>;
@@ -1434,7 +1433,7 @@ final class GenericMutProvider extends $AsyncNotifierProvider<GenericMut, int> {
       _$GenericMutElement(pointer);
 
   ProviderListenable<GenericMut$Increment> get increment =>
-      $LazyProxyListenable<GenericMut$Increment, AsyncValue<int>, int>(
+      $LazyProxyListenable<GenericMut$Increment, AsyncValue<int>>(
         this,
         (element) {
           element as _$GenericMutElement;
@@ -1557,7 +1556,7 @@ final class FailingCtorProvider extends $NotifierProvider<FailingCtor, int> {
       _$FailingCtorElement(pointer);
 
   ProviderListenable<FailingCtor$Increment> get increment =>
-      $LazyProxyListenable<FailingCtor$Increment, int, int>(
+      $LazyProxyListenable<FailingCtor$Increment, int>(
         this,
         (element) {
           element as _$FailingCtorElement;
@@ -1686,7 +1685,7 @@ final class TypedProvider extends $NotifierProvider<Typed, String> {
       _$TypedElement(pointer);
 
   ProviderListenable<Typed$Mutate> get mutate =>
-      $LazyProxyListenable<Typed$Mutate, String, String>(
+      $LazyProxyListenable<Typed$Mutate, String>(
         this,
         (element) {
           element as _$TypedElement;

--- a/packages/riverpod_generator/test/mutation_test.dart
+++ b/packages/riverpod_generator/test/mutation_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:mockito/mockito.dart';
 import 'package:riverpod/riverpod.dart';
-import 'package:riverpod/src/internals.dart' show NodeInternal;
 import 'package:riverpod/src/mutation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:test/test.dart';
@@ -248,20 +247,6 @@ void main() {
 
     await container.pump();
     expect(container.exists(simpleProvider), false);
-  });
-
-  test('Listening a mutation lazily initializes the provider', () async {
-    final container = ProviderContainer.test();
-
-    final sub = container.listen(simpleProvider.increment, (a, b) {});
-
-    final element = container.readProviderElement(simpleProvider);
-
-    expect(element.stateResult(), null);
-
-    await sub.read().call(2);
-
-    expect(container.read(simpleProvider), 2);
   });
 
   test('If notifier constructor throws, the mutation immediately throws',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new `select` method for providers, enabling more efficient updates by allowing widgets to listen to specific subparts of provider state.

- **Refactor**
  - Simplified provider type parameters across the API, reducing generic complexity and streamlining public interfaces.
  - Unified and modernized provider subscription handling for improved consistency and maintainability.
  - Updated proxy provider listenables and provider elements to use simplified generic parameters and subscription types.
  - Removed deprecated mixins and streamlined listener and subscription implementations.

- **Documentation**
  - Corrected references in provider selection method documentation.

These changes enhance API usability and enable more efficient widget rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->