### PR TITLE
When a provider emits an error, keep preserved state.

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Fix provider rebuild order issue.
 - Fix "Tried to refresh x multiple times in the same frame" incorrectly triggering.
 - Removed `FamilyNotifier` and variants, in favour of `Notifier`.
+- Preserve persisted state if a provider throws.
+- `provider.future` will now skip offline-persisted state by default.
+  This avoids awkward unexpected provider rebuild when chaining persisted providers.
 
 ## 3.0.0-dev.17 - 2025-08-01
 


### PR DESCRIPTION
fixes #4129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Persisted state is preserved if a provider throws, preventing loss of cached data.
  - provider.future now skips offline-persisted state by default, avoiding unexpected rebuilds when chaining persisted providers.

- Documentation
  - Updated changelog to reflect the new persistence and error-handling behavior.

- Tests
  - Added coverage ensuring decoded state is preserved when an error occurs after decoding.
  - Removed an obsolete async storage test to align with current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->