### PR TITLE
Replace `StateError` with `ProviderMissingLastValueError` when disposing a provider with no value emitted

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -11,6 +11,7 @@
   the error is now wrapped in a `ProviderException`.
 - Use TickerMode instead of Visibility for pausing out-of-view widgets
 - Reworked offline to simplify its usage
+- Replace `StateError` with `ProviderMissingLastValueError` when disposing a provider with no value emitted. (thanks to @AlexV525)
 
 ## 3.0.0-dev.15 - 2025-05-04
 

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -1229,10 +1229,10 @@ mixin SyncProviderElement<ValueT> on ProviderElement<ValueT, ValueT> {
 ///
 /// The error was intended to inherit the [StateError] so that any specific
 /// handling around the previous [StateError] still works.
-final class ProviderMissingLastValueError<StateT> extends StateError {
+final class ProviderMissingLastValueError extends StateError {
   /// Creates an [ProviderMissingLastValueError].
   ProviderMissingLastValueError(
-    $ProviderBaseImpl<StateT> origin,
+    $ProviderBaseImpl<Object?> origin,
   ) : super(
           'The provider $origin was disposed during loading state, '
           'yet no value could be emitted.',

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -181,13 +181,6 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
     _cancelSubscription?.resume?.call();
   }
 
-  StateError _missingLastValueError() {
-    return StateError(
-      'The provider $origin was disposed during loading state, '
-      'yet no value could be emitted.',
-    );
-  }
-
   /// Listens to a [Future] and convert it into an [AsyncValue].
   @preferInline
   @internal
@@ -315,7 +308,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
       } else {
         // The listened stream completed during a "loading" state.
         completer.completeError(
-          _missingLastValueError(),
+          ProviderMissingLastValueError(origin),
           StackTrace.current,
         );
       }
@@ -1229,4 +1222,19 @@ mixin SyncProviderElement<ValueT> on ProviderElement<ValueT, ValueT> {
 
   @override
   void setValueFromState(ValueT state) => value = AsyncData(state);
+}
+
+/// An error thrown when a provider is disposed while in loading state,
+/// and no value was emitted.
+///
+/// The error was intended to inherit the [StateError] so that any specific
+/// handling around the previous [StateError] still works.
+class ProviderMissingLastValueError<StateT> extends StateError {
+  /// Creates an [ProviderMissingLastValueError].
+  ProviderMissingLastValueError(
+    $ProviderBaseImpl<StateT> origin,
+  ) : super(
+          'The provider $origin was disposed during loading state, '
+          'yet no value could be emitted.',
+        );
 }

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -1229,7 +1229,7 @@ mixin SyncProviderElement<ValueT> on ProviderElement<ValueT, ValueT> {
 ///
 /// The error was intended to inherit the [StateError] so that any specific
 /// handling around the previous [StateError] still works.
-class ProviderMissingLastValueError<StateT> extends StateError {
+final class ProviderMissingLastValueError<StateT> extends StateError {
   /// Creates an [ProviderMissingLastValueError].
   ProviderMissingLastValueError(
     $ProviderBaseImpl<StateT> origin,

--- a/packages/riverpod/test/old/legacy_providers/stream_provider/stream_provider_test.dart
+++ b/packages/riverpod/test/old/legacy_providers/stream_provider/stream_provider_test.dart
@@ -353,7 +353,8 @@ void main() {
       await expectLater(
         future,
         throwsA(
-          const TypeMatcher<ProviderMissingLastValueError<int>>().having(
+          const TypeMatcher<ProviderMissingLastValueError<AsyncValue<int>>>()
+              .having(
             (e) => e.message,
             'message',
             equalsIgnoringHashCodes(

--- a/packages/riverpod/test/old/legacy_providers/stream_provider/stream_provider_test.dart
+++ b/packages/riverpod/test/old/legacy_providers/stream_provider/stream_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:mockito/mockito.dart';
 import 'package:riverpod/legacy.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:riverpod/src/internals.dart' show ProviderElement;
+import 'package:riverpod/src/internals.dart' show ProviderMissingLastValueError;
 import 'package:riverpod/src/internals.dart' show InternalProviderContainer;
 import 'package:test/test.dart';
 
@@ -352,7 +353,7 @@ void main() {
       await expectLater(
         future,
         throwsA(
-          isStateError.having(
+          const TypeMatcher<ProviderMissingLastValueError<int>>().having(
             (e) => e.message,
             'message',
             equalsIgnoringHashCodes(

--- a/packages/riverpod/test/old/legacy_providers/stream_provider/stream_provider_test.dart
+++ b/packages/riverpod/test/old/legacy_providers/stream_provider/stream_provider_test.dart
@@ -353,8 +353,7 @@ void main() {
       await expectLater(
         future,
         throwsA(
-          const TypeMatcher<ProviderMissingLastValueError<AsyncValue<int>>>()
-              .having(
+          const TypeMatcher<ProviderMissingLastValueError>().having(
             (e) => e.message,
             'message',
             equalsIgnoringHashCodes(


### PR DESCRIPTION
## Related Issues

Working towards https://github.com/rrousselGit/riverpod/discussions/3223

Throwing an error would be acceptable, but users have to write hard-coded strings to match and escape:
```dart
void handleExceptions(Object error) {
  if (error case final StateError error when error.message.contains('was disposed during loading state, yet no value could be emitted.') {
    // ignore
    return;
  }
}
```

The PR adds `ProviderMissingLastValueError` so the error could be gracefully caught and handled specifically.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when disposing a provider that has not emitted any value. The error type is now more specific, making it easier to identify and understand this scenario.

- **Documentation**
  - Updated changelog to reflect the new error type for provider disposal without emitted values.

- **Tests**
  - Updated tests to expect the new, more specific error type when a provider is disposed before emitting a value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->