### PR TITLE
Have offline decoding emit an AsyncLoading instead of AsyncError

### DIFF
--- a/packages/riverpod/lib/src/core/async_value.dart
+++ b/packages/riverpod/lib/src/core/async_value.dart
@@ -1,10 +1,4 @@
-import 'package:meta/meta.dart';
-
-import '../common/internal_lints.dart';
-import '../common/stack_trace.dart';
-import '../framework.dart';
-import '../providers/future_provider.dart' show FutureProvider;
-import '../providers/stream_provider.dart' show StreamProvider;
+part of '../framework.dart';
 
 @internal
 extension AsyncTransition<ValueT> on AsyncValue<ValueT> {
@@ -34,6 +28,15 @@ extension<ValueT> on _DataRecord<ValueT> {
 /// Adds non-state related methods/getters to [AsyncValue].
 @publicInRiverpodAndCodegen
 extension AsyncValueExtensions<ValueT> on AsyncValue<ValueT> {
+  bool get _isMultiState {
+    var count = 0;
+    if (_loading != null) count++;
+    if (_value != null) count++;
+    if (_error != null) count++;
+
+    return count > 1;
+  }
+
   _DataFilledRecord<ValueT>? get _valueFilled {
     final value = _value;
     if (value == null) return null;

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -61,6 +61,11 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
   }) {
     final previous = value;
 
+    if (newState._isMultiState) {
+      super.value = newState;
+      return;
+    }
+
     super.value =
         newState.cast<ValueT>().copyWithPrevious(previous, isRefresh: seamless);
   }

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -297,7 +297,11 @@ abstract class $AsyncNotifierBase<ValueT>
     with AnyNotifier<AsyncValue<ValueT>, ValueT> {
   @override
   void _setStateFromValue(ValueT value) {
-    state = AsyncData(value, kind: DataKind.cache);
+    state = AsyncLoading._(
+      (progress: state.progress,),
+      value: (value, kind: DataKind.cache, source: _DataSource.liveOrRefresh),
+      error: state._error,
+    );
   }
 
   @override

--- a/packages/riverpod/lib/src/framework.dart
+++ b/packages/riverpod/lib/src/framework.dart
@@ -34,3 +34,4 @@ part 'core/proxy_provider_listenable.dart';
 part 'core/mutations.dart';
 part 'core/ref.dart';
 part 'core/scheduler.dart';
+part 'core/async_value.dart';

--- a/packages/riverpod/lib/src/internals.dart
+++ b/packages/riverpod/lib/src/internals.dart
@@ -13,7 +13,6 @@ export 'common/internal_lints.dart';
 export 'common/listenable.dart';
 export 'common/result.dart';
 export 'common/stack_trace.dart';
-export 'core/async_value.dart';
 export 'core/persist.dart';
 export 'framework.dart';
 export 'providers/async_notifier.dart';

--- a/packages/riverpod/lib/src/providers/async_notifier.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier.dart
@@ -4,7 +4,6 @@ import 'package:meta/meta.dart';
 
 import '../builder.dart';
 import '../common/internal_lints.dart';
-import '../core/async_value.dart';
 import '../framework.dart';
 import 'future_provider.dart' show FutureProvider;
 import 'notifier.dart';

--- a/packages/riverpod/lib/src/providers/future_provider.dart
+++ b/packages/riverpod/lib/src/providers/future_provider.dart
@@ -4,7 +4,6 @@ import 'package:meta/meta.dart';
 
 import '../builder.dart';
 import '../common/internal_lints.dart';
-import '../core/async_value.dart';
 import '../framework.dart';
 import 'async_notifier.dart';
 import 'provider.dart' show Provider;

--- a/packages/riverpod/lib/src/providers/notifier.dart
+++ b/packages/riverpod/lib/src/providers/notifier.dart
@@ -2,7 +2,6 @@ import 'package:meta/meta.dart';
 
 import '../builder.dart';
 import '../common/internal_lints.dart';
-import '../core/async_value.dart';
 import '../framework.dart';
 import 'async_notifier.dart';
 import 'provider.dart';

--- a/packages/riverpod/lib/src/providers/provider.dart
+++ b/packages/riverpod/lib/src/providers/provider.dart
@@ -2,7 +2,6 @@ import 'package:meta/meta.dart';
 
 import '../builder.dart';
 import '../common/internal_lints.dart';
-import '../core/async_value.dart';
 import '../framework.dart';
 import 'legacy/state_notifier_provider.dart' show StateNotifierProvider;
 import 'stream_provider.dart' show StreamProvider;

--- a/packages/riverpod/lib/src/providers/stream_notifier.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier.dart
@@ -4,7 +4,6 @@ import 'package:meta/meta.dart';
 
 import '../builder.dart';
 import '../common/internal_lints.dart';
-import '../core/async_value.dart';
 import '../framework.dart';
 import 'async_notifier.dart';
 import 'future_provider.dart' show FutureProvider;

--- a/packages/riverpod/lib/src/providers/stream_provider.dart
+++ b/packages/riverpod/lib/src/providers/stream_provider.dart
@@ -6,7 +6,6 @@ import '../builder.dart';
 import '../common/internal_lints.dart';
 import '../common/listenable.dart';
 import '../common/result.dart';
-import '../core/async_value.dart';
 import '../framework.dart';
 import 'future_provider.dart' show FutureProvider;
 import 'provider.dart' show Provider;

--- a/packages/riverpod/test/src/core/async_value_test.dart
+++ b/packages/riverpod/test/src/core/async_value_test.dart
@@ -3,7 +3,7 @@
 import 'dart:async';
 
 import 'package:riverpod/riverpod.dart';
-import 'package:riverpod/src/core/async_value.dart' show DataKind;
+import 'package:riverpod/src/internals.dart' show DataKind;
 import 'package:test/test.dart';
 
 import '../utils.dart';


### PR DESCRIPTION
fixes #4218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Loading states now preserve cached value, progress, and prior errors for smoother UI during updates.
  - Improved handling of complex async transitions to avoid merging issues.

- Bug Fixes
  - Reduced unnecessary rebuilds in chained/offline provider scenarios.
  - More reliable behavior when decoding persisted data and when adapters emit values from storage.

- Refactor
  - Internal module consolidation and import cleanup; no public API changes.

- Tests
  - Added regression tests covering offline chaining, async persistence decoding, and DB-backed emissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->