### PR TITLE
Add support for maintaining providers active for side-effects

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased minor
 
+- **Experimental breaking** `Mutation.run` is modified: `MutationTransaction` is removed.
+  Before:
+  ```dart
+  mutation.run(ref, (tsx) async => tsx.get(...))
+  ```
+  After:
+  ```dart
+  mutation.run(ref, () async => ref.read(...));
+  ```
+  The behavior is otherwise the same.
+- Added `action`/`voidAction`, as syntax sugar to using Mutations for keeping providers alive
+  during side-effects.
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.
 - Refactored internal scheduling mechanism to solve some markNeedsBuild error.
 

--- a/packages/flutter_riverpod/lib/experimental/action.dart
+++ b/packages/flutter_riverpod/lib/experimental/action.dart
@@ -1,0 +1,1 @@
+export '../src/internals.dart' show action, voidAction;

--- a/packages/flutter_riverpod/lib/experimental/mutation.dart
+++ b/packages/flutter_riverpod/lib/experimental/mutation.dart
@@ -1,6 +1,5 @@
 export '../src/internals.dart'
     show
-        MutationTransaction,
         Mutation,
         MutationState,
         MutationIdle,

--- a/packages/flutter_riverpod/lib/flutter_riverpod.dart
+++ b/packages/flutter_riverpod/lib/flutter_riverpod.dart
@@ -1,6 +1,5 @@
 export 'src/internals.dart'
     show
-        action,
         AsyncValue,
         AsyncData,
         AsyncLoading,
@@ -32,5 +31,4 @@ export 'src/internals.dart'
         ProviderListenableSelect,
         AsyncResult,
         AsyncValueExtensions,
-        AsyncValueIsLoadingException,
-        voidAction;
+        AsyncValueIsLoadingException;

--- a/packages/flutter_riverpod/lib/flutter_riverpod.dart
+++ b/packages/flutter_riverpod/lib/flutter_riverpod.dart
@@ -1,5 +1,6 @@
 export 'src/internals.dart'
     show
+        action,
         AsyncValue,
         AsyncData,
         AsyncLoading,
@@ -31,4 +32,5 @@ export 'src/internals.dart'
         ProviderListenableSelect,
         AsyncResult,
         AsyncValueExtensions,
-        AsyncValueIsLoadingException;
+        AsyncValueIsLoadingException,
+        voidAction;

