### PR TITLE
[riverpod_generator] Add option to remove regular expression from generated providers name 

### DIFF
--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Allow passing `persist(key: ...)`
 - Bump minimum `meta` version
 - Support `@Riverpod(name: ...)`
-- Add `providerNameStripPattern` build option
+- Add `provider_name_strip_pattern` build option
 
 ## 3.0.0-dev.16 - 2025-06-20
 

--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Allow passing `persist(key: ...)`
 - Bump minimum `meta` version
 - Support `@Riverpod(name: ...)`
+- Add `providerNameStripPattern` build option
 
 ## 3.0.0-dev.16 - 2025-06-20
 

--- a/packages/riverpod_generator/README.md
+++ b/packages/riverpod_generator/README.md
@@ -188,7 +188,7 @@ targets:
           # Given a class named `CounterNotifier`, Riverpod will
           # remove any text matching the regex (so here `Notifier`).
           # We end-up with `Counter` ; which is then transformed to `counterProvider`
-          provider_ame_strip_pattern: "Notifier$"
+          provider_name_strip_pattern: "Notifier$"
 ```
 
 [family]: https://riverpod.dev/docs/concepts/modifiers/family

--- a/packages/riverpod_generator/README.md
+++ b/packages/riverpod_generator/README.md
@@ -183,8 +183,11 @@ targets:
           provider_family_name_suffix: "Provider" # (default)
           # A regular expression that riverpod_generator will
           # remove from generated providers names.
-          # Here the generated provider for notifier class
-          # AuthMethodNotifier would be authMethodProvider
+          # The following regex removes the trailing `Notifier` from
+          # the name of generated providers.
+          # Given a class named `CounterNotifier`, Riverpod will
+          # remove any text matching the regex (so here `Notifier`).
+          # We end-up with `Counter` ; which is then transformed to `counterProvider`
           providerNameStripPattern: "Notifier$"
 ```
 

--- a/packages/riverpod_generator/README.md
+++ b/packages/riverpod_generator/README.md
@@ -188,7 +188,7 @@ targets:
           # Given a class named `CounterNotifier`, Riverpod will
           # remove any text matching the regex (so here `Notifier`).
           # We end-up with `Counter` ; which is then transformed to `counterProvider`
-          providerNameStripPattern: "Notifier$"
+          provider_ame_strip_pattern: "Notifier$"
 ```
 
 [family]: https://riverpod.dev/docs/concepts/modifiers/family

--- a/packages/riverpod_generator/README.md
+++ b/packages/riverpod_generator/README.md
@@ -181,6 +181,11 @@ targets:
           # providers with parameters ("families").
           # This takes precedence over provider_name_suffix.
           provider_family_name_suffix: "Provider" # (default)
+          # A regular expression that riverpod_generator will
+          # remove from generated providers names.
+          # Here the generated provider for notifier class
+          # AuthMethodNotifier would be authMethodProvider
+          providerNameStripPattern: "Notifier$"
 ```
 
 [family]: https://riverpod.dev/docs/concepts/modifiers/family

--- a/packages/riverpod_generator/integration/build_yaml/build.yaml
+++ b/packages/riverpod_generator/integration/build_yaml/build.yaml
@@ -7,3 +7,4 @@ targets:
           provider_family_name_prefix: 'myFamily'
           provider_name_suffix: 'Pod'
           provider_family_name_suffix: 'ProviderFamily'
+          provider_name_strip_pattern: '(Controller|Controller2)$'

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.dart
@@ -79,3 +79,19 @@ class CountStreamNotifier2 extends _$CountStreamNotifier2 {
     return Stream.value(1);
   }
 }
+
+@riverpod
+class TimeController extends _$TimeController {
+  @override
+  int build() {
+    return 1;
+  }
+}
+
+@riverpod
+class TimeController2 extends _$TimeController2 {
+  @override
+  int build(int a) {
+    return 1;
+  }
+}

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
@@ -728,5 +728,142 @@ abstract class _$CountStreamNotifier2 extends $StreamNotifier<int> {
   }
 }
 
