### PR TITLE
Update 3.0_migration.mdx

### DIFF
--- a/website/docs/3.0_migration.mdx
+++ b/website/docs/3.0_migration.mdx
@@ -96,7 +96,7 @@ class MyWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TickerMode(
-      enabled: true, // Never pause any decsendent listener.
+      enabled: true, // Never pause any descendant listener.
       child: Consumer(
         builder: (context, ref, child) {
           // This "watch" will not follow the automatic pausing behavior

--- a/website/docs/3.0_migration.mdx
+++ b/website/docs/3.0_migration.mdx
@@ -52,12 +52,7 @@ void main() {
 void main() {
   final container = ProviderContainer(
     // Never retry any provider
-    retry: (retryCount, error) {
-      if (error is SomeSpecificError) return null;
-      if (retryCount > 5) return null;
-
-      return Duration(seconds: retryCount * 2);
-    },
+    retry: (retryCount, error) => null,
   );
 }
 ```
@@ -101,11 +96,11 @@ class MyWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TickerMode(
-      enabled: false, // This will pause the listeners
+      enabled: true, // Never pause any decsendent listener.
       child: Consumer(
         builder: (context, ref, child) {
-          // This "watch" will be paused
-          // until TickerMode is set to true
+          // This "watch" will not follow the automatic pausing behavior
+          // until TickerMode is removed.
           final value = ref.watch(myProvider);
           return Text(value.toString());
         },


### PR DESCRIPTION
Minor update to avoid misunderstanding in 3.0 migration guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated 3.0 migration guide to show that per-container retry customization is effectively disabled in the showcased pattern.
  - Clarified TickerMode behavior: descendant listeners are not paused while TickerMode is active and guidance on when automatic pausing resumes.
  - Restored and adjusted the ProviderException reference link for improved navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->