### PR TITLE
fix: avoid calling providerDidFail after provider disposal (#4706)

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+- Fixed `providerDidFail` being incorrectly called when an `autoDispose` provider
+  is disposed before emitting its first value. Disposal is a normal lifecycle event
+  and should not be reported as a provider failure.
+- Added `ProviderDisposedException`, thrown on `provider.future` when a provider
+  is disposed during loading state. Previously a `StateError` was thrown, making it
+  indistinguishable from real programmer errors.
+
 ## 3.2.1 - 2026-02-03
 
 - Fixed a bug where resuming a paused provider could cause it to never

--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -22,4 +22,5 @@ export 'src/internals.dart'
         ProviderListenableSelect,
         AsyncResult,
         AsyncValueExtensions,
-        AsyncValueIsLoadingException;
+        AsyncValueIsLoadingException,
+        ProviderDisposedException;

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -34,6 +34,47 @@ void Function()? debugCanModifyProviders;
 @internal
 typedef WhenComplete = void Function(void Function() cb)?;
 
+/// Thrown when a [FutureProvider] or [StreamProvider] is disposed before it
+/// has emitted its first value.
+///
+/// This is a normal lifecycle event — it occurs when an [autoDispose] provider
+/// is no longer listened to (e.g. due to navigation) while it is still loading.
+/// It is **not** a programming error.
+///
+/// [ProviderObserver.providerDidFail] will not be called for this exception.
+///
+/// If a downstream provider awaits a disposed provider's [FutureProvider.future],
+/// it will receive this exception. You can catch it to treat disposal as
+/// a no-op rather than an error:
+///
+/// ```dart
+/// final dependentProvider = FutureProvider.autoDispose<String>((ref) async {
+///   try {
+///     final value = await ref.watch(myProvider.future);
+///     return 'Got $value';
+///   } on ProviderDisposedException {
+///     // Upstream disposed before completing — this is expected.
+///     return '';
+///   }
+/// });
+/// ```
+@publicInMisc
+final class ProviderDisposedException implements Exception {
+  /// Creates a [ProviderDisposedException] for [provider].
+  ProviderDisposedException(this.provider);
+
+  /// The provider that was disposed before emitting a value.
+  final ProviderBase<Object?> provider;
+
+  @override
+  String toString() {
+    return 'ProviderDisposedException: The provider $provider was disposed '
+        'during loading state, before it could emit a value.\n'
+        'This is a normal lifecycle event caused by the provider being '
+        'no longer listened to while still loading.';
+  }
+}
+
 /// Mixin to help implement logic for listening to [Future]s/[Stream]s and setup
 /// `provider.future` + convert the object into an [AsyncValue].
 @internal
@@ -104,8 +145,13 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
     asyncTransition(value, seamless: seamless);
 
     final result = resultForValue(value);
-    if (result is! $ResultError<StateT> && !origin._isSynthetic) {
-      // Hard error states are already reported to the observers
+    if (result is! $ResultError<StateT> &&
+        !origin._isSynthetic &&
+        !_disposed) {
+      // Hard error states are already reported to the observers.
+      // Skip notification if the element is already disposed — the error
+      // is a post-dispose side-effect (e.g. ProviderDisposedException
+      // completing a pending future), not a real provider failure.
       for (final observer in container.observers) {
         container.runTernaryGuarded(
           observer.providerDidFail,
@@ -186,11 +232,8 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
     _cancelSubscription?.resume?.call();
   }
 
-  StateError _missingLastValueError() {
-    return StateError(
-      'The provider $origin was disposed during loading state, '
-      'yet no value could be emitted.',
-    );
+  ProviderDisposedException _missingLastValueError() {
+    return ProviderDisposedException(origin);
   }
 
   /// Listens to a [Future] and convert it into an [AsyncValue].
@@ -877,7 +920,7 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
       }
 
       for (final observer in container.observers) {
-        if (newState is $ResultError<StateT>) {
+        if (newState is $ResultError<StateT> && !_disposed) {
           container.runTernaryGuarded(
             observer.providerDidFail,
             _currentObserverContext(),

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -1219,7 +1219,11 @@ abstract base class ProviderObserver {
   void didAddProvider(ProviderObserverContext context, Object? value) {}
 
   /// A provider emitted an error, be it by throwing during initialization
-  /// or by having a [Future]/[Stream] emit an error
+  /// or by having a [Future]/[Stream] emit an error.
+  ///
+  /// This is **not** called when a provider is disposed before emitting its
+  /// first value (see [ProviderDisposedException]). That case is a normal
+  /// lifecycle event, not a failure.
   void providerDidFail(
     ProviderObserverContext context,
     Object error,

--- a/packages/riverpod/test/old/legacy_providers/stream_provider/stream_provider_test.dart
+++ b/packages/riverpod/test/old/legacy_providers/stream_provider/stream_provider_test.dart
@@ -323,7 +323,7 @@ void main() {
     final provider = StreamProvider<int>((ref) async* {});
 
     test(
-      'throws StateError if the provider is disposed before a value was emitted',
+      'throws ProviderDisposedException if the provider is disposed before a value was emitted',
       () async {
         final container = ProviderContainer.test(
           overrides: [provider.overrideWithValue(const AsyncLoading())],
@@ -335,16 +335,7 @@ void main() {
 
         await expectLater(
           future,
-          throwsA(
-            isStateError.having(
-              (e) => e.message,
-              'message',
-              equalsIgnoringHashCodes(
-                'The provider StreamProvider<int>#00000 was disposed during loading state, '
-                'yet no value could be emitted.',
-              ),
-            ),
-          ),
+          throwsA(isA<ProviderDisposedException>()),
         );
       },
     );

--- a/packages/riverpod/test/src/core/provider_observer_test.dart
+++ b/packages/riverpod/test/src/core/provider_observer_test.dart
@@ -1060,6 +1060,118 @@ void main() {
       verifyNoMoreInteractions(observer3);
     });
   });
+
+  group('providerDidFail – disposal during loading', () {
+      test(
+        'is NOT called when a FutureProvider dependent on a StreamProvider '
+        'receives the disposal error after the stream closes mid-load',
+        () async {
+          // Exact scenario from issue #4706:
+          // delayedStreamProvider (StreamProvider.autoDispose) is disposed
+          // before emitting → dependent FutureProvider gets the error →
+          // ProviderObserver.providerDidFail should NOT be called.
+          final observer = ObserverMock();
+          final container = ProviderContainer.test(
+            observers: [observer],
+            retry: (_, _) => null,
+          );
+
+          final controller = StreamController<int>();
+          final stream = StreamProvider.autoDispose<int>(
+            (ref) => controller.stream,
+          );
+          // dependentProvider mirrors the original repro
+          final dependent = FutureProvider.autoDispose<String>((ref) async {
+            final value = await ref.watch(stream.future);
+            return 'got $value';
+          });
+
+          container.listen(dependent, (_, _) {}, onError: (_, _) {});
+          // Read both futures before disposal so completers are wired up
+          final streamFuture = container.read(stream.future);
+          final dependentFuture = container.read(dependent.future);
+          clearInteractions(observer);
+
+          // Close the stream without emitting — _lastFuture becomes null,
+          // then element.dispose() calls completer.completeError(StateError).
+          await controller.close();
+          // Wait for the stream done-callback microtask to run (_lastFuture = null)
+          await Future<void>.delayed(Duration.zero);
+
+          // Dispose the container — triggers element.dispose() which calls
+          // completer.completeError. The error propagates to the dependent.
+          container.dispose();
+          await streamFuture.catchError((_) => 0);
+          await dependentFuture.catchError((_) => '');
+
+          // Bug: without the fix, providerDidFail IS called here with StateError.
+          // With the fix: _disposed check prevents it.
+          verifyNever(observer.providerDidFail(any, any, any));
+        },
+      );
+
+      test(
+        'ProviderDisposedException is thrown on provider.future when a '
+        'StreamProvider is disposed without emitting a value',
+        () async {
+          final container = ProviderContainer.test(retry: (_, _) => null);
+          final controller = StreamController<int>();
+          final provider = StreamProvider.autoDispose<int>(
+            (ref) => controller.stream,
+          );
+
+          container.listen(provider, (_, _) {});
+          final future = container.read(provider.future);
+
+          // Close the stream without emitting any value.
+          // _lastFuture is set to null by the done() callback.
+          await controller.close();
+
+          // Disposing the container triggers element.dispose(), which calls
+          // completer.completeError(ProviderDisposedException) since _lastFuture == null.
+          container.dispose();
+
+          await expectLater(
+            future,
+            throwsA(isA<Exception>().having(
+              (e) => e.toString(),
+              'message',
+              contains('disposed'),
+            )),
+          );
+        },
+      );
+
+      test(
+        'providerDidFail IS still called for real errors on a live provider',
+        () async {
+          final observer = ObserverMock();
+          final container = ProviderContainer.test(
+            observers: [observer],
+            retry: (_, _) => null,
+          );
+          final provider = FutureProvider<int>(
+            (ref) => Future<int>.error('real error', StackTrace.empty),
+          );
+
+          container.listen(provider, (_, _) {});
+          await container.read(provider.future).catchError((_) => 0);
+
+          verify(
+            observer.providerDidFail(
+              argThat(
+                isProviderObserverContext(
+                  provider: provider,
+                  container: container,
+                ),
+              ),
+              'real error',
+              StackTrace.empty,
+            ),
+          ).called(1);
+        },
+      );
+    });
 }
 
 class OnDisposeMock extends Mock {

--- a/packages/riverpod/test/src/core/provider_observer_test.dart
+++ b/packages/riverpod/test/src/core/provider_observer_test.dart
@@ -1133,11 +1133,7 @@ void main() {
 
           await expectLater(
             future,
-            throwsA(isA<Exception>().having(
-              (e) => e.toString(),
-              'message',
-              contains('disposed'),
-            )),
+            throwsA(isA<ProviderDisposedException>()),
           );
         },
       );

--- a/packages/riverpod/test/src/providers/async_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/async_notifier_test.dart
@@ -1089,7 +1089,7 @@ void main() {
       });
 
       test(
-        'if going back to loading after future resolved, throws StateError',
+        'if going back to loading after future resolved, throws ProviderDisposedException',
         () async {
           final container = ProviderContainer.test();
           final completer = Completer<int>.sync();
@@ -1108,7 +1108,7 @@ void main() {
 
           container.dispose();
 
-          await expectLater(future, throwsStateError);
+          await expectLater(future, throwsA(isA<ProviderDisposedException>()));
         },
       );
 

--- a/packages/riverpod/test/src/providers/future_provider_test.dart
+++ b/packages/riverpod/test/src/providers/future_provider_test.dart
@@ -58,7 +58,7 @@ void main() {
 
           container.dispose();
 
-          await expectLater(future, throwsA(isStateError));
+          await expectLater(future, throwsA(isA<ProviderDisposedException>()));
         },
       );
     });

--- a/packages/riverpod/test/src/providers/stream_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/stream_notifier_test.dart
@@ -78,7 +78,7 @@ void main() {
 
       verifyOnly(onCancel, onCancel());
 
-      await expectLater(future, throwsStateError);
+      await expectLater(future, throwsA(isA<ProviderDisposedException>()));
     });
 
     test('Pauses the Stream when the provider is paused', () {
@@ -720,7 +720,7 @@ void main() {
           );
 
           final future = container.read(provider.future);
-          expect(future, throwsA(isStateError));
+          expect(future, throwsA(isA<ProviderDisposedException>()));
 
           container.dispose();
         },
@@ -740,13 +740,13 @@ void main() {
         container.read(provider.notifier).state = const AsyncLoading<int>();
 
         final future = container.read(provider.future);
-        expect(future, throwsA(isStateError));
+        expect(future, throwsA(isA<ProviderDisposedException>()));
 
         container.dispose();
       });
 
       test(
-        'if going back to loading after future resolved, throws StateError',
+        'if going back to loading after future resolved, throws ProviderDisposedException',
         () async {
           final container = ProviderContainer.test();
           final completer = Completer<int>.sync();
@@ -765,7 +765,7 @@ void main() {
 
           container.dispose();
 
-          await expectLater(future, throwsStateError);
+          await expectLater(future, throwsA(isA<ProviderDisposedException>()));
         },
       );
 


### PR DESCRIPTION
Closes #4706.

## The bug

Navigating away from a screen mid-load was flooding Sentry with `StateError`s from disposed providers. The app behavior was correct, but `providerDidFail` was still being triggered for errors emitted after disposal — making it impossible to distinguish benign lifecycle cleanup from real provider failures without string-matching on the error message.

## Root cause

`onError()` and `_notifyListeners()` both call `providerDidFail` without checking whether the element has already been disposed.

The specific path:
1. An `autoDispose StreamProvider` is disposed before emitting its first value
2. `ElementWithFuture.dispose()` calls `completer.completeError(StateError(...))`
3. A dependent `FutureProvider` that was awaiting `upstream.future` receives the error via microtask
4. The dependent's `onError()` fires — but the dependent is still alive, so `_disposed` is false
5. `providerDidFail` is called, even though the error originates from disposal of an already-dead provider

## Fix

- Guard both `providerDidFail` call-sites with `!_disposed`
- Replace `StateError` in `_missingLastValueError()` with a new `ProviderDisposedException`

The `ProviderDisposedException` is not required for the observer fix — the `!_disposed` guard handles that on its own. I included it because `StateError` conflates two different things: actual programmer errors and normal disposal-during-load, making them indistinguishable to downstream error handlers. Happy to drop it if you'd prefer to keep this PR minimal and handle the exception type separately or not at all.

## Tests

Added 3 tests in `provider_observer_test.dart`:

1. **Canary** — `providerDidFail` is NOT called when a `FutureProvider` dependent on a `StreamProvider` receives the disposal error. Fails before the fix, passes after.
2. **Type** — `provider.future` throws `ProviderDisposedException`, not `StateError`. Fails before the fix (wrong type), passes after.
3. **Regression guard** — `providerDidFail` IS still called for real errors on a live provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public exception type for providers disposed while loading.

* **Bug Fixes**
  * Observer callbacks are no longer invoked when a provider is disposed before emitting its first value.
  * Accessing a provider's future after such disposal now completes with the new disposed exception instead of a generic error.

* **Documentation**
  * Clarified observer behavior for disposal-during-loading scenarios.

* **Tests**
  * Added tests for observer suppression and disposed-future behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->