+@ProviderFor(TimeController)
+const myTimePod = TimeControllerProvider._();
+
+final class TimeControllerProvider
+    extends $NotifierProvider<TimeController, int> {
+  const TimeControllerProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'myTimePod',
+          isAutoDispose: true,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$timeControllerHash();
+
+  @$internal
+  @override
+  TimeController create() => TimeController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(int value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<int>(value),
+    );
+  }
+}
+
+String _$timeControllerHash() => r'6bf21e367715e4d476170b36e2ab75e34a653c7d';
+
+abstract class _$TimeController extends $Notifier<int> {
+  int build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<int, int>;
+    final element = ref.element
+        as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
+    element.handleValue(ref, created);
+  }
+}
+
+@ProviderFor(TimeController2)
+const myFamilyTimeProviderFamily = TimeController2Family._();
+
+final class TimeController2Provider
+    extends $NotifierProvider<TimeController2, int> {
+  const TimeController2Provider._(
+      {required TimeController2Family super.from, required int super.argument})
+      : super(
+          retry: null,
+          name: r'myFamilyTimeProviderFamily',
+          isAutoDispose: true,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$timeController2Hash();
+
+  @override
+  String toString() {
+    return r'myFamilyTimeProviderFamily'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  TimeController2 create() => TimeController2();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(int value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<int>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is TimeController2Provider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$timeController2Hash() => r'8bba0763d5955bd6e276ee913a0f25e032aa0db6';
+
+final class TimeController2Family extends $Family
+    with $ClassFamilyOverride<TimeController2, int, int, int, int> {
+  const TimeController2Family._()
+      : super(
+          retry: null,
+          name: r'myFamilyTimeProviderFamily',
+          dependencies: null,
+          $allTransitiveDependencies: null,
+          isAutoDispose: true,
+        );
+
+  TimeController2Provider call(
+    int a,
+  ) =>
+      TimeController2Provider._(argument: a, from: this);
+
+  @override
+  String toString() => r'myFamilyTimeProviderFamily';
+}
+
+abstract class _$TimeController2 extends $Notifier<int> {
+  late final _$args = ref.$arg as int;
+  int get a => _$args;
+
+  int build(
+    int a,
+  );
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(
+      _$args,
+    );
+    final ref = this.ref as $Ref<int, int>;
+    final element = ref.element
+        as $ClassProviderElement<AnyNotifier<int, int>, int, Object?, Object?>;
+    element.handleValue(ref, created);
+  }
+}
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/riverpod_generator/integration/build_yaml/test/build_yaml_test.dart
+++ b/packages/riverpod_generator/integration/build_yaml/test/build_yaml_test.dart
@@ -58,4 +58,9 @@ void main() {
       ]),
     );
   });
+
+  test('strip pattern', () {
+    expect(myTimePod.name, 'myTimePod');
+    expect(myFamilyTimeProviderFamily.name, 'myFamilyTimeProviderFamily');
+  });
 }

--- a/packages/riverpod_generator/lib/src/models.dart
+++ b/packages/riverpod_generator/lib/src/models.dart
@@ -4,6 +4,7 @@ class BuildYamlOptions {
     this.providerFamilyNamePrefix,
     this.providerNameSuffix,
     this.providerFamilyNameSuffix,
+    this.providerNameStripPattern,
   });
 
   factory BuildYamlOptions.fromMap(Map<String, dynamic> map) {
@@ -12,6 +13,7 @@ class BuildYamlOptions {
       providerFamilyNamePrefix: map['provider_family_name_prefix'] as String?,
       providerNameSuffix: map['provider_name_suffix'] as String?,
       providerFamilyNameSuffix: map['provider_family_name_suffix'] as String?,
+      providerNameStripPattern: map['provider_name_strip_pattern'] as String?,
     );
   }
 
