### PR TITLE
Don't pause ref.listen/ref.listenManual based off TickerMode

### DIFF
--- a/packages/flutter_riverpod/lib/src/core/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/core/consumer.dart
@@ -383,14 +383,6 @@ base class ConsumerStatefulElement extends StatefulElement
   List<ProviderSubscription<Object?>>? _manualListeners;
   bool? _isActive;
 
-  Iterable<ProviderSubscription> get _allSubscriptions sync* {
-    yield* _dependencies.values;
-    yield* _listeners;
-    if (_manualListeners != null) {
-      yield* _manualListeners!;
-    }
-  }
-
   void _applyTickerMode(ProviderSubscription sub) {
     if (_isActive == false) sub.pause();
   }
@@ -413,7 +405,7 @@ base class ConsumerStatefulElement extends StatefulElement
     final isActive = TickerMode.of(context);
     if (isActive != _isActive) {
       _isActive = isActive;
-      for (final sub in _allSubscriptions) {
+      for (final sub in _dependencies.values) {
         if (isActive) {
           sub.resume();
         } else {
@@ -507,7 +499,6 @@ base class ConsumerStatefulElement extends StatefulElement
     // which listen call was preserved between widget rebuild, and we wouldn't
     // want to call the listener on every rebuild.
     final sub = container.listen<StateT>(provider, listener, onError: onError);
-    _applyTickerMode(sub);
     _listeners.add(sub);
   }
 
@@ -569,7 +560,6 @@ base class ConsumerStatefulElement extends StatefulElement
       _manualListeners?.remove(sub);
     };
 
-    _applyTickerMode(sub);
     listeners.add(sub);
 
     return sub;

--- a/packages/flutter_riverpod/test/src/core/consumer_test.dart
+++ b/packages/flutter_riverpod/test/src/core/consumer_test.dart
@@ -310,15 +310,7 @@ void main() {
 
   testWidgets('can extend ConsumerWidget', (tester) async {
     final provider = Provider((ref) => 'hello world');
-    await tester.pumpWidget(
-      ProviderScope(
-        child: Consumer(
-          builder: (context, ref, _) {
-            return Text(ref.watch(provider), textDirection: TextDirection.rtl);
-          },
-        ),
-      ),
-    );
+    await tester.pumpWidget(const ProviderScope(child: MyWidget()));
 
     expect(find.text('hello world'), findsOneWidget);
   });
@@ -825,7 +817,16 @@ class TestNotifier extends StateNotifier<int> {
   @override
   int get state;
 }
+final _provider = Provider((ref) => 'hello world');
 
+class MyWidget extends ConsumerWidget {
+  const MyWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Text(ref.watch(_provider), textDirection: TextDirection.rtl);
+  }
+}
 class CallbackConsumerWidget extends ConsumerStatefulWidget {
   const CallbackConsumerWidget({
     super.key,

--- a/packages/flutter_riverpod/test/src/core/consumer_test.dart
+++ b/packages/flutter_riverpod/test/src/core/consumer_test.dart
@@ -816,6 +816,7 @@ class TestNotifier extends StateNotifier<int> {
   @override
   int get state;
 }
+
 final _provider = Provider((ref) => 'hello world');
 
 class MyWidget extends ConsumerWidget {
@@ -826,6 +827,7 @@ class MyWidget extends ConsumerWidget {
     return Text(ref.watch(_provider), textDirection: TextDirection.rtl);
   }
 }
+
 class CallbackConsumerWidget extends ConsumerStatefulWidget {
   const CallbackConsumerWidget({
     super.key,

--- a/packages/flutter_riverpod/test/src/core/consumer_test.dart
+++ b/packages/flutter_riverpod/test/src/core/consumer_test.dart
@@ -309,7 +309,6 @@ void main() {
   });
 
   testWidgets('can extend ConsumerWidget', (tester) async {
-    final provider = Provider((ref) => 'hello world');
     await tester.pumpWidget(const ProviderScope(child: MyWidget()));
 
     expect(find.text('hello world'), findsOneWidget);


### PR DESCRIPTION
fixes #4231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted TickerMode behavior to pause only provider dependencies. Listener and manual subscriptions are no longer paused on creation, improving alignment with widget visibility.
* **Tests**
  * Reworked tests to validate TickerMode-driven pausing of subscriptions and removed legacy scenarios around manual listening.
  * Simplified test widgets to be self-contained and updated disposal checks.

No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->