### PR TITLE
Remove ref.read invocation for only_use_keep_alive_inside_keep_alive lint

### DIFF
--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased minor
+
+- Exclude `ref.read` invocations for `only_use_keep_alive_inside_keep_alive` lint (Thanks to @codeOfJannik)
+
 ## 3.1.3 - 2026-02-03
 
 - Assists to convert widgets to other widget types now correctly trigger on anything


### PR DESCRIPTION
## Related Issues

fixes #4334 

## Description

This pull request updates the `only_use_keep_alive_inside_keep_alive` lint in the `riverpod_lint` package to exclude `ref.read` invocations from its checks, ensuring the lint only applies to `ref.watch` and `ref.listen`.

**Lint rule behavior changes:**

* Updated the `only_use_keep_alive_inside_keep_alive` lint to ignore `ref.read` invocations, so it now only checks `ref.watch` and `ref.listen` calls.

**Documentation:**

* Added a changelog entry describing the exclusion of `ref.read` for this lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved keep_alive lint accuracy by refining detection logic for function invocation types
  * Enhanced lint handling for auto-dispose provider scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->