### PR TITLE
fixes https://github.com/rrousselGit/riverpod/issues/3498

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased build
+
+- Fixed a "markNeedsBuild" exception in some edge-cases when using scoped providers.
+
 ## 3.0.0-dev.17 - 2025-08-01
 
 - Added `MutationState.isPending/isIdle/hasError/isSuccess`

--- a/packages/flutter_riverpod/lib/src/core.dart
+++ b/packages/flutter_riverpod/lib/src/core.dart
@@ -1,6 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart' hide describeIdentity;
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart' as flutter_test;
 import 'package:meta/meta.dart';
 

--- a/packages/flutter_riverpod/test/provider_scope_test.dart
+++ b/packages/flutter_riverpod/test/provider_scope_test.dart
@@ -58,7 +58,7 @@ void main() {
 
       expect(find.text('is combined? true'), findsOneWidget);
       expect(find.text('second: 42, combined 42'), findsOneWidget);
-    }); 
+    });
 
     group('retry', () {
       testWidgets('passes the value to the ProviderContainer', (tester) async {

--- a/packages/flutter_riverpod/test/provider_scope_test.dart
+++ b/packages/flutter_riverpod/test/provider_scope_test.dart
@@ -4,6 +4,62 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('ProviderScope', () {
+    testWidgets(
+        'Supports scheduling rebuilds of a scoped provider '
+        'from an ancestor scope update', (tester) async {
+      // Regression test for https://github.com/rrousselGit/riverpod/issues/3498
+      final futureProvider = FutureProvider.autoDispose<int>(
+        (ref) async {
+          await null;
+          return 42;
+        },
+        name: 'futureProvider',
+      );
+
+      final secondProvider = Provider.autoDispose<int?>(
+        (ref) => ref.watch(futureProvider).value,
+        name: 'secondProvider',
+      );
+
+      final combinedProvider = Provider.autoDispose<int?>(
+        (ref) => ref.watch(secondProvider),
+        name: 'combinedProvider',
+      );
+
+      const key = Key('Widget1');
+      final widget1 = Consumer(
+        key: key,
+        builder: (context, ref, _) {
+          final isCombined = ref.watch(combinedProvider) != null;
+          return Text('is combined? $isCombined');
+        },
+      );
+      final widget2 = Consumer(
+        builder: (context, ref, _) {
+          final combined = ref.watch(combinedProvider);
+          final second = ref.watch(secondProvider);
+          return Text('second: $second, combined $combined');
+        },
+      );
+      final app = MaterialApp(
+        home: ProviderScope(
+          overrides: [combinedProvider],
+          child: Scaffold(body: Column(children: [widget1, widget2])),
+        ),
+      );
+
+      await tester.pumpWidget(ProviderScope(child: app));
+
+      expect(find.text('is combined? false'), findsOneWidget);
+
+      final container = tester.container(of: find.byKey(key));
+      await container.read(futureProvider.future);
+      await tester.pump();
+
+      expect(find.text('is combined? true'), findsOneWidget);
+      expect(find.text('second: 42, combined 42'), findsOneWidget);
+    }); 
+
     group('retry', () {
       testWidgets('passes the value to the ProviderContainer', (tester) async {
         Duration? retry(int count, Object error) => Duration.zero;

--- a/packages/flutter_riverpod/test/src/core/consumer_test.dart
+++ b/packages/flutter_riverpod/test/src/core/consumer_test.dart
@@ -305,6 +305,25 @@ void main() {
     expect(find.byKey(const Key('42')), findsOneWidget);
   });
 
+  testWidgets(
+      'Handles using ref.read inside initState on autoDispose providers',
+      (tester) async {
+    // Regression test for https://github.com/rrousselGit/riverpod/issues/3498
+    // When using autoDispose + ref.read, this could trigger a markNeedsBuild
+    // exception in the ProviderScope.
+    final provider = Provider.autoDispose((ref) => 0);
+
+    final widget = CallbackConsumerWidget(
+      initState: (context, ref) {
+        ref.read(provider);
+      },
+    );
+
+    await tester.pumpWidget(ProviderScope(child: widget));
+
+    // Should not have thrown an exception
+  });
+
   testWidgets('Ref is unusable after dispose', (tester) async {
     late WidgetRef ref;
     await tester.pumpWidget(


### PR DESCRIPTION
## Related Issues

fixes https://github.com/rrousselGit/riverpod/issues/3498

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue causing "markNeedsBuild" exceptions in certain edge cases when using scoped providers.

* **Tests**
  * Added widget tests to verify correct rebuild scheduling with ancestor scope updates and to ensure no exceptions occur when reading providers during widget initialization.

* **Documentation**
  * Updated the changelog to document the fix for the scoped provider rebuild issue.

* **Refactor**
  * Improved provider scope widget lifecycle and rebuild management by restructuring it to use a stateful wrapper.
  * Enhanced scheduler reliability with added assertions ensuring provider elements belong to the current scheduler instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->