--- a/packages/flutter_riverpod/lib/src/core/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/core/consumer.dart
@@ -519,6 +519,10 @@ base class ConsumerStatefulElement extends StatefulElement
   }) {
     _assertNotDisposed();
     assert(
+      !$isInAction(),
+      'Cannot use WidgetRef.listen inside action callbacks.',
+    );
+    assert(
       debugDoingBuild,
       'ref.listen can only be used within the build method of a ConsumerWidget',
     );

--- a/packages/flutter_riverpod/lib/src/core/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/core/consumer.dart
@@ -464,6 +464,10 @@ base class ConsumerStatefulElement extends StatefulElement
   @override
   StateT watch<StateT>(ProviderListenable<StateT> target) {
     _assertNotDisposed();
+    assert(
+      !$isInAction(),
+      'Cannot use WidgetRef.watch inside action callbacks.',
+    );
     return _dependencies
             .putIfAbsent(target, () {
               final oldDependency = _oldDependencies?.remove(target);

--- a/packages/flutter_riverpod/test/features/mutations_test.dart
+++ b/packages/flutter_riverpod/test/features/mutations_test.dart
@@ -33,7 +33,7 @@ void main() {
 
     expect(find.text('42'), findsNothing);
 
-    await mut.run(container, (tsx) async {
+    await mut.run(container, () async {
       return 42;
     });
     await tester.pump();

--- a/packages/flutter_riverpod/test/listen_test.dart
+++ b/packages/flutter_riverpod/test/listen_test.dart
@@ -189,19 +189,25 @@ void main() {
   group('WidgetRef.listen', () {
     testWidgets('throws inside action', (tester) async {
       final provider = Provider((ref) => 0);
+      late WidgetRef widgetRef;
 
       await tester.pumpWidget(
         ProviderScope(
           child: Consumer(
             builder: (context, ref, _) {
-              action(() => ref.listen(provider, (_, _) {}));
+              widgetRef = ref;
               return Container();
             },
           ),
         ),
       );
 
-      expect(tester.takeException(), isA<AssertionError>());
+      await expectLater(
+        action(() async {
+          widgetRef.listen(provider, (_, _) {});
+        }),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
     testWidgets('expose previous and new value on change', (tester) async {

--- a/packages/flutter_riverpod/test/listen_test.dart
+++ b/packages/flutter_riverpod/test/listen_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart' hide Listener;
+import 'package:flutter_riverpod/experimental/action.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter_riverpod/test/listen_test.dart
+++ b/packages/flutter_riverpod/test/listen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart' hide Listener;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
@@ -150,9 +152,58 @@ void main() {
       ref.read(provider.notifier).state++;
       verifyNoMoreInteractions(listener);
     });
+
+    testWidgets('closes subscriptions when the action ends', (tester) async {
+      final completer = Completer<void>();
+      final provider = StateProvider((ref) => 0);
+      final listener = Listener<int>();
+
+      late WidgetRef ref;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: Consumer(
+            builder: (context, r, _) {
+              ref = r;
+              return Container();
+            },
+          ),
+        ),
+      );
+
+      final future = action(() async {
+        ref.listenManual(provider, listener.call);
+        await completer.future;
+      });
+
+      ref.read(provider.notifier).state++;
+      verifyOnly(listener, listener(0, 1));
+
+      completer.complete();
+      await future;
+
+      ref.read(provider.notifier).state++;
+      verifyNoMoreInteractions(listener);
+    });
   });
 
   group('WidgetRef.listen', () {
+    testWidgets('throws inside action', (tester) async {
+      final provider = Provider((ref) => 0);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: Consumer(
+            builder: (context, ref, _) {
+              action(() => ref.listen(provider, (_, _) {}));
+              return Container();
+            },
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isA<AssertionError>());
+    });
+
     testWidgets('expose previous and new value on change', (tester) async {
       final container = ProviderContainer.test();
       final dep = StateNotifierProvider<StateController<int>, int>(

--- a/packages/flutter_riverpod/test/src/core/widget_ref_test.dart
+++ b/packages/flutter_riverpod/test/src/core/widget_ref_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     final sub = ref.listenManual(mutation, (a, b) {});
 
-    await mutation.run(ref, (tsx) async {
+    await mutation.run(ref, () async {
       return 1;
     });
 

--- a/packages/flutter_riverpod/test/widget_ref_test.dart
+++ b/packages/flutter_riverpod/test/widget_ref_test.dart
@@ -37,19 +37,23 @@ void main() {
 
     testWidgets('watch throws inside action', (tester) async {
       final provider = Provider((ref) => 42);
+      late WidgetRef widgetRef;
 
       await tester.pumpWidget(
         ProviderScope(
           child: Consumer(
             builder: (context, ref, _) {
-              action(() => ref.watch(provider));
+              widgetRef = ref;
               return Container();
             },
           ),
         ),
       );
 
-      expect(tester.takeException(), isA<AssertionError>());
+      await expectLater(
+        action(() async => widgetRef.watch(provider)),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
     group('invalidate', () {

--- a/packages/flutter_riverpod/test/widget_ref_test.dart
+++ b/packages/flutter_riverpod/test/widget_ref_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/experimental/action.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter_riverpod/test/widget_ref_test.dart
+++ b/packages/flutter_riverpod/test/widget_ref_test.dart
@@ -1,9 +1,57 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('WidgetRef', () {
+    testWidgets('read participates in action retention', (tester) async {
+      final completer = Completer<int>();
+      var disposed = false;
+      final provider = FutureProvider.autoDispose<int>((ref) {
+        ref.onDispose(() => disposed = true);
+        return completer.future;
+      });
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: Consumer(builder: (context, ref, _) => Container()),
+        ),
+      );
+
+      final ref = tester.firstElement(find.byType(Consumer)) as WidgetRef;
+
+      final future = action(() async => ref.read(provider.future));
+
+      await tester.pump();
+      expect(disposed, false);
+
+      completer.complete(42);
+
+      await expectLater(future, completion(42));
+      await tester.pump();
+
+      expect(disposed, true);
+    });
+
+    testWidgets('watch throws inside action', (tester) async {
+      final provider = Provider((ref) => 42);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: Consumer(
+            builder: (context, ref, _) {
+              action(() => ref.watch(provider));
+              return Container();
+            },
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isA<AssertionError>());
+    });
+
     group('invalidate', () {
       testWidgets('supports asReload', (tester) async {
         final provider = FutureProvider<int>((r) async => 0);

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased minor
 
+- **Experimental breaking** `Mutation.run` is modified: `MutationTransaction` is removed.
+  Before:
+  ```dart
+  mutation.run(ref, (tsx) async => tsx.get(...))
+  ```
+  After:
+  ```dart
+  mutation.run(ref, () async => ref.read(...));
+  ```
+  The behavior is otherwise the same.
+- Added `action`/`voidAction`, as syntax sugar to using Mutations for keeping providers alive
+  during side-effects.
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.
 - Refactored internal scheduling mechanism to solve some markNeedsBuild error.
 

--- a/packages/hooks_riverpod/lib/experimental/action.dart
+++ b/packages/hooks_riverpod/lib/experimental/action.dart
@@ -1,0 +1,1 @@
+export '../src/internals.dart' show action, voidAction;

--- a/packages/hooks_riverpod/lib/experimental/mutation.dart
+++ b/packages/hooks_riverpod/lib/experimental/mutation.dart
@@ -1,6 +1,5 @@
 export '../src/internals.dart'
     show
-        MutationTransaction,
         Mutation,
         MutationState,
         MutationIdle,

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased minor
 
+- **Experimental breaking** `Mutation.run` is modified: `MutationTransaction` is removed.
+  Before:
+  ```dart
+  mutation.run(ref, (tsx) async => tsx.get(...))
+  ```
+  After:
+  ```dart
+  mutation.run(ref, () async => ref.read(...));
+  ```
+  The behavior is otherwise the same.
+- Added `action`/`voidAction`, as syntax sugar to using Mutations for keeping providers alive
+  during side-effects.
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.
 - Refactored internal scheduling mechanism to solve some markNeedsBuild error.
 

--- a/packages/riverpod/lib/experimental/action.dart
+++ b/packages/riverpod/lib/experimental/action.dart
@@ -1,0 +1,1 @@
+export '../src/internals.dart' show action, voidAction;

--- a/packages/riverpod/lib/experimental/mutation.dart
+++ b/packages/riverpod/lib/experimental/mutation.dart
@@ -1,6 +1,5 @@
 export '../src/internals.dart'
     show
-        MutationTransaction,
         Mutation,
         MutationState,
         MutationIdle,

--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -4,6 +4,8 @@ export 'src/internals.dart'
         AsyncData,
         AsyncLoading,
         AsyncError,
+        action,
+        voidAction,
         ProviderContainer,
         ProviderReference,
         ProviderObserverContext,

--- a/packages/riverpod/lib/riverpod.dart
+++ b/packages/riverpod/lib/riverpod.dart
@@ -4,8 +4,6 @@ export 'src/internals.dart'
         AsyncData,
         AsyncLoading,
         AsyncError,
-        action,
-        voidAction,
         ProviderContainer,
         ProviderReference,
         ProviderObserverContext,

--- a/packages/riverpod/lib/src/core/action.dart
+++ b/packages/riverpod/lib/src/core/action.dart
@@ -1,0 +1,71 @@
+part of '../framework.dart';
+
+const _actionZoneKey = #_action;
+
+_ActionExecution? _currentAction() {
+  final current = Zone.current[_actionZoneKey];
+  if (current case final _ActionExecution action when !action._closed) {
+    return action;
+  }
+
+  return null;
+}
+
+/// Returns `true` if the current code is running inside an [action].
+@publicInCodegen
+bool $isInAction() => _currentAction() != null;
+
+/// Runs [cb] while keeping providers read inside it alive until completion.
+///
+/// Providers accessed through [Ref.read] or [ProviderContainer.read] while the
+/// callback is pending are kept alive and active for the duration of the
+/// action.
+FutureOr<ResultT> action<ResultT>(FutureOr<ResultT> Function() cb) {
+  if (_currentAction() != null) return cb();
+
+  final action = _ActionExecution();
+
+  try {
+    return runZoned<FutureOr<ResultT>>(() {
+      final result = cb();
+
+      if (result is Future<ResultT>) {
+        return result.whenComplete(action._close);
+      }
+
+      action._close();
+      return result;
+    }, zoneValues: {_actionZoneKey: action});
+  } catch (_) {
+    action._close();
+    rethrow;
+  }
+}
+
+/// Returns a callback that executes [cb] inside [action].
+///
+/// This is equivalent to writing `() => action(cb)`.
+void Function() voidAction(FutureOr<void> Function() cb) {
+  return () {
+    action(cb);
+  };
+}
+
+final class _ActionExecution {
+  var _closed = false;
+
+  final _subscriptions = <ProviderSubscription>[];
+
+  void register(ProviderSubscription subscription) {
+    assert(!_closed, 'Cannot register subscriptions on a closed action');
+    _subscriptions.add(subscription);
+  }
+
+  void _close() {
+    if (_closed) return;
+    _closed = true;
+
+    _closeSubscriptions(_subscriptions);
+    _subscriptions.clear();
+  }
+}

--- a/packages/riverpod/lib/src/core/action.dart
+++ b/packages/riverpod/lib/src/core/action.dart
@@ -42,7 +42,7 @@ Future<ResultT> action<ResultT>(Future<ResultT> Function() cb) {
 /// Returns a callback that executes [cb] inside [action].
 ///
 /// This is equivalent to writing `() => action(cb)`.
-void Function() voidAction(Future<void> Function() cb) => () => action(cb);
+Future<T> Function() voidAction<T>(Future<T> Function() cb) => () => action(cb);
 
 final class _ActionExecution {
   var _closed = false;

--- a/packages/riverpod/lib/src/core/action.dart
+++ b/packages/riverpod/lib/src/core/action.dart
@@ -20,21 +20,18 @@ bool $isInAction() => _currentAction() != null;
 /// Providers accessed through [Ref.read] or [ProviderContainer.read] while the
 /// callback is pending are kept alive and active for the duration of the
 /// action.
-FutureOr<ResultT> action<ResultT>(FutureOr<ResultT> Function() cb) {
+Future<ResultT> action<ResultT>(Future<ResultT> Function() cb) {
   if (_currentAction() != null) return cb();
 
   final action = _ActionExecution();
 
   try {
-    return runZoned<FutureOr<ResultT>>(() {
-      final result = cb();
-
-      if (result is Future<ResultT>) {
-        return result.whenComplete(action._close);
+    return runZoned<Future<ResultT>>(() async {
+      try {
+        return await cb();
+      } finally {
+        action._close();
       }
-
-      action._close();
-      return result;
     }, zoneValues: {_actionZoneKey: action});
   } catch (_) {
     action._close();
@@ -45,11 +42,7 @@ FutureOr<ResultT> action<ResultT>(FutureOr<ResultT> Function() cb) {
 /// Returns a callback that executes [cb] inside [action].
 ///
 /// This is equivalent to writing `() => action(cb)`.
-void Function() voidAction(FutureOr<void> Function() cb) {
-  return () {
-    action(cb);
-  };
-}
+void Function() voidAction(Future<void> Function() cb) => () => action(cb);
 
 final class _ActionExecution {
   var _closed = false;

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -665,6 +665,11 @@ depending on itself.
   /// Invokes [create] and handles errors.
   @internal
   void buildState($Ref<StateT, ValueT> ref) {
+    if (_currentAction() != null) {
+      runZoned(() => buildState(ref), zoneValues: {_actionZoneKey: null});
+      return;
+    }
+
     if (_didChangeDependency) _retryCount = 0;
 
     _didChangeDependency = false;

--- a/packages/riverpod/lib/src/core/mutations.dart
+++ b/packages/riverpod/lib/src/core/mutations.dart
@@ -6,52 +6,6 @@ part of '../framework.dart';
 @publicInCodegenMutation
 const mutationZoneKey = #_mutation;
 
-/// A "ref" to be used within [Mutation.run].
-///
-/// By using this ref instead of the usual [Ref]/`WidgetRef`, this enables
-/// [Mutation.run] to be do things such as:
-/// - Keeping providers alive for the `run` duration.
-/// - Closing any pending subscriptions specific to `run` after it completes.
-///
-///
-/// See also:
-/// - [get], the primary way to interact with providers within [Mutation.run].
-@publicInMutations
-final class MutationTransaction {
-  MutationTransaction._(this._container);
-
-  final ProviderContainer _container;
-  var _closed = false;
-  final List<ProviderSubscription<Object?>> _subscriptions = [];
-
-  /// Reads the current state of a listenable and maintains a subscription
-  /// to it until the transaction completes.
-  ///
-  /// **Note**: Updates to the listenable during the transaction are ignored.
-  StateT get<StateT>(ProviderListenable<StateT> listenable) {
-    assert(
-      !_closed,
-      'Cannot get a listenable after the transaction has been closed',
-    );
-
-    final sub = _container.listen(
-      listenable,
-      (previous, next) {},
-      onError: (error, stackTrace) {},
-    );
-
-    _subscriptions.add(sub);
-
-    return sub.readSafe().valueOrProviderException;
-  }
-
-  void _close() {
-    assert(!_closed, 'MutationTransaction is already closed');
-    _closed = true;
-    _closeSubscriptions(_subscriptions);
-  }
-}
-
 final class _MutationProvider<ValueT>
     extends
         $FunctionalProvider<
@@ -100,10 +54,9 @@ class _MutationNotifier<ValueT> {
   _MutationNotifier(this.state, this.setState, this.setRef, this.getRef);
 
   final MutationState<ValueT> state;
-  final void Function(MutationState<ValueT> state, MutationTransaction ref)
-  setState;
-  final void Function(MutationTransaction ref) setRef;
-  final MutationTransaction? Function() getRef;
+  final void Function(MutationState<ValueT> state, Object ref) setState;
+  final void Function(Object ref) setRef;
+  final Object? Function() getRef;
 
   @override
   String toString() {
@@ -126,9 +79,9 @@ class _MutationElement<StateT>
     final provider = this.provider as _MutationProvider<StateT>;
     final mutation = provider.mutation;
 
-    MutationTransaction? activeRef;
+    Object? activeRef;
 
-    void setState(MutationState<StateT> state, MutationTransaction? mutRef) {
+    void setState(MutationState<StateT> state, Object? mutRef) {
       if (mutRef != activeRef) return;
 
       final prevState = value;
@@ -258,10 +211,10 @@ abstract class MutationTarget {
 /// ```dart
 /// ElevatedButton(
 ///   onPressed: () {
-///     addTodoMutation.run(ref, (tsx) async {
+///     addTodoMutation.run(ref, () async {
 ///       // This is where you perform the side-effect. Here, you can
 ///       // read your providers to modify them.
-///       await tsx.get(todoListProvider.notifier).addTodo(
+///       await ref.read(todoListProvider.notifier).addTodo(
 ///         Todo(title: 'New Todo'),
 ///       );
 ///     });
@@ -318,7 +271,7 @@ abstract class MutationTarget {
 /// onPressed: () {
 ///   // Upon calling `run`, you will have to pass the same key as when
 ///   // watching the mutation.
-///   deleteTodo(todo.id).run(ref, (tsx) async { /* ... */ });
+///   deleteTodo(todo.id).run(ref, () async { /* ... */ });
 /// }
 /// ```
 ///
@@ -362,13 +315,13 @@ sealed class Mutation<ResultT>
   /// [MutationSuccess] or [MutationError] depending on whether the callback
   /// completes successfully or throws an error.
   ///
-  /// While within the callback, use [MutationTransaction] to interact with providers.
-  /// When doing so, [run] will naturally keep the providers alive for the duration
-  /// of the callback, and close any pending subscriptions after it completes.
-  Future<ResultT> run(
-    MutationTarget target,
-    Future<ResultT> Function(MutationTransaction transaction) cb,
-  );
+  /// [run] executes [cb] inside an [action].
+  ///
+  /// This means imperative APIs such as [ProviderContainer.read] and [Ref.read]
+  /// automatically keep touched providers alive for the duration of [cb].
+  /// Any action-managed subscriptions created during the callback are closed
+  /// when the mutation completes.
+  Future<ResultT> run(MutationTarget target, Future<ResultT> Function() cb);
 
   /// Resets the mutation to its initial state ([MutationIdle]).
   void reset(MutationTarget container);
@@ -415,10 +368,7 @@ final class MutationImpl<ResultT>
   }
 
   @override
-  Future<ResultT> run(
-    MutationTarget target,
-    Future<ResultT> Function(MutationTransaction ref) cb,
-  ) {
+  Future<ResultT> run(MutationTarget target, Future<ResultT> Function() cb) {
     return runZoned(zoneValues: {mutationZoneKey: this}, () async {
       final container = target.container;
 
@@ -427,12 +377,12 @@ final class MutationImpl<ResultT>
         _MutationProvider(this),
         (_, _) {},
       );
-      final ref = MutationTransaction._(container);
+      final ref = Object();
 
       try {
         mut._mutationStart(sub, ref);
 
-        final result = await cb(ref);
+        final result = await action(cb);
 
         mut._mutationSuccess(sub, ref, result);
 
@@ -443,7 +393,6 @@ final class MutationImpl<ResultT>
         rethrow;
       } finally {
         sub.close();
-        ref._close();
       }
     });
   }
@@ -462,7 +411,7 @@ final class MutationImpl<ResultT>
 
   void _mutationStart(
     ProviderSubscription<_MutationNotifier<ResultT>> sub,
-    MutationTransaction ref,
+    Object ref,
   ) {
     final _MutationNotifier(:state, :setState, :setRef) =
         sub.readSafe().valueOrRawException;
@@ -474,7 +423,7 @@ final class MutationImpl<ResultT>
 
   void _mutationSuccess(
     ProviderSubscription<_MutationNotifier<ResultT>> sub,
-    MutationTransaction ref,
+    Object ref,
     ResultT result,
   ) {
     final _MutationNotifier(:state, :setState) =
@@ -485,7 +434,7 @@ final class MutationImpl<ResultT>
 
   void _mutationErrored(
     ProviderSubscription<_MutationNotifier<ResultT>> sub,
-    MutationTransaction ref,
+    Object ref,
     Object error,
     StackTrace stackTrace,
   ) {

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -976,8 +976,6 @@ final class ProviderContainer implements Node, MutationTarget {
     final currentAction = _currentAction();
     final sub = listen(provider, (_, _) {});
 
-    if (currentAction != null) currentAction.register(sub);
-
     try {
       return sub.readSafe().valueOrProviderException;
     } finally {

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -973,12 +973,15 @@ final class ProviderContainer implements Node, MutationTarget {
   /// }
   /// ```
   StateT read<StateT>(ProviderListenable<StateT> provider) {
+    final currentAction = _currentAction();
     final sub = listen(provider, (_, _) {});
+
+    if (currentAction != null) currentAction.register(sub);
 
     try {
       return sub.readSafe().valueOrProviderException;
     } finally {
-      sub.close();
+      if (currentAction == null) sub.close();
     }
   }
 

--- a/packages/riverpod/lib/src/core/provider_container.dart
+++ b/packages/riverpod/lib/src/core/provider_container.dart
@@ -1061,6 +1061,8 @@ final class ProviderContainer implements Node, MutationTarget {
 
     sub.impl._listenedElement.addDependentSubscription(sub.impl);
 
+    _currentAction()?.register(sub);
+
     return sub;
   }
 

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -695,13 +695,17 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
     bool fireImmediately = false,
   }) {
     _throwIfInvalidUsage();
-    return _element.listen(
+    final sub = _element.listen(
       provider,
       listener,
       weak: weak,
       onError: onError,
       fireImmediately: fireImmediately,
     );
+
+    _currentAction()?.register(sub);
+
+    return sub;
   }
 }
 

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -651,6 +651,7 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   /// ```
   StateT watch<StateT>(ProviderListenable<StateT> listenable) {
     _throwIfInvalidUsage();
+    assert(!$isInAction(), 'Cannot use Ref.watch inside action callbacks.');
     late ProviderSubscription<StateT> sub;
     sub = _element.listen<StateT>(
       listenable,

--- a/packages/riverpod/lib/src/framework.dart
+++ b/packages/riverpod/lib/src/framework.dart
@@ -35,3 +35,4 @@ part 'core/mutations.dart';
 part 'core/ref.dart';
 part 'core/scheduler.dart';
 part 'core/async_value.dart';
+part 'core/action.dart';

--- a/packages/riverpod/test/feature/mutation_test.dart
+++ b/packages/riverpod/test/feature/mutation_test.dart
@@ -18,7 +18,7 @@ void main() {
       fireImmediately: true,
     );
 
-    await mut.run(container, (tsx) async {});
+    await mut.run(container, () async {});
 
     expect(container.read(mut), isMutationSuccess<void>());
   });
@@ -51,9 +51,9 @@ void main() {
       (_, _) {},
     );
 
-    await mut.run(container, (tsx) async => 9);
-    await mutInt.run(container, (tsx) async => 42);
-    await mutDouble.run(container, (tsx) async => 3.14);
+    await mut.run(container, () async => 9);
+    await mutInt.run(container, () async => 42);
+    await mutDouble.run(container, () async => 3.14);
 
     expect(sub.read(), isMutationSuccess<num>(9));
     expect(subInt.read(), isMutationSuccess<int>(42));
@@ -69,7 +69,7 @@ void main() {
 
     final sub = container.listen(mut, listener.call);
 
-    final a = mut.run(container, (tsx) => completer1.future);
+    final a = mut.run(container, () => completer1.future);
     verifyOnly(
       listener,
       listener(
@@ -78,7 +78,7 @@ void main() {
       ),
     );
 
-    final b = mut.run(container, (tsx) => completer2.future);
+    final b = mut.run(container, () => completer2.future);
     verifyNoMoreInteractions(listener);
 
     completer1.complete(1);
@@ -111,7 +111,7 @@ void main() {
       listener(argThat(isNull), argThat(isMutationIdle<int>())),
     );
 
-    final result = mut.run(container, (tsx) => completer.future);
+    final result = mut.run(container, () => completer.future);
 
     verifyOnly(
       listener,
@@ -149,7 +149,7 @@ void main() {
       listener(argThat(isNull), argThat(isMutationIdle<int>())),
     );
 
-    final result = mut.run(container, (tsx) => completer.future);
+    final result = mut.run(container, () => completer.future);
 
     // caching errors before they are reported to the zone
     expect(result, throwsA(42));
@@ -180,7 +180,7 @@ void main() {
         final mut = Mutation<int>();
         final container = ProviderContainer.test();
 
-        unawaited(mut.run(container, (tsx) async => 42));
+        unawaited(mut.run(container, () async => 42));
         mut.reset(container);
 
         expect(container.read(mut), isMutationIdle<int>());
@@ -242,7 +242,7 @@ void main() {
     final sub = container.listen(mut(1), (previous, next) {});
     final sub2 = container.listen(mut(2), (previous, next) {});
 
-    final first = mut(1).run(container, (tsx) => completer.future);
+    final first = mut(1).run(container, () => completer.future);
 
     verifyOnly(
       observer,
@@ -268,9 +268,7 @@ void main() {
       ),
     );
 
-    final second = mut(
-      2,
-    ).run(container, (tsx) async => throw Exception('error'));
+    final second = mut(2).run(container, () async => throw Exception('error'));
 
     verifyOnly(
       observer,
@@ -309,8 +307,8 @@ void main() {
       final provider = Provider<int>((ref) => 0);
 
       unawaited(
-        mut.run(container, (tsx) async {
-          tsx.get(provider);
+        mut.run(container, () async {
+          container.read(provider);
         }),
       );
 
@@ -342,8 +340,8 @@ void main() {
       final container = ProviderContainer.test();
       final completer = Completer<void>();
 
-      final f = mut.run(container, (tsx) async {
-        tsx.get(p);
+      final f = mut.run(container, () async {
+        container.read(p);
 
         await completer.future;
 
@@ -368,7 +366,7 @@ void main() {
     final mut = Mutation<int>();
     final container = ProviderContainer.test();
 
-    await mut.run(container, (tsx) async => 0);
+    await mut.run(container, () async => 0);
 
     await container.pump();
 
@@ -387,10 +385,10 @@ void main() {
     final sub3 = container.listen(mut3, (previous, next) {});
     final sub4 = container.listen(mut4, (previous, next) {});
 
-    await mut1.run(container, (tsx) async => 1);
-    await mut2.run(container, (tsx) async => 2);
-    await mut3.run(container, (tsx) async => 3);
-    await mut4.run(container, (tsx) async => 4);
+    await mut1.run(container, () async => 1);
+    await mut2.run(container, () async => 2);
+    await mut3.run(container, () async => 3);
+    await mut4.run(container, () async => 4);
 
     expect(container.read(mut1), isMutationSuccess<int>(1));
     expect(container.read(mut2), isMutationSuccess<int>(2));

--- a/packages/riverpod/test/src/core/action_test.dart
+++ b/packages/riverpod/test/src/core/action_test.dart
@@ -189,7 +189,7 @@ void main() {
         await container.read(provider.future);
       });
 
-      callback();
+      unawaited(callback());
 
       final element = container.readProviderElement(provider);
       expect(element.isActive, true);

--- a/packages/riverpod/test/src/core/action_test.dart
+++ b/packages/riverpod/test/src/core/action_test.dart
@@ -88,13 +88,13 @@ void main() {
         return 42;
       });
 
-      final result = action(() {
+      final result = action(() async {
         expect(container.read(provider), 42);
         expect(container.read(provider), 42);
         return container.read(provider);
       });
 
-      expect(result, 42);
+      await expectLater(result, completion(42));
       expect(buildCount, 1);
 
       await container.pump();
@@ -102,7 +102,7 @@ void main() {
       expect(container.pointerManager.readPointer(provider), isNull);
     });
 
-    test('throws if Ref.watch is used inside an action', () {
+    test('throws if Ref.watch is used inside an action', () async {
       final container = ProviderContainer.test();
       final notifier = DeferredNotifier<int>((ref, self) => 0);
       final holder = NotifierProvider<DeferredNotifier<int>, int>(
@@ -112,8 +112,8 @@ void main() {
 
       container.read(holder);
 
-      expect(
-        () => action(() => notifier.ref.watch(provider)),
+      await expectLater(
+        action(() async => notifier.ref.watch(provider)),
         throwsA(isA<AssertionError>()),
       );
     });

--- a/packages/riverpod/test/src/core/action_test.dart
+++ b/packages/riverpod/test/src/core/action_test.dart
@@ -119,6 +119,91 @@ void main() {
     });
 
     test(
+      'does not treat Ref.watch from providers initialized in an action as part of the action',
+      () async {
+        final container = ProviderContainer.test();
+        final dep = StateProvider((ref) => 42);
+        final provider = Provider.autoDispose((ref) => ref.watch(dep));
+
+        await expectLater(
+          action(() async => container.read(provider)),
+          completion(42),
+        );
+
+        await container.pump();
+
+        expect(container.pointerManager.readPointer(provider), isNull);
+      },
+    );
+
+    test(
+      'does not treat Ref.read from providers initialized in an action as part of the action',
+      () async {
+        final container = ProviderContainer.test();
+        final providerCompleter = Completer<int>();
+        final actionCompleter = Completer<void>();
+        final onDispose = OnDisposeMock();
+
+        final dep = FutureProvider.autoDispose<int>((ref) {
+          ref.onDispose(onDispose.call);
+          return providerCompleter.future;
+        });
+        final provider = Provider.autoDispose<Future<int>>(
+          (ref) => ref.read(dep.future),
+        );
+
+        final future = action(() async {
+          container.read(provider);
+          await actionCompleter.future;
+        });
+
+        await container.pump();
+
+        verifyOnly(onDispose, onDispose());
+        expect(container.pointerManager.readPointer(provider), isNotNull);
+        expect(container.pointerManager.readPointer(dep), isNull);
+
+        actionCompleter.complete();
+        await future;
+
+        providerCompleter.complete(42);
+      },
+    );
+
+    test(
+      'does not close Ref.listen from providers initialized in an action when the action ends',
+      () async {
+        final container = ProviderContainer.test();
+        final actionCompleter = Completer<void>();
+        final listener = Listener<int>();
+        final dep = StateProvider((ref) => 0);
+
+        final provider = Provider.autoDispose((ref) {
+          ref.listen(dep, listener.call);
+          return 42;
+        });
+
+        final future = action(() async {
+          expect(container.read(provider), 42);
+          await actionCompleter.future;
+        });
+
+        await container.pump();
+
+        final keepAlive = container.listen(provider, (_, _) {});
+
+        actionCompleter.complete();
+        await future;
+
+        container.read(dep.notifier).state++;
+
+        verifyOnly(listener, listener(0, 1));
+
+        keepAlive.close();
+      },
+    );
+
+    test(
       'closes ProviderContainer.listen subscriptions when the action ends',
       () async {
         final container = ProviderContainer.test();

--- a/packages/riverpod/test/src/core/action_test.dart
+++ b/packages/riverpod/test/src/core/action_test.dart
@@ -148,7 +148,7 @@ void main() {
           ref.onDispose(onDispose.call);
           return providerCompleter.future;
         });
-        final provider = Provider.autoDispose<Future<int>>(
+        final provider = FutureProvider.autoDispose<Future<int>>(
           (ref) => ref.read(dep.future),
         );
 

--- a/packages/riverpod/test/src/core/action_test.dart
+++ b/packages/riverpod/test/src/core/action_test.dart
@@ -117,6 +117,61 @@ void main() {
         throwsA(isA<AssertionError>()),
       );
     });
+
+    test(
+      'closes ProviderContainer.listen subscriptions when the action ends',
+      () async {
+        final container = ProviderContainer.test();
+        final completer = Completer<void>();
+        final listener = Listener<int>();
+        final dep = StateProvider((ref) => 0);
+
+        final future = action(() async {
+          container.listen(dep, listener.call);
+          await completer.future;
+        });
+
+        container.read(dep.notifier).state++;
+
+        verifyOnly(listener, listener(0, 1));
+
+        completer.complete();
+        await future;
+
+        container.read(dep.notifier).state++;
+
+        verifyNoMoreInteractions(listener);
+      },
+    );
+
+    test('closes Ref.listen subscriptions when the action ends', () async {
+      final container = ProviderContainer.test();
+      final completer = Completer<void>();
+      final listener = Listener<int>();
+      final dep = StateProvider((ref) => 0);
+      final notifier = DeferredNotifier<int>((ref, self) => 0);
+      final holder = NotifierProvider<DeferredNotifier<int>, int>(
+        () => notifier,
+      );
+
+      container.read(holder);
+
+      final future = action(() async {
+        notifier.ref.listen(dep, listener.call);
+        await completer.future;
+      });
+
+      container.read(dep.notifier).state++;
+
+      verifyOnly(listener, listener(0, 1));
+
+      completer.complete();
+      await future;
+
+      container.read(dep.notifier).state++;
+
+      verifyNoMoreInteractions(listener);
+    });
   });
 
   group('voidAction', () {

--- a/packages/riverpod/test/src/core/action_test.dart
+++ b/packages/riverpod/test/src/core/action_test.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+
+import 'package:mockito/mockito.dart';
+import 'package:riverpod/src/internals.dart';
+import 'package:test/test.dart';
+
+import '../matrix.dart';
+import '../utils.dart';
+
+void main() {
+  group('action', () {
+    test('keeps autoDispose providers active while pending', () async {
+      final container = ProviderContainer.test();
+      final completer = Completer<int>();
+      final onDispose = OnDisposeMock();
+
+      final provider = FutureProvider.autoDispose<int>((ref) {
+        ref.onDispose(onDispose.call);
+        return completer.future;
+      });
+
+      final future = action(() async {
+        return container.read(provider.future);
+      });
+
+      final element = container.readProviderElement(provider);
+      expect(element.isActive, true);
+
+      await container.pump();
+
+      expect(element.isActive, true);
+      verifyZeroInteractions(onDispose);
+
+      completer.complete(42);
+
+      await expectLater(future, completion(42));
+      await container.pump();
+
+      verifyOnly(onDispose, onDispose());
+      expect(container.pointerManager.readPointer(provider), isNull);
+    });
+
+    test(
+      'keeps autoDispose providers active while pending with Ref.read',
+      () async {
+        final container = ProviderContainer.test();
+        final completer = Completer<int>();
+        final onDispose = OnDisposeMock();
+        final notifier = DeferredNotifier<int>((ref, self) {
+          return 0;
+        });
+
+        final holder = NotifierProvider<DeferredNotifier<int>, int>(
+          () => notifier,
+        );
+        final provider = FutureProvider.autoDispose<int>((ref) {
+          ref.onDispose(onDispose.call);
+          return completer.future;
+        });
+
+        container.read(holder);
+
+        final future = action(() async => notifier.ref.read(provider.future));
+
+        final element = container.readProviderElement(provider);
+        expect(element.isActive, true);
+
+        await container.pump();
+
+        expect(element.isActive, true);
+        verifyZeroInteractions(onDispose);
+
+        completer.complete(42);
+
+        await expectLater(future, completion(42));
+        await container.pump();
+
+        verifyOnly(onDispose, onDispose());
+        expect(container.pointerManager.readPointer(provider), isNull);
+      },
+    );
+
+    test('deduplicates reads of the same provider within an action', () async {
+      final container = ProviderContainer.test();
+      var buildCount = 0;
+      final provider = Provider.autoDispose((ref) {
+        buildCount++;
+        return 42;
+      });
+
+      final result = action(() {
+        expect(container.read(provider), 42);
+        expect(container.read(provider), 42);
+        return container.read(provider);
+      });
+
+      expect(result, 42);
+      expect(buildCount, 1);
+
+      await container.pump();
+
+      expect(container.pointerManager.readPointer(provider), isNull);
+    });
+
+    test('throws if Ref.watch is used inside an action', () {
+      final container = ProviderContainer.test();
+      final notifier = DeferredNotifier<int>((ref, self) => 0);
+      final holder = NotifierProvider<DeferredNotifier<int>, int>(
+        () => notifier,
+      );
+      final provider = Provider((ref) => 42);
+
+      container.read(holder);
+
+      expect(
+        () => action(() => notifier.ref.watch(provider)),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('voidAction', () {
+    test('returns a callback that runs inside action', () async {
+      final container = ProviderContainer.test();
+      final completer = Completer<int>();
+      final onDispose = OnDisposeMock();
+
+      final provider = FutureProvider.autoDispose<int>((ref) {
+        ref.onDispose(onDispose.call);
+        return completer.future;
+      });
+
+      final callback = voidAction(() async {
+        await container.read(provider.future);
+      });
+
+      callback();
+
+      final element = container.readProviderElement(provider);
+      expect(element.isActive, true);
+
+      await container.pump();
+
+      verifyZeroInteractions(onDispose);
+      expect(element.isActive, true);
+
+      completer.complete(21);
+      await Future<void>.delayed(Duration.zero);
+      await container.pump();
+
+      verifyOnly(onDispose, onDispose());
+      expect(container.pointerManager.readPointer(provider), isNull);
+    });
+  });
+}

--- a/packages/riverpod/test/src/core/mutations_test.dart
+++ b/packages/riverpod/test/src/core/mutations_test.dart
@@ -16,7 +16,7 @@ void main() {
           .having((e) => e.isSuccess, 'isSuccess', false),
     );
 
-    final future = mut.run(container, (tsx) async {});
+    final future = mut.run(container, () async {});
 
     expect(
       container.read(mut),
@@ -39,7 +39,7 @@ void main() {
     );
 
     await mut
-        .run(container, (tsx) async {
+        .run(container, () async {
           throw Exception('error');
         })
         .catchError((_) {});

--- a/packages/riverpod/test/src/core/ref_test.dart
+++ b/packages/riverpod/test/src/core/ref_test.dart
@@ -56,7 +56,7 @@ void main() {
       container.read(provider);
       final sub = container.listen(mutation, (a, b) {});
 
-      await mutation.run(notifier.ref, (tsx) async {
+      await mutation.run(notifier.ref, () async {
         notifier.state++;
 
         return notifier.state;

--- a/website/docs/concepts2/actions.mdx
+++ b/website/docs/concepts2/actions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Actions
+title: Actions (experimental)
 ---
 import CodeBlock from "@theme/CodeBlock";
 import { Link } from "/src/components/Link";
@@ -10,6 +10,11 @@ import keepingAlive from 'raw-loader!./actions/keeping_alive.dart';
 
 Actions are an imperative helper for running side-effects while temporarily
 keeping the providers used by that side-effect alive.
+
+:::caution
+Actions are experimental, and the API may change in a breaking way without a
+major version bump.
+:::
 
 They are designed for callbacks such as button presses, commands, tests, or
 other event handlers where using `watch` would be inappropriate.

--- a/website/docs/concepts2/actions.mdx
+++ b/website/docs/concepts2/actions.mdx
@@ -1,0 +1,77 @@
+---
+title: Actions
+---
+import CodeBlock from "@theme/CodeBlock";
+import { Link } from "/src/components/Link";
+import { trimSnippet } from "/src/components/CodeSnippet";
+import runningAction from 'raw-loader!./actions/running_action.dart';
+import returningResult from 'raw-loader!./actions/returning_result.dart';
+import keepingAlive from 'raw-loader!./actions/keeping_alive.dart';
+
+Actions are an imperative helper for running side-effects while temporarily
+keeping the providers used by that side-effect alive.
+
+They are designed for callbacks such as button presses, commands, tests, or
+other event handlers where using `watch` would be inappropriate.
+
+Riverpod exposes two top-level helpers:
+
+- `action`, which returns a value.
+- `voidAction`, a shorthand for actions that return `void`.
+
+## Running an action
+
+Use an action from an imperative callback, then interact with providers through
+`read`.
+
+<CodeBlock>{trimSnippet(runningAction)}</CodeBlock>
+
+If you need a result, use `action` instead:
+
+<CodeBlock>{trimSnippet(returningResult)}</CodeBlock>
+
+## Keeping providers alive
+
+While an action is pending, providers read or listened to from inside its
+callback stay alive until the action completes.
+
+This is especially useful with `autoDispose` providers:
+
+<CodeBlock>{trimSnippet(keepingAlive)}</CodeBlock>
+
+Without the action wrapper, an imperative read like this may allow the provider
+to dispose as soon as the read is no longer actively listened to.
+
+## Supported APIs inside actions
+
+Actions are meant to work with imperative APIs:
+
+- `ProviderContainer.read`
+- `Ref.read`
+- `WidgetRef.read`
+- `ProviderContainer.listen`
+- `Ref.listen`
+- `WidgetRef.listenManual`
+
+Subscriptions created by those listen APIs are automatically closed when the
+action ends.
+
+## APIs to avoid inside actions
+
+Actions are not declarative, so `watch`-based APIs are intentionally not part
+of the pattern.
+
+- Use `read` instead of `Ref.watch` or `WidgetRef.watch`.
+- Use `WidgetRef.listenManual` instead of `WidgetRef.listen`.
+
+If you need rebuilds driven by provider changes, stay in a declarative widget or
+provider context and use <Link documentID="concepts2/consumers" /> or
+<Link documentID="concepts2/refs" /> APIs directly.
+
+## Actions vs mutations
+
+Use actions when you simply want to perform imperative work while keeping the
+used providers alive.
+
+Use <Link documentID="concepts2/mutations" /> when the user interface should
+also react to the pending, error, or success state of that side-effect.

--- a/website/docs/concepts2/actions/keeping_alive.dart
+++ b/website/docs/concepts2/actions/keeping_alive.dart
@@ -1,0 +1,27 @@
+import 'package:riverpod/riverpod.dart';
+
+Future<T> action<T>(Future<T> Function() cb) => cb();
+
+class User {
+  const User();
+}
+
+class Api {
+  Future<User> fetchCurrentUser() async {
+    return const User();
+  }
+}
+
+final apiProvider = Provider((ref) => Api());
+
+/* SNIPPET START */
+final currentUserProvider = FutureProvider.autoDispose<User>((ref) {
+  return ref.read(apiProvider).fetchCurrentUser();
+});
+
+Future<User> loadCurrentUser(ProviderContainer container) {
+  return action(() async {
+    return await container.read(currentUserProvider.future);
+  });
+}
+/* SNIPPET END */

--- a/website/docs/concepts2/actions/keeping_alive.dart
+++ b/website/docs/concepts2/actions/keeping_alive.dart
@@ -1,7 +1,5 @@
 import 'package:riverpod/riverpod.dart';
 
-Future<T> action<T>(Future<T> Function() cb) => cb();
-
 class User {
   const User();
 }

--- a/website/docs/concepts2/actions/keeping_alive.dart
+++ b/website/docs/concepts2/actions/keeping_alive.dart
@@ -1,3 +1,4 @@
+import 'package:riverpod/experimental/action.dart';
 import 'package:riverpod/riverpod.dart';
 
 class User {

--- a/website/docs/concepts2/actions/returning_result.dart
+++ b/website/docs/concepts2/actions/returning_result.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class Todo {
+  Todo(this.title);
+
+  final String title;
+}
+
+final todoListProvider = NotifierProvider<TodoListNotifier, List<Todo>>(
+  TodoListNotifier.new,
+);
+
+class TodoListNotifier extends Notifier<List<Todo>> {
+  @override
+  List<Todo> build() => const [];
+
+  Future<Todo> addTodo(String title) async {
+    final todo = Todo(title);
+    state = [...state, todo];
+    return todo;
+  }
+}
+
+/* SNIPPET START */
+Future<Todo> createTodo(WidgetRef ref, String title) {
+  return action(() {
+    return ref.read(todoListProvider.notifier).addTodo(title);
+  });
+}
+/* SNIPPET END */

--- a/website/docs/concepts2/actions/returning_result.dart
+++ b/website/docs/concepts2/actions/returning_result.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/experimental/action.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class Todo {

--- a/website/docs/concepts2/actions/running_action.dart
+++ b/website/docs/concepts2/actions/running_action.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final todoListProvider = NotifierProvider<TodoListNotifier, List<String>>(
+  TodoListNotifier.new,
+);
+
+class TodoListNotifier extends Notifier<List<String>> {
+  @override
+  List<String> build() => const [];
+
+  Future<void> addTodo(String title) async {
+    state = [...state, title];
+  }
+}
+
+/* SNIPPET START */
+class AddTodoButton extends ConsumerWidget {
+  const AddTodoButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ElevatedButton(
+      onPressed: voidAction(() async {
+        await ref.read(todoListProvider.notifier).addTodo('Eat a cookie');
+      }),
+      child: const Text('Add todo'),
+    );
+  }
+}
+
+/* SNIPPET END */

--- a/website/docs/concepts2/actions/running_action.dart
+++ b/website/docs/concepts2/actions/running_action.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/experimental/action.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final todoListProvider = NotifierProvider<TodoListNotifier, List<String>>(

--- a/website/docs/concepts2/mutations.mdx
+++ b/website/docs/concepts2/mutations.mdx
@@ -82,6 +82,11 @@ So far, we've listened to the state of a mutation, but nothing actually happens 
 To trigger a mutation, we can use [Mutation.run], pass our mutation, and provide an asynchronous callback
 that updates whatever state we want. Lastly, we'll need to return a value matching the generic type of the mutation.
 
+If you do not need pending/error/success state in the UI, consider using
+<Link documentID="concepts2/actions" /> instead. Actions cover the imperative
+"keep providers alive while this callback is pending" use-case, whereas
+mutations add UI-facing state on top of that side-effect.
+
 <CodeBlock>{trimSnippet(triggering)}</CodeBlock>
 
 ### The different mutation states and their meaning

--- a/website/docs/concepts2/mutations/generic.dart
+++ b/website/docs/concepts2/mutations/generic.dart
@@ -40,8 +40,8 @@ final create = Mutation<ApiResponse>();
 final createTodo = create<CreatedResponse<Todo>>('create_todo');
 
 Future<void> executeCreateTodo(MutationTarget ref) async {
-  await createTodo.run(ref, (tsx) async {
-    final client = tsx.get(apiProvider);
+  await createTodo.run(ref, () async {
+    final client = ref.container.read(apiProvider);
     final response = client.post('/todos', data: {'title': 'Eat a cookie'});
     return CreatedResponse<Todo>.fromJson(response.data, Todo.fromJson);
   });

--- a/website/docs/concepts2/mutations/listening.dart
+++ b/website/docs/concepts2/mutations/listening.dart
@@ -27,7 +27,7 @@ class Example extends ConsumerWidget {
             },
           ),
           onPressed: () {
-            addTodo.run(ref, (tsx) async {
+            addTodo.run(ref, () async {
               // todo
             });
           },

--- a/website/docs/concepts2/mutations/triggering.dart
+++ b/website/docs/concepts2/mutations/triggering.dart
@@ -35,12 +35,11 @@ class AddTodoButton extends ConsumerWidget {
     return ElevatedButton(
       onPressed: () {
         // Trigger the mutation, and run the callback.
-        // During the callback, we obtain a MutationTransaction (tsx) object
-        // which we can use to access providers and perform operations.
-        addTodo.run(ref, (tsx) async {
-          // We use tsx.get to access providers within mutations.
-          // This will keep the provider alive for the duration of the operation.
-          final todoNotifier = tsx.get(todoNotifierProvider.notifier);
+        // The callback runs inside an action.
+        // This lets imperative APIs such as read keep providers alive
+        // for the duration of the operation.
+        addTodo.run(ref, () async {
+          final todoNotifier = ref.read(todoNotifierProvider.notifier);
 
           // We perform a request using a Notifier.
           final createdTodo = await todoNotifier.addTodo('Eat a cookie');

--- a/website/docs/concepts2/providers.mdx
+++ b/website/docs/concepts2/providers.mdx
@@ -80,7 +80,7 @@ them more powerful:
   The result of a provider can be persisted to disk and automatically
   reloaded when the app is restarted.
 - **<Link documentID="concepts2/mutations" />** <br/>
-  Providers offer a built-in way for UIs render a spinner/error for side effects (such as form submission).
+  Providers offer a built-in way for UIs to render a spinner/error state for side effects such as form submission.
 
 Providers come 6 variants:
 

--- a/website/docs/whats_new.mdx
+++ b/website/docs/whats_new.mdx
@@ -256,18 +256,18 @@ followed:
 
 ```dart
 onPressed: () {
-  addTodoMutation.run(ref, (tsx) async {
+  addTodoMutation.run(ref, () async {
     // This is where we run our side-effect.
-    // Here, we typically obtain a Notifier and call a method on it.
-    await tsx.get(todoListProvider.notifier).addTodo('New Todo');
+    // Here, we typically use Ref.read to obtain a Notifier and call a method on it.
+    await ref.read(todoListProvider.notifier).addTodo('New Todo');
   });
 }
 ```
 
 :::note
-Note how we called [tsx.get] here instead of [Ref.read].  
-This is a feature unique to mutations. That [tsx.get] obtains the state of a provider,
-but keep it alive until the mutation is completed.
+Mutations now execute their callback inside an action.  
+As such, imperative APIs such as [Ref.read] keep touched providers alive until
+the mutation completes.
 :::
 
 
@@ -1399,7 +1399,6 @@ regarding combining multiple "sources of truth" in a single provider.
 [riverpod_lint]: https://pub.dev/packages/riverpod_lint
 [Ref]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/Ref-class.html
 [Ref.read]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/Ref/read.html
-[tsx.get]: https://pub.dev/documentation/riverpod/latest/experimental_mutation/MutationTransaction/get.html
 [WidgetRef]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/WidgetRef-class.html
 [TickerMode]: https://api.flutter.dev/flutter/widgets/TickerMode-class.html
 [Consumer]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/Consumer-class.html

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/whats_new.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/whats_new.mdx
@@ -245,17 +245,17 @@ class AddTodoButton extends ConsumerWidget {
 
 ```dart
 onPressed: () {
-  addTodoMutation.run(ref, (tsx) async {
+  addTodoMutation.run(ref, () async {
     // 여기서 사이드이펙트를 실행합니다.
-    // 보통 여기서 Notifier를 가져와서 메서드를 호출합니다.
-    await tsx.get(todoListProvider.notifier).addTodo('새 할일');
+    // 보통 여기서 Ref.read로 Notifier를 가져와서 메서드를 호출합니다.
+    await ref.read(todoListProvider.notifier).addTodo('새 할일');
   });
 }
 ```
 
 :::note
-여기서 [Ref.read] 대신 [tsx.get]을 호출했다는 점에 주목하세요. 이는 Mutation 고유의 기능입니다. [tsx.get]은 Provider의 상태를 가져오지만,
-Mutation이 완료될 때까지 그것을 유지합니다.
+Mutation은 이제 콜백을 action 내부에서 실행합니다.  
+따라서 [Ref.read] 같은 명령형 API는 Mutation이 완료될 때까지 사용한 Provider를 유지합니다.
 :::
 
 
@@ -1292,7 +1292,6 @@ Future<int> myFutureProvider() => throw UnimplementedError();
 [riverpod_lint]: https://pub.dev/packages/riverpod_lint
 [Ref]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/Ref-class.html
 [Ref.read]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/Ref/read.html
-[tsx.get]: https://pub.dev/documentation/riverpod/latest/experimental_mutation/MutationTransaction/get.html
 [WidgetRef]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/WidgetRef-class.html
 [TickerMode]: https://api.flutter.dev/flutter/widgets/TickerMode-class.html
 [Consumer]: https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/Consumer-class.html

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -27,6 +27,7 @@ module.exports = {
         "concepts2/refs",
         "concepts2/auto_dispose",
         "concepts2/family",
+        "concepts2/actions",
         "concepts2/mutations",
         "concepts2/offline",
         "concepts2/retry",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -203,11 +203,6 @@ module.exports = {
             },
             {
               type: "link",
-              label: "MutationTransaction",
-              href: "https://pub.dev/documentation/hooks_riverpod/latest/experimental_mutation/MutationTransaction-class.html",
-            },
-            {
-              type: "link",
               label: "MutationState",
               href: "https://pub.dev/documentation/hooks_riverpod/latest/experimental_mutation/MutationState-class.html",
             },

--- a/website/src/documents_meta.js
+++ b/website/src/documents_meta.js
@@ -25,6 +25,7 @@ export const documentTitles = {
     "concepts2/overrides": "Provider overrides",
     "concepts2/offline": "Offline persistence (experimental)",
     "concepts2/observers": "ProviderObservers",
+    "concepts2/actions": "Actions",
     "concepts2/mutations": "Mutations (experimental)",
     "concepts2/family": "Family",
     "concepts2/containers": "ProviderContainers/ProviderScopes",

--- a/website/src/documents_meta.js
+++ b/website/src/documents_meta.js
@@ -25,7 +25,7 @@ export const documentTitles = {
     "concepts2/overrides": "Provider overrides",
     "concepts2/offline": "Offline persistence (experimental)",
     "concepts2/observers": "ProviderObservers",
-    "concepts2/actions": "Actions",
+    "concepts2/actions": "Actions (experimental)",
     "concepts2/mutations": "Mutations (experimental)",
     "concepts2/family": "Family",
     "concepts2/containers": "ProviderContainers/ProviderScopes",


### PR DESCRIPTION
fixes #4714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced `action` and `voidAction` helpers to keep providers alive during side-effect execution.
  * Added comprehensive documentation and examples for the new action API.

* **Bug Fixes**
  * Added runtime assertions to prevent improper `WidgetRef.watch` and `WidgetRef.listen` usage in action callbacks.

* **Breaking Changes**
  * Removed `MutationTransaction` type from public API.
  * Simplified `Mutation.run` callback signature (no longer receives a transaction parameter).

* **Documentation**
  * Updated mutation examples to reflect new callback patterns.
  * Clarified provider lifecycle behavior within actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->