### PR TITLE
Remove unused onPuase method that does not have a page

### DIFF
--- a/website/docs/concepts2/refs.mdx
+++ b/website/docs/concepts2/refs.mdx
@@ -17,7 +17,7 @@ On top of that, [Ref] also enables a provider to observe life-cycles about its o
 Think "initState" and "dispose", but for providers. This includes methods such as:
 - [onDispose]
 - [onCancel]
-- [onPause]
+
 - etc.
 
 ## How to obtain a [Ref]
@@ -400,6 +400,5 @@ unregister();
 [WidgetRef]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/WidgetRef-class.html
 [onDispose]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/Ref/onDispose.html
 [onCancel]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/Ref/onCancel.html
-[onPause]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/Ref/onPause.html
 [select]: https://pub.dev/documentation/hooks_riverpod/latest/misc/ProviderListenable/select.html
 [ProviderSubscription]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/ProviderSubscription-class.html


### PR DESCRIPTION
If you search onPause method it doesn't have a page on https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/Ref/onPause.html

So It's confusing to read about this unimplemented method

## Related Issues

fixes #your-issue-number

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
