### PR TITLE
During retry after error, keep flagging the state as Loading

### DIFF
--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -108,13 +108,10 @@ final class ProviderScope extends StatefulWidget {
     return scope.container;
   }
 
-  /// The default retry logic used by providers associated to this container.
+  /// The retry logic used by providers associated to this container.
   ///
-  /// The default implementation:
-  /// - has unlimited retries
-  /// - starts with a delay of 200ms
-  /// - doubles the delay on each retry up to 6.4 seconds
-  /// - retries all failures
+  /// See [ProviderContainer.defaultRetry] for information about the
+  /// default retry logic.
   final Retry? retry;
 
   /// The part of the widget tree that can use Riverpod and has overridden providers.

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased build
 
+- A provider that is currently being retried is now flagged as "loading"
+  while the retry attempts complete.
+  Meaning that `ref.watch(provider.future)` skips the intermediate error states.
 - Fix an issue with the internals of AsyncValue
 - `ProviderObserver` is now marked with `base`
 - Fix provider rebuild order issue.

--- a/packages/riverpod/lib/src/core/async_value.dart
+++ b/packages/riverpod/lib/src/core/async_value.dart
@@ -755,12 +755,10 @@ final class AsyncLoading<ValueT> extends AsyncValue<ValueT> {
           value: previousValue,
         ),
         loading: (_) {
-          if (_value == previousValue) return this;
-
           return AsyncLoading<ValueT>._(
             _loading,
             value: previousValue,
-            error: _error,
+            error: previous._error,
           );
         },
       );

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -1295,8 +1295,9 @@ mixin SyncProviderElement<ValueT> on ProviderElement<ValueT, ValueT> {
     switch (value) {
       case AsyncData():
         return $ResultData(value.value);
-      case AsyncError():
-        return $ResultError(value.error, value.stackTrace);
+      case AsyncLoading(:final error?, :final stackTrace?) when value.retrying:
+      case AsyncError(:final error, :final stackTrace):
+        return $ResultError(error, stackTrace);
       case AsyncLoading():
         return null;
     }

--- a/packages/riverpod/lib/src/core/modifiers/future.dart
+++ b/packages/riverpod/lib/src/core/modifiers/future.dart
@@ -178,7 +178,7 @@ mixin FutureModifierClassElement<
         $ClassProviderElement<NotifierT, AsyncValue<ValueT>, ValueT, CreatedT> {
   @override
   void handleError(Ref ref, Object error, StackTrace stackTrace) {
-    onError(triggerRetry(error, stackTrace), seamless: !ref.isReload);
+    onValue(triggerRetry(error, stackTrace), seamless: !ref.isReload);
   }
 }
 

--- a/packages/riverpod/pubspec.yaml
+++ b/packages/riverpod/pubspec.yaml
@@ -20,6 +20,7 @@ environment:
 resolution: workspace
 
 dependencies:
+  async: ^2.13.0
   clock: ^1.1.1
   collection: ^1.18.0
   meta: ^1.15.0

--- a/packages/riverpod/test/feature/offline_test.dart
+++ b/packages/riverpod/test/feature/offline_test.dart
@@ -302,7 +302,7 @@ void main() {
 
               expect(
                 container.read(provider),
-                isA<AsyncError<Object?>>()
+                isA<AsyncLoading<Object?>>()
                     .having((e) => e.isFromCache, 'isFromCache', true)
                     .having((e) => e.value, 'value', 42)
                     .having((e) => e.stackTrace, 'stackTrace', isNotNull)

--- a/packages/riverpod/test/old/legacy_providers/future_provider/future_provider_test.dart
+++ b/packages/riverpod/test/old/legacy_providers/future_provider/future_provider_test.dart
@@ -372,8 +372,11 @@ void main() {
   });
 
   test('throwing inside "create" result in an AsyncValue.error', () {
-    // ignore: only_throw_errors
-    final provider = FutureProvider<int>((ref) => throw 42);
+    final provider = FutureProvider<int>(
+      // ignore: only_throw_errors
+      (ref) => throw 42,
+      retry: (_, __) => null,
+    );
     final container = ProviderContainer.test();
 
     expect(
@@ -403,11 +406,7 @@ void main() {
 
     expect(
       container.read(provider),
-      isA<AsyncValue<int>>().having(
-        (s) => s.maybeWhen(error: (err, _) => err, orElse: () => null),
-        'error',
-        42,
-      ),
+      isA<AsyncValue<int>>().having((s) => s.error, 'error', 42),
     );
   });
 

--- a/packages/riverpod/test/old/legacy_providers/stream_provider/stream_provider_test.dart
+++ b/packages/riverpod/test/old/legacy_providers/stream_provider/stream_provider_test.dart
@@ -497,8 +497,11 @@ void main() {
   test('throwing inside "create" result in an AsyncValue.error', () {
     final container = ProviderContainer.test();
 
-    // ignore: only_throw_errors
-    final provider = StreamProvider<int>((ref) => throw 42);
+    final provider = StreamProvider<int>(
+      // ignore: only_throw_errors
+      (ref) => throw 42,
+      retry: (_, _) => null,
+    );
 
     expect(
       container.read(provider),
@@ -735,25 +738,13 @@ void main() {
         await controller.close();
       });
 
-      test('read currentValue before first error', () async {
+      test('read currentValue after error', () async {
         final container = ProviderContainer.test();
         final controller = StreamController<int>();
-        final provider = StreamProvider<int>((_) => controller.stream);
-
-        container.listen(provider, (p, n) {});
-        final future = container.read(provider.future);
-
-        controller.addError(42);
-
-        await expectLater(future, throwsA(42));
-
-        await controller.close();
-      });
-
-      test('read currentValue before after error', () async {
-        final container = ProviderContainer.test();
-        final controller = StreamController<int>();
-        final provider = StreamProvider<int>((_) => controller.stream);
+        final provider = StreamProvider<int>(
+          (_) => controller.stream,
+          retry: (_, __) => null,
+        );
 
         controller.addError(42);
 

--- a/packages/riverpod/test/src/core/modifiers/select_async_test.dart
+++ b/packages/riverpod/test/src/core/modifiers/select_async_test.dart
@@ -32,7 +32,10 @@ void main() {
       final controller = StreamController<int>();
       final provider = Provider((ref) => ref);
       addTearDown(controller.close);
-      final dep = StreamProvider<int>((ref) => controller.stream);
+      final dep = StreamProvider<int>(
+        (ref) => controller.stream,
+        retry: (_, _) => null,
+      );
 
       container.listen(dep, (p, n) {});
       final ref = container.listen(provider, (a, b) {});

--- a/packages/riverpod/test/src/core/modifiers/select_async_test.dart
+++ b/packages/riverpod/test/src/core/modifiers/select_async_test.dart
@@ -74,7 +74,10 @@ void main() {
   test('implements ProviderSubscription.read on AsyncError', () async {
     final container = ProviderContainer.test();
     final dep = StateProvider((ref) => 0);
-    final provider = FutureProvider<int>((ref) => Future.error(ref.watch(dep)));
+    final provider = FutureProvider<int>(
+      (ref) => Future.error(ref.watch(dep)),
+      retry: (_, __) => null,
+    );
 
     final sub = container.listen<Future<bool>>(
       provider.selectAsync((data) => data.isEven),

--- a/packages/riverpod/test/src/providers/future_provider_test.dart
+++ b/packages/riverpod/test/src/providers/future_provider_test.dart
@@ -1,9 +1,12 @@
-import 'package:mockito/mockito.dart';
+import 'dart:async';
+
+import 'package:async/async.dart';
 import 'package:riverpod/riverpod.dart';
+import 'package:riverpod/src/framework.dart';
 import 'package:test/test.dart';
 
 import '../../third_party/fake_async.dart';
-import '../utils.dart';
+import '../matrix.dart';
 
 void main() {
   group('FutureProvider', () {
@@ -12,43 +15,79 @@ void main() {
         'handles retry',
         () => fakeAsync((fake) async {
           final container = ProviderContainer.test();
-          var err = Exception('foo');
+          final controller = StreamController<AsyncValue<int>>();
+          addTearDown(controller.close);
+          final queue = StreamQueue(controller.stream);
+          addTearDown(queue.cancel);
+
+          Object? err;
           final stack = StackTrace.current;
-          final provider = FutureProvider<int>(
-            (ref) => Error.throwWithStackTrace(err, stack),
-            retry: (_, __) => const Duration(seconds: 1),
-          );
-          final listener = Listener<AsyncValue<int>>();
+          final provider = AsyncNotifierProvider<AsyncNotifier<int>, int>(
+            () => DeferredAsyncNotifier((ref, self) {
+              if (err == null) return 42;
+              Error.throwWithStackTrace(err, stack);
+            }),
+            retry: (retryCount, __) {
+              if (retryCount >= 2) return null;
 
-          container.listen(provider, fireImmediately: true, listener.call);
-          await container.read(provider.future).catchError((e) => 0);
-
-          verifyOnly(
-            listener,
-            listener(
-              any,
-              argThat(
-                isAsyncError<int>(err, stackTrace: stack, retrying: true),
-              ),
-            ),
+              return const Duration(seconds: 1);
+            },
           );
+
+          final sub = container.listen(provider, fireImmediately: true, (_, b) {
+            controller.add(b);
+          });
+          await queue.next;
+
+          err = Exception('foo');
+          container.invalidate(provider);
+          fake.elapse(const Duration(microseconds: 50));
+          await queue.next;
+
+          AsyncValue<int> value = sub.read() as AsyncLoading<int>;
+          expect(
+            value.error,
+            isException.having((e) => '$e', 'toString', 'Exception: foo'),
+          );
+          expect(value.stackTrace, stack);
+          expect(value.value, 42);
+          expect(value.isLoading, true);
+          expect(value.retrying, true);
+          expect(value.valueFilled!.source, DataSource.liveOrRefresh);
 
           err = Exception('bar');
-
           fake.elapse(const Duration(seconds: 1));
           fake.flushMicrotasks();
 
-          await container.read(provider.future).catchError((e) => 0);
+          await queue.next;
 
-          verifyOnly(
-            listener,
-            listener(
-              any,
-              argThat(
-                isAsyncError<int>(err, stackTrace: stack, retrying: true),
-              ),
-            ),
+          value = sub.read() as AsyncLoading<int>;
+          expect(
+            value.error,
+            isException.having((e) => '$e', 'toString', 'Exception: bar'),
           );
+          expect(value.stackTrace, stack);
+          expect(value.value, 42);
+          expect(value.isLoading, true);
+          expect(value.retrying, true);
+          expect(value.valueFilled!.source, DataSource.liveOrRefresh);
+
+          err = Exception('baz');
+          fake.elapse(const Duration(seconds: 1));
+          fake.flushMicrotasks();
+
+          await queue.next;
+
+          value = sub.read() as AsyncError<int>;
+          expect(
+            value.error,
+            isException.having((e) => '$e', 'toString', 'Exception: baz'),
+          );
+          expect(value.stackTrace, stack);
+          expect(value.isLoading, false);
+          expect(value.value, 42);
+          expect(value.retrying, false);
+          expect(value.valueFilled!.source, DataSource.liveOrRefresh);
         }),
       );
     });

--- a/packages/riverpod/test/src/utils.dart
+++ b/packages/riverpod/test/src/utils.dart
@@ -285,7 +285,11 @@ TypeMatcher<AsyncLoading<ValueT>> isAsyncLoading<ValueT>({
     matcher = matcher.having((e) => e.isReloading, 'isReloading', isReloading);
   }
   if (isRefreshing != const _Sentinel()) {
-    matcher = matcher.having((e) => e.isRefreshing, 'isRefreshing', isRefreshing);
+    matcher = matcher.having(
+      (e) => e.isRefreshing,
+      'isRefreshing',
+      isRefreshing,
+    );
   }
   if (retrying != const _Sentinel()) {
     matcher = matcher.having((e) => e.retrying, 'retrying', retrying);

--- a/packages/riverpod/test/src/utils.dart
+++ b/packages/riverpod/test/src/utils.dart
@@ -269,8 +269,24 @@ TypeMatcher<AsyncLoading<ValueT>> isAsyncLoading<ValueT>({
   Object? error = const _Sentinel(),
   Object? stackTrace = const _Sentinel(),
   Object? hasError = const _Sentinel(),
+  Object? isReloading = const _Sentinel(),
+  Object? isRefreshing = const _Sentinel(),
+  Object? progress = const _Sentinel(),
 }) {
-  var matcher = isA<AsyncLoading<ValueT>>();
+  var matcher = isA<AsyncLoading<ValueT>>().having(
+    (e) => e.isLoading,
+    'isLoading',
+    true,
+  );
+  if (progress != const _Sentinel()) {
+    matcher = matcher.having((e) => e.progress, 'progress', progress);
+  }
+  if (isReloading != const _Sentinel()) {
+    matcher = matcher.having((e) => e.isReloading, 'isReloading', isReloading);
+  }
+  if (isRefreshing != const _Sentinel()) {
+    matcher = matcher.having((e) => e.isRefreshing, 'isRefreshing', isRefreshing);
+  }
   if (retrying != const _Sentinel()) {
     matcher = matcher.having((e) => e.retrying, 'retrying', retrying);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Providers now report a loading state while retrying; watching provider.future skips transient errors.
  - FutureProvider/StreamProvider gain a configurable retry callback to control retry behavior.

- **Improvements**
  - More consistent handling of loading/error states and retry semantics, preserving previous data during retries.

- **Documentation**
  - Retry docs updated to reference the central default retry policy.

- **Chores**
  - Added dependency on async.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->