@@ -19,6 +21,7 @@ class BuildYamlOptions {
   final String? providerFamilyNamePrefix;
   final String? providerNameSuffix;
   final String? providerFamilyNameSuffix;
+  final String? providerNameStripPattern;
 }
 
 extension CaseChangeExtension on String {

--- a/packages/riverpod_generator/lib/src/riverpod_generator.dart
+++ b/packages/riverpod_generator/lib/src/riverpod_generator.dart
@@ -3,7 +3,6 @@ import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:meta/meta.dart';
 import 'package:riverpod_analyzer_utils/riverpod_analyzer_utils.dart';
-
 // ignore: implementation_imports, safe as we are the one controlling this file
 import 'package:riverpod_annotation/src/riverpod_annotation.dart';
 import 'package:source_gen/source_gen.dart';
@@ -223,7 +222,18 @@ extension ProviderElementNames on GeneratorProviderDeclarationElement {
             : options.providerNameSuffix) ??
         _defaultProviderNameSuffix;
 
-    return '$prefix${prefix.isEmpty ? name.lowerFirst : name.titled}$suffix';
+    var baseName = name;
+
+    if (options.providerNameStripPattern case final stripPattern?) {
+      try {
+        final regex = RegExp(stripPattern);
+        baseName = name.replaceAll(regex, '');
+      } catch (_) {
+        // If the regex is invalid ignore it
+      }
+    }
+
+    return '$prefix${prefix.isEmpty ? baseName.lowerFirst : baseName.titled}$suffix';
   }
 
   String get providerTypeName => '${name.titled}Provider';

--- a/packages/riverpod_generator/lib/src/riverpod_generator.dart
+++ b/packages/riverpod_generator/lib/src/riverpod_generator.dart
@@ -228,8 +228,11 @@ extension ProviderElementNames on GeneratorProviderDeclarationElement {
       try {
         final regex = RegExp(stripPattern);
         baseName = name.replaceAll(regex, '');
-      } catch (_) {
-        // If the regex is invalid ignore it
+      } on FormatException {
+        throw InvalidGenerationSourceError(
+          'Your providerNameStripPattern definition is not a valid regular expression: $stripPattern',
+          element: element,
+        );
       }
     }
 

--- a/packages/riverpod_generator/test/build_yaml_config_test.dart
+++ b/packages/riverpod_generator/test/build_yaml_config_test.dart
@@ -25,4 +25,16 @@ void main() {
     final options = BuildYamlOptions.fromMap(map);
     expect(options.providerFamilyNamePrefix, 'myFamily');
   });
+
+  test('provider name strip pattern', () async {
+    const map = {'provider_name_strip_pattern': r'Notifier$'};
+    final options = BuildYamlOptions.fromMap(map);
+    expect(options.providerNameStripPattern, r'Notifier$');
+  });
+
+  test('provider name strip pattern with multiple patterns', () async {
+    const map = {'provider_name_strip_pattern': r'(Notifier|Controller)$'};
+    final options = BuildYamlOptions.fromMap(map);
+    expect(options.providerNameStripPattern, r'(Notifier|Controller)$');
+  });
 }


### PR DESCRIPTION
## Related Issues

#2244 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.

## Discussion

This PR propose an option for `build.yaml` to remove a regular expression from generated providers.

As stated in this comment https://github.com/rrousselGit/riverpod/issues/2244#issuecomment-1668701712, to reduce verbosity and line length, instead of :

```dart
ref.read(authMethodNotifierProvider.notifier).switch(AuthMethod.google);
```

We would prefer:

```dart
ref.read(authMethodProvider.notifier).switch(AuthMethod.google);
```

Without this PR we had name our notifier class `AuthMethod` and it clashes with the model class `AuthMethod`.

With this PR, if you set `providerNameStripPattern: "Notifier$"` in `build.yaml`, you can name the notifier class `AuthMethodNotifier` and the generated provider variable will be `authMethodProvider`.

It's opt-in to prevent breaking changes and is compatible with custom prefixes and suffixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a configuration option to strip specified patterns from generated provider names using regular expressions.
  * Added support for customizing provider names by removing suffixes like "Notifier" or "Controller" during code generation.
  * Added new notifier providers with synchronous integer state initialization, including single and family providers.

* **Documentation**
  * Updated documentation to explain the new provider name strip pattern option with usage examples.

* **Tests**
  * Added tests to verify correct parsing and application of the provider name strip pattern configuration.
  * Added test cases confirming provider names match expected values after applying strip patterns.

* **Chores**
  * Updated changelog to reflect the new configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->