### PR TITLE
Fix mistake of wrongly nested providers

### DIFF
--- a/website/docs/concepts2/retry.mdx
+++ b/website/docs/concepts2/retry.mdx
@@ -48,8 +48,7 @@ for that specific provider:
     return 0;
   }
   `}
-  raw={`final myProvider = FutureProvider<int>((ref) async {
-  final provider = Provider<int>(
+  raw={`final myProvider = Provider<int>(
     // highlight-next-line
     retry: myRetry,
     (ref) => 0,


### PR DESCRIPTION
A future provider is wrongly being shown above the normal provider.

## Related Issues

fixes #your-issue-number

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated “Retry” concept docs with a simplified, synchronous provider example for clearer guidance.
  * Clarifies use of the retry option and expected initial values.
  * Replaces outdated asynchronous example, improving readability and consistency with current patterns.
  * Enhances accuracy for users migrating from async usage and reduces confusion.
  * No product behavior changes; docs-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->