### PR TITLE
Synchronise tabs in website

### DIFF
--- a/website/docs/concepts2/providers.mdx
+++ b/website/docs/concepts2/providers.mdx
@@ -134,7 +134,7 @@ as per the table above.
 <Tabs>
 <TabItem value="Unmodifiable" label="Unmodifiable (functional)">
 
-<Tabs>
+<Tabs groupId="riverpod">
 <TabItem value="riverpod" label="riverpod">
 <Legend
   code={`
@@ -290,7 +290,7 @@ The type of this object is determined by the name of the function/class.
 </TabItem>
 
 <TabItem value="Modifiable" label="Modifiable (notifier)">
-<Tabs>
+<Tabs groupId="riverpod">
 <TabItem value="riverpod" label="riverpod">
 <Legend
   code={`final name = SomeNotifierProvider.someModifier<MyNotifier, Result>(MyNotifier.new);

--- a/website/src/components/CodeSnippet/index.tsx
+++ b/website/src/components/CodeSnippet/index.tsx
@@ -185,7 +185,7 @@ export function AutoSnippet(props: {
   }
 
   return (
-    <Tabs>
+    <Tabs groupId="riverpod">
       {tab(props.raw, "riverpod")}
       {tab(props.hooks, "riverpod + flutter_hooks")}
       {tab(props.codegen, "riverpod_generator")}


### PR DESCRIPTION
## Related Issues

fixes #4330


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Tab groups in provider docs now share selection state across related examples, so switching a tab in one snippet keeps the same selection in other corresponding snippets—making comparisons and navigation smoother and reducing repetitive clicks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->