### PR TITLE
Revert MutationTransaction removal. Add run2 to avoid breaking change

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,15 +1,15 @@
 ## Unreleased minor
 
-- **Experimental breaking** `Mutation.run` is modified: `MutationTransaction` is removed.
+- **Deprecated** `Mutation.run`. A replacement `Mutation.run2` has been added with a modified prototype.
   Before:
   ```dart
   mutation.run(ref, (tsx) async => tsx.get(...))
   ```
   After:
   ```dart
-  mutation.run(ref, () async => ref.read(...));
+  mutation.run2(ref, () async => ref.read(...));
   ```
-  The behavior is otherwise the same.
+  In version 4.0, `run` will be removed and `run2` will be renamed to `run`.
 - Added `action`/`voidAction`, as syntax sugar to using Mutations for keeping providers alive
   during side-effects.
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.

--- a/packages/flutter_riverpod/lib/experimental/mutation.dart
+++ b/packages/flutter_riverpod/lib/experimental/mutation.dart
@@ -1,5 +1,6 @@
 export '../src/internals.dart'
     show
+        MutationTransaction,
         Mutation,
         MutationState,
         MutationIdle,

--- a/packages/flutter_riverpod/test/features/mutations_test.dart
+++ b/packages/flutter_riverpod/test/features/mutations_test.dart
@@ -33,7 +33,7 @@ void main() {
 
     expect(find.text('42'), findsNothing);
 
-    await mut.run(container, () async {
+    await mut.run2(container, () async {
       return 42;
     });
     await tester.pump();

--- a/packages/flutter_riverpod/test/src/core/widget_ref_test.dart
+++ b/packages/flutter_riverpod/test/src/core/widget_ref_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     final sub = ref.listenManual(mutation, (a, b) {});
 
-    await mutation.run(ref, () async {
+    await mutation.run2(ref, () async {
       return 1;
     });
 

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,15 +1,15 @@
 ## Unreleased minor
 
-- **Experimental breaking** `Mutation.run` is modified: `MutationTransaction` is removed.
+- **Deprecated** `Mutation.run`. A replacement `Mutation.run2` has been added with a modified prototype.
   Before:
   ```dart
   mutation.run(ref, (tsx) async => tsx.get(...))
   ```
   After:
   ```dart
-  mutation.run(ref, () async => ref.read(...));
+  mutation.run2(ref, () async => ref.read(...));
   ```
-  The behavior is otherwise the same.
+  In version 4.0, `run` will be removed and `run2` will be renamed to `run`.
 - Added `action`/`voidAction`, as syntax sugar to using Mutations for keeping providers alive
   during side-effects.
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.

--- a/packages/hooks_riverpod/lib/experimental/mutation.dart
+++ b/packages/hooks_riverpod/lib/experimental/mutation.dart
@@ -1,5 +1,6 @@
 export '../src/internals.dart'
     show
+        MutationTransaction,
         Mutation,
         MutationState,
         MutationIdle,

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,15 +1,15 @@
 ## Unreleased minor
 
-- **Experimental breaking** `Mutation.run` is modified: `MutationTransaction` is removed.
+- **Deprecated** `Mutation.run`. A replacement `Mutation.run2` has been added with a modified prototype.
   Before:
   ```dart
   mutation.run(ref, (tsx) async => tsx.get(...))
   ```
   After:
   ```dart
-  mutation.run(ref, () async => ref.read(...));
+  mutation.run2(ref, () async => ref.read(...));
   ```
-  The behavior is otherwise the same.
+  In version 4.0, `run` will be removed and `run2` will be renamed to `run`.
 - Added `action`/`voidAction`, as syntax sugar to using Mutations for keeping providers alive
   during side-effects.
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.

--- a/packages/riverpod/lib/experimental/mutation.dart
+++ b/packages/riverpod/lib/experimental/mutation.dart
@@ -1,5 +1,7 @@
 export '../src/internals.dart'
     show
+        // ignore: deprecated_member_use_from_same_package
+        MutationTransaction,
         Mutation,
         MutationState,
         MutationIdle,

--- a/packages/riverpod/lib/src/core/mutations.dart
+++ b/packages/riverpod/lib/src/core/mutations.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 part of '../framework.dart';
 
 /// Mutation code. This should be in riverpod_annotation, but has to be here
@@ -5,6 +7,35 @@ part of '../framework.dart';
 @internal
 @publicInCodegenMutation
 const mutationZoneKey = #_mutation;
+
+/// A transaction object used within [Mutation.run].
+///
+/// Use [get] to imperatively read a provider while the mutation is pending.
+/// Providers accessed this way remain alive for the duration of the mutation.
+@Deprecated('Use actions')
+@publicInMutations
+final class MutationTransaction {
+  @Deprecated('Use actions')
+  MutationTransaction._(this._container);
+
+  final ProviderContainer _container;
+  var _closed = false;
+
+  /// Reads the current state of a listenable and keeps it alive until the
+  /// enclosing mutation completes.
+  StateT get<StateT>(ProviderListenable<StateT> listenable) {
+    assert(
+      !_closed,
+      'Cannot access MutationTransaction after the mutation has completed',
+    );
+
+    return _container.read(listenable);
+  }
+
+  void _close() {
+    _closed = true;
+  }
+}
 
 final class _MutationProvider<ValueT>
     extends
@@ -54,9 +85,10 @@ class _MutationNotifier<ValueT> {
   _MutationNotifier(this.state, this.setState, this.setRef, this.getRef);
 
   final MutationState<ValueT> state;
-  final void Function(MutationState<ValueT> state, Object ref) setState;
-  final void Function(Object ref) setRef;
-  final Object? Function() getRef;
+  final void Function(MutationState<ValueT> state, MutationTransaction ref)
+  setState;
+  final void Function(MutationTransaction ref) setRef;
+  final MutationTransaction? Function() getRef;
 
   @override
   String toString() {
@@ -79,9 +111,9 @@ class _MutationElement<StateT>
     final provider = this.provider as _MutationProvider<StateT>;
     final mutation = provider.mutation;
 
-    Object? activeRef;
+    MutationTransaction? activeRef;
 
-    void setState(MutationState<StateT> state, Object? mutRef) {
+    void setState(MutationState<StateT> state, MutationTransaction? mutRef) {
       if (mutRef != activeRef) return;
 
       final prevState = value;
@@ -204,14 +236,14 @@ abstract class MutationTarget {
 /// This is for the UI logic. But on its own, the state of the mutation
 /// will never change.
 ///
-/// To change the mutation state, you need to call [Mutation.run].
+/// To change the mutation state, you need to call [Mutation.run2].
 /// This is typically done inside a callback, such as the `onPressed`
 /// of a button:
 ///
 /// ```dart
 /// ElevatedButton(
 ///   onPressed: () {
-///     addTodoMutation.run(ref, () async {
+///     addTodoMutation.run2(ref, () async {
 ///       // This is where you perform the side-effect. Here, you can
 ///       // read your providers to modify them.
 ///       await ref.read(todoListProvider.notifier).addTodo(
@@ -244,7 +276,7 @@ abstract class MutationTarget {
 ///
 /// Currently, mutations do not restrict concurrent calls in any capacity.
 ///
-/// This means that if you call [Mutation.run] while a previous call is still
+/// This means that if you call [Mutation.run2] while a previous call is still
 /// pending, the mutation state will be set to [MutationPending] again,
 /// and the previous call's return value will be ignored.
 ///
@@ -269,9 +301,9 @@ abstract class MutationTarget {
 /// ...
 ///
 /// onPressed: () {
-///   // Upon calling `run`, you will have to pass the same key as when
+///   // Upon calling `run2`, you will have to pass the same key as when
 ///   // watching the mutation.
-///   deleteTodo(todo.id).run(ref, () async { /* ... */ });
+///   deleteTodo(todo.id).run2(ref, () async { /* ... */ });
 /// }
 /// ```
 ///
@@ -316,12 +348,32 @@ sealed class Mutation<ResultT>
   /// completes successfully or throws an error.
   ///
   /// [run] executes [cb] inside an [action].
-  ///
   /// This means imperative APIs such as [ProviderContainer.read] and [Ref.read]
   /// automatically keep touched providers alive for the duration of [cb].
   /// Any action-managed subscriptions created during the callback are closed
   /// when the mutation completes.
-  Future<ResultT> run(MutationTarget target, Future<ResultT> Function() cb);
+  ///
+  /// Use [MutationTransaction.get] inside [cb] to interact with providers while
+  /// keeping them alive for the duration of the mutation.
+  @Deprecated('use run2')
+  Future<ResultT> run(
+    MutationTarget target,
+    Future<ResultT> Function(MutationTransaction transaction) cb,
+  );
+
+  /// Starts a mutation and set its state based on the result of the callback.
+  ///
+  /// This sets the mutation state to [MutationPending],
+  /// call the callback, then set the mutation state to either
+  /// [MutationSuccess] or [MutationError] depending on whether the callback
+  /// completes successfully or throws an error.
+  ///
+  /// [run2] executes [cb] inside an [action].
+  /// This means imperative APIs such as [ProviderContainer.read] and [Ref.read]
+  /// automatically keep touched providers alive for the duration of [cb].
+  /// Any action-managed subscriptions created during the callback are closed
+  /// when the mutation completes.
+  Future<ResultT> run2(MutationTarget target, Future<ResultT> Function() cb);
 
   /// Resets the mutation to its initial state ([MutationIdle]).
   void reset(MutationTarget container);
@@ -368,7 +420,10 @@ final class MutationImpl<ResultT>
   }
 
   @override
-  Future<ResultT> run(MutationTarget target, Future<ResultT> Function() cb) {
+  Future<ResultT> run(
+    MutationTarget target,
+    Future<ResultT> Function(MutationTransaction transaction) cb,
+  ) {
     return runZoned(zoneValues: {mutationZoneKey: this}, () async {
       final container = target.container;
 
@@ -377,12 +432,12 @@ final class MutationImpl<ResultT>
         _MutationProvider(this),
         (_, _) {},
       );
-      final ref = Object();
+      final ref = MutationTransaction._(container);
 
       try {
         mut._mutationStart(sub, ref);
 
-        final result = await action(cb);
+        final result = await action(() => cb(ref));
 
         mut._mutationSuccess(sub, ref, result);
 
@@ -393,8 +448,14 @@ final class MutationImpl<ResultT>
         rethrow;
       } finally {
         sub.close();
+        ref._close();
       }
     });
+  }
+
+  @override
+  Future<ResultT> run2(MutationTarget target, Future<ResultT> Function() cb) {
+    return run(target, (_) => cb());
   }
 
   @override
@@ -411,7 +472,7 @@ final class MutationImpl<ResultT>
 
   void _mutationStart(
     ProviderSubscription<_MutationNotifier<ResultT>> sub,
-    Object ref,
+    MutationTransaction ref,
   ) {
     final _MutationNotifier(:state, :setState, :setRef) =
         sub.readSafe().valueOrRawException;
@@ -423,7 +484,7 @@ final class MutationImpl<ResultT>
 
   void _mutationSuccess(
     ProviderSubscription<_MutationNotifier<ResultT>> sub,
-    Object ref,
+    MutationTransaction ref,
     ResultT result,
   ) {
     final _MutationNotifier(:state, :setState) =
@@ -434,7 +495,7 @@ final class MutationImpl<ResultT>
 
   void _mutationErrored(
     ProviderSubscription<_MutationNotifier<ResultT>> sub,
-    Object ref,
+    MutationTransaction ref,
     Object error,
     StackTrace stackTrace,
   ) {

--- a/packages/riverpod/test/feature/mutation_test.dart
+++ b/packages/riverpod/test/feature/mutation_test.dart
@@ -18,7 +18,7 @@ void main() {
       fireImmediately: true,
     );
 
-    await mut.run(container, () async {});
+    await mut.run2(container, () async {});
 
     expect(container.read(mut), isMutationSuccess<void>());
   });
@@ -51,9 +51,9 @@ void main() {
       (_, _) {},
     );
 
-    await mut.run(container, () async => 9);
-    await mutInt.run(container, () async => 42);
-    await mutDouble.run(container, () async => 3.14);
+    await mut.run2(container, () async => 9);
+    await mutInt.run2(container, () async => 42);
+    await mutDouble.run2(container, () async => 3.14);
 
     expect(sub.read(), isMutationSuccess<num>(9));
     expect(subInt.read(), isMutationSuccess<int>(42));
@@ -69,7 +69,7 @@ void main() {
 
     final sub = container.listen(mut, listener.call);
 
-    final a = mut.run(container, () => completer1.future);
+    final a = mut.run2(container, () => completer1.future);
     verifyOnly(
       listener,
       listener(
@@ -78,7 +78,7 @@ void main() {
       ),
     );
 
-    final b = mut.run(container, () => completer2.future);
+    final b = mut.run2(container, () => completer2.future);
     verifyNoMoreInteractions(listener);
 
     completer1.complete(1);
@@ -111,7 +111,7 @@ void main() {
       listener(argThat(isNull), argThat(isMutationIdle<int>())),
     );
 
-    final result = mut.run(container, () => completer.future);
+    final result = mut.run2(container, () => completer.future);
 
     verifyOnly(
       listener,
@@ -149,7 +149,7 @@ void main() {
       listener(argThat(isNull), argThat(isMutationIdle<int>())),
     );
 
-    final result = mut.run(container, () => completer.future);
+    final result = mut.run2(container, () => completer.future);
 
     // caching errors before they are reported to the zone
     expect(result, throwsA(42));
@@ -180,7 +180,7 @@ void main() {
         final mut = Mutation<int>();
         final container = ProviderContainer.test();
 
-        unawaited(mut.run(container, () async => 42));
+        unawaited(mut.run2(container, () async => 42));
         mut.reset(container);
 
         expect(container.read(mut), isMutationIdle<int>());
@@ -242,7 +242,7 @@ void main() {
     final sub = container.listen(mut(1), (previous, next) {});
     final sub2 = container.listen(mut(2), (previous, next) {});
 
-    final first = mut(1).run(container, () => completer.future);
+    final first = mut(1).run2(container, () => completer.future);
 
     verifyOnly(
       observer,
@@ -268,7 +268,7 @@ void main() {
       ),
     );
 
-    final second = mut(2).run(container, () async => throw Exception('error'));
+    final second = mut(2).run2(container, () async => throw Exception('error'));
 
     verifyOnly(
       observer,
@@ -299,7 +299,7 @@ void main() {
   });
 
   test(
-    'While within `run`, ProviderObserver events log the current mutation',
+    'While within `run2`, ProviderObserver events log the current mutation',
     () async {
       final mut = Mutation<void>();
       final observer = ObserverMock();
@@ -307,7 +307,7 @@ void main() {
       final provider = Provider<int>((ref) => 0);
 
       unawaited(
-        mut.run(container, () async {
+        mut.run2(container, () async {
           container.read(provider);
         }),
       );
@@ -340,7 +340,7 @@ void main() {
       final container = ProviderContainer.test();
       final completer = Completer<void>();
 
-      final f = mut.run(container, () async {
+      final f = mut.run2(container, () async {
         container.read(p);
 
         await completer.future;
@@ -366,7 +366,7 @@ void main() {
     final mut = Mutation<int>();
     final container = ProviderContainer.test();
 
-    await mut.run(container, () async => 0);
+    await mut.run2(container, () async => 0);
 
     await container.pump();
 
@@ -385,10 +385,10 @@ void main() {
     final sub3 = container.listen(mut3, (previous, next) {});
     final sub4 = container.listen(mut4, (previous, next) {});
 
-    await mut1.run(container, () async => 1);
-    await mut2.run(container, () async => 2);
-    await mut3.run(container, () async => 3);
-    await mut4.run(container, () async => 4);
+    await mut1.run2(container, () async => 1);
+    await mut2.run2(container, () async => 2);
+    await mut3.run2(container, () async => 3);
+    await mut4.run2(container, () async => 4);
 
     expect(container.read(mut1), isMutationSuccess<int>(1));
     expect(container.read(mut2), isMutationSuccess<int>(2));

--- a/packages/riverpod/test/src/core/mutations_test.dart
+++ b/packages/riverpod/test/src/core/mutations_test.dart
@@ -16,7 +16,7 @@ void main() {
           .having((e) => e.isSuccess, 'isSuccess', false),
     );
 
-    final future = mut.run(container, () async {});
+    final future = mut.run2(container, () async {});
 
     expect(
       container.read(mut),
@@ -39,7 +39,7 @@ void main() {
     );
 
     await mut
-        .run(container, () async {
+        .run2(container, () async {
           throw Exception('error');
         })
         .catchError((_) {});

--- a/packages/riverpod/test/src/core/ref_test.dart
+++ b/packages/riverpod/test/src/core/ref_test.dart
@@ -56,7 +56,7 @@ void main() {
       container.read(provider);
       final sub = container.listen(mutation, (a, b) {});
 
-      await mutation.run(notifier.ref, () async {
+      await mutation.run2(notifier.ref, () async {
         notifier.state++;
 
         return notifier.state;

--- a/website/docs/concepts2/mutations.mdx
+++ b/website/docs/concepts2/mutations.mdx
@@ -79,7 +79,7 @@ based on the input parameters, such as with deserialization.
 
 So far, we've listened to the state of a mutation, but nothing actually happens yet.
 
-To trigger a mutation, we can use [Mutation.run], pass our mutation, and provide an asynchronous callback
+To trigger a mutation, we can use [Mutation.run2], pass our mutation, and provide an asynchronous callback
 that updates whatever state we want. Lastly, we'll need to return a value matching the generic type of the mutation.
 
 If you do not need pending/error/success state in the UI, consider using
@@ -119,7 +119,7 @@ by calling the [Mutation.reset] method:
 [MutationSuccess]: https://pub.dev/documentation/riverpod/latest/experimental_mutation/MutationSuccess-class.html
 [MutationIdle]: https://pub.dev/documentation/riverpod/latest/experimental_mutation/MutationIdle-class.html
 [Mutation.reset]: https://pub.dev/documentation/riverpod/latest/experimental_mutation/Mutation/reset.html
-[Mutation.run]: https://pub.dev/documentation/riverpod/latest/experimental_mutation/Mutation/run.html
+[Mutation.run2]: https://pub.dev/documentation/riverpod/latest/experimental_mutation/Mutation/run2.html
 [Mutation]: https://pub.dev/documentation/riverpod/latest/experimental_mutation/Mutation-class.html
 [Notifier]: https://pub.dev/documentation/riverpod/latest/riverpod/Notifier-class.html
 [Ref.watch]: https://pub.dev/documentation/riverpod/latest/riverpod/Ref/watch.html

--- a/website/docs/concepts2/mutations/generic.dart
+++ b/website/docs/concepts2/mutations/generic.dart
@@ -40,7 +40,7 @@ final create = Mutation<ApiResponse>();
 final createTodo = create<CreatedResponse<Todo>>('create_todo');
 
 Future<void> executeCreateTodo(MutationTarget ref) async {
-  await createTodo.run(ref, () async {
+  await createTodo.run2(ref, () async {
     final client = ref.container.read(apiProvider);
     final response = client.post('/todos', data: {'title': 'Eat a cookie'});
     return CreatedResponse<Todo>.fromJson(response.data, Todo.fromJson);

--- a/website/docs/concepts2/mutations/listening.dart
+++ b/website/docs/concepts2/mutations/listening.dart
@@ -27,7 +27,7 @@ class Example extends ConsumerWidget {
             },
           ),
           onPressed: () {
-            addTodo.run(ref, () async {
+            addTodo.run2(ref, () async {
               // todo
             });
           },

--- a/website/docs/concepts2/mutations/triggering.dart
+++ b/website/docs/concepts2/mutations/triggering.dart
@@ -35,10 +35,9 @@ class AddTodoButton extends ConsumerWidget {
     return ElevatedButton(
       onPressed: () {
         // Trigger the mutation, and run the callback.
-        // The callback runs inside an action.
-        // This lets imperative APIs such as read keep providers alive
-        // for the duration of the operation.
-        addTodo.run(ref, () async {
+        // Reads inside the callback keep providers alive
+        // for the duration of the mutation.
+        addTodo.run2(ref, () async {
           final todoNotifier = ref.read(todoNotifierProvider.notifier);
 
           // We perform a request using a Notifier.

--- a/website/docs/whats_new.mdx
+++ b/website/docs/whats_new.mdx
@@ -256,18 +256,18 @@ followed:
 
 ```dart
 onPressed: () {
-  addTodoMutation.run(ref, () async {
+  addTodoMutation.run2(ref, () async {
     // This is where we run our side-effect.
-    // Here, we typically use Ref.read to obtain a Notifier and call a method on it.
+    // Here, we can read a Notifier directly and call a method on it.
     await ref.read(todoListProvider.notifier).addTodo('New Todo');
   });
 }
 ```
 
 :::note
-Mutations now execute their callback inside an action.  
-As such, imperative APIs such as [Ref.read] keep touched providers alive until
-the mutation completes.
+`run2` executes the callback inside an action.  
+Imperative reads such as [Ref.read] keep touched providers alive until the
+mutation completes.
 :::
 
 

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/whats_new.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/whats_new.mdx
@@ -245,17 +245,17 @@ class AddTodoButton extends ConsumerWidget {
 
 ```dart
 onPressed: () {
-  addTodoMutation.run(ref, () async {
+  addTodoMutation.run2(ref, () async {
     // 여기서 사이드이펙트를 실행합니다.
-    // 보통 여기서 Ref.read로 Notifier를 가져와서 메서드를 호출합니다.
+    // 여기서 Notifier를 직접 읽어서 메서드를 호출할 수 있습니다.
     await ref.read(todoListProvider.notifier).addTodo('새 할일');
   });
 }
 ```
 
 :::note
-Mutation은 이제 콜백을 action 내부에서 실행합니다.  
-따라서 [Ref.read] 같은 명령형 API는 Mutation이 완료될 때까지 사용한 Provider를 유지합니다.
+`run2`는 콜백을 action 내부에서 실행합니다.  
+[Ref.read] 같은 명령형 읽기는 Mutation이 완료될 때까지 사용한 Provider를 유지합니다.
 :::
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Mutation.run2` as the primary API for triggering mutations.

* **Deprecations**
  * Deprecated `Mutation.run`; migrate to `Mutation.run2` instead.

* **Documentation**
  * Updated all guides, examples, and code snippets to use the new mutation API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->