### PR TITLE
feat: allow disabling of duplicate override error

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- Added `ProviderScope` parameter to disable duplicate override error in tests.
+
 ## 3.0.0 - 2025-09-10
 
 Finally, a stable release for Riverpod 3.0!

--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -77,6 +77,7 @@ final class ProviderScope extends StatefulWidget {
     this.overrides = const [],
     this.observers,
     this.retry,
+    @visibleForTesting this.throwOnOverrideDuplication = kDebugMode,
     required this.child,
   });
 
@@ -136,6 +137,12 @@ final class ProviderScope extends StatefulWidget {
   /// Ancestors of this [ProviderScope] will not be affected by the overrides.
   final List<Override> overrides;
 
+  /// Whether to throw if a provider is overridden more than once.
+  ///
+  /// This is enabled by default in debug mode to catch mistakes, and disabled
+  /// in release mode.
+  final bool throwOnOverrideDuplication;
+
   @override
   ProviderScopeState createState() => ProviderScopeState();
 }
@@ -163,6 +170,8 @@ final class ProviderScopeState extends State<ProviderScope> {
       overrides: widget.overrides,
       observers: widget.observers,
       retry: widget.retry,
+      // ignore: invalid_use_of_visible_for_testing_member
+      throwOnOverrideDuplication: widget.throwOnOverrideDuplication,
       onError: (err, stack) {
         FlutterError.reportError(
           FlutterErrorDetails(

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- Added `ProviderContainer` parameter to disable duplicate override error in tests.
+
 ## 3.0.0 - 2025-09-10
 
 Finally, a stable release for Riverpod 3.0!

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -740,7 +740,7 @@ final class ProviderContainer implements Node, MutationTarget {
     List<ProviderObserver>? observers,
     @internal void Function(Object error, StackTrace stackTrace)? onError,
     Retry? retry,
-    @visibleForTesting bool throwOnDuplicatedOverride = kDebugMode,
+    @visibleForTesting bool throwOnOverrideDuplication = kDebugMode,
   }) : _debugOverridesLength = overrides.length,
        _depth = parent == null ? 0 : parent._depth + 1,
        _parent = parent,
@@ -756,7 +756,7 @@ final class ProviderContainer implements Node, MutationTarget {
       }
     }
 
-    if (throwOnDuplicatedOverride) {
+    if (throwOnOverrideDuplication) {
       final overrideOrigins = <Object?>{};
       for (final override in overrides) {
         switch (override) {

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -740,6 +740,7 @@ final class ProviderContainer implements Node, MutationTarget {
     List<ProviderObserver>? observers,
     @internal void Function(Object error, StackTrace stackTrace)? onError,
     Retry? retry,
+    @visibleForTesting bool throwOnDuplicatedOverride = kDebugMode,
   }) : _debugOverridesLength = overrides.length,
        _depth = parent == null ? 0 : parent._depth + 1,
        _parent = parent,
@@ -755,7 +756,7 @@ final class ProviderContainer implements Node, MutationTarget {
       }
     }
 
-    if (false) {
+    if (throwOnDuplicatedOverride) {
       final overrideOrigins = <Object?>{};
       for (final override in overrides) {
         switch (override) {

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -755,7 +755,7 @@ final class ProviderContainer implements Node, MutationTarget {
       }
     }
 
-    if (kDebugMode) {
+    if (false) {
       final overrideOrigins = <Object?>{};
       for (final override in overrides) {
         switch (override) {


### PR DESCRIPTION
## Related Issues

fixes [#4302](https://github.com/rrousselGit/riverpod/issues/4302)

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a testing-only option to disable duplicate override errors via new parameters on ProviderScope and ProviderContainer. Enabled by default in debug builds, configurable for test scenarios.

- Documentation
  - Updated CHANGELOGs with an “Unreleased fix” entry describing the new option to disable duplicate override errors in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->