### PR TITLE
Rename actions

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -10,7 +10,7 @@
   mutation.run2(ref, () async => ref.read(...));
   ```
   In version 4.0, `run` will be removed and `run2` will be renamed to `run`.
-- Added `action`/`voidAction`, as syntax sugar to using Mutations for keeping providers alive
+- Added `run`/`voidRun`, as syntax sugar to using Mutations for keeping providers alive
   during side-effects.
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.
 - Refactored internal scheduling mechanism to solve some markNeedsBuild error.

--- a/packages/flutter_riverpod/lib/experimental/action.dart
+++ b/packages/flutter_riverpod/lib/experimental/action.dart
@@ -1,1 +1,1 @@
-export '../src/internals.dart' show action, voidAction;
+export '../src/internals.dart' show run, voidRun;

--- a/packages/flutter_riverpod/lib/src/core/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/core/consumer.dart
@@ -464,10 +464,7 @@ base class ConsumerStatefulElement extends StatefulElement
   @override
   StateT watch<StateT>(ProviderListenable<StateT> target) {
     _assertNotDisposed();
-    assert(
-      !$isInAction(),
-      'Cannot use WidgetRef.watch inside action callbacks.',
-    );
+    assert(!$isInAction(), 'Cannot use WidgetRef.watch inside run callbacks.');
     return _dependencies
             .putIfAbsent(target, () {
               final oldDependency = _oldDependencies?.remove(target);
@@ -518,10 +515,7 @@ base class ConsumerStatefulElement extends StatefulElement
     bool weak = false,
   }) {
     _assertNotDisposed();
-    assert(
-      !$isInAction(),
-      'Cannot use WidgetRef.listen inside action callbacks.',
-    );
+    assert(!$isInAction(), 'Cannot use WidgetRef.listen inside run callbacks.');
     assert(
       debugDoingBuild,
       'ref.listen can only be used within the build method of a ConsumerWidget',

--- a/packages/flutter_riverpod/test/listen_test.dart
+++ b/packages/flutter_riverpod/test/listen_test.dart
@@ -154,7 +154,7 @@ void main() {
       verifyNoMoreInteractions(listener);
     });
 
-    testWidgets('closes subscriptions when the action ends', (tester) async {
+    testWidgets('closes subscriptions when the run ends', (tester) async {
       final completer = Completer<void>();
       final provider = StateProvider((ref) => 0);
       final listener = Listener<int>();
@@ -171,7 +171,7 @@ void main() {
         ),
       );
 
-      final future = action(() async {
+      final future = run(() async {
         ref.listenManual(provider, listener.call);
         await completer.future;
       });
@@ -188,7 +188,7 @@ void main() {
   });
 
   group('WidgetRef.listen', () {
-    testWidgets('throws inside action', (tester) async {
+    testWidgets('throws inside run', (tester) async {
       final provider = Provider((ref) => 0);
       late WidgetRef widgetRef;
 
@@ -204,7 +204,7 @@ void main() {
       );
 
       await expectLater(
-        action(() async {
+        run(() async {
           widgetRef.listen(provider, (_, _) {});
         }),
         throwsA(isA<AssertionError>()),

--- a/packages/flutter_riverpod/test/widget_ref_test.dart
+++ b/packages/flutter_riverpod/test/widget_ref_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('WidgetRef', () {
-    testWidgets('read participates in action retention', (tester) async {
+    testWidgets('read participates in run retention', (tester) async {
       final completer = Completer<int>();
       var disposed = false;
       final provider = FutureProvider.autoDispose<int>((ref) {
@@ -23,7 +23,7 @@ void main() {
 
       final ref = tester.firstElement(find.byType(Consumer)) as WidgetRef;
 
-      final future = action(() async => ref.read(provider.future));
+      final future = run(() async => ref.read(provider.future));
 
       await tester.pump();
       expect(disposed, false);
@@ -36,7 +36,7 @@ void main() {
       expect(disposed, true);
     });
 
-    testWidgets('watch throws inside action', (tester) async {
+    testWidgets('watch throws inside run', (tester) async {
       final provider = Provider((ref) => 42);
       late WidgetRef widgetRef;
 
@@ -52,7 +52,7 @@ void main() {
       );
 
       await expectLater(
-        action(() async => widgetRef.watch(provider)),
+        run(() async => widgetRef.watch(provider)),
         throwsA(isA<AssertionError>()),
       );
     });

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -10,7 +10,7 @@
   mutation.run2(ref, () async => ref.read(...));
   ```
   In version 4.0, `run` will be removed and `run2` will be renamed to `run`.
-- Added `action`/`voidAction`, as syntax sugar to using Mutations for keeping providers alive
+- Added `run`/`voidRun`, as syntax sugar to using Mutations for keeping providers alive
   during side-effects.
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.
 - Refactored internal scheduling mechanism to solve some markNeedsBuild error.

--- a/packages/hooks_riverpod/lib/experimental/action.dart
+++ b/packages/hooks_riverpod/lib/experimental/action.dart
@@ -1,1 +1,1 @@
-export '../src/internals.dart' show action, voidAction;
+export '../src/internals.dart' show run, voidRun;

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -30,7 +30,7 @@
   mutation.run2(ref, () async => ref.read(...));
   ```
   In version 4.0, `run` will be removed and `run2` will be renamed to `run`.
-- Added `action`/`voidAction`, as syntax sugar to using Mutations for keeping providers alive
+- Added `run`/`voidRun`, as syntax sugar to using Mutations for keeping providers alive
   during side-effects.
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.
 - Refactored internal scheduling mechanism to solve some markNeedsBuild error.

--- a/packages/riverpod/lib/experimental/action.dart
+++ b/packages/riverpod/lib/experimental/action.dart
@@ -1,1 +1,1 @@
-export '../src/internals.dart' show action, voidAction;
+export '../src/internals.dart' show run, voidRun;

--- a/packages/riverpod/lib/src/core/action.dart
+++ b/packages/riverpod/lib/src/core/action.dart
@@ -11,7 +11,7 @@ _ActionExecution? _currentAction() {
   return null;
 }
 
-/// Returns `true` if the current code is running inside an [action].
+/// Returns `true` if the current code is running inside a [run] callback.
 @publicInCodegen
 bool $isInAction() => _currentAction() != null;
 
@@ -19,8 +19,8 @@ bool $isInAction() => _currentAction() != null;
 ///
 /// Providers accessed through [Ref.read] or [ProviderContainer.read] while the
 /// callback is pending are kept alive and active for the duration of the
-/// action.
-Future<ResultT> action<ResultT>(Future<ResultT> Function() cb) {
+/// run callback.
+Future<ResultT> _runInternal<ResultT>(Future<ResultT> Function() cb) {
   if (_currentAction() != null) return cb();
 
   final action = _ActionExecution();
@@ -39,10 +39,18 @@ Future<ResultT> action<ResultT>(Future<ResultT> Function() cb) {
   }
 }
 
-/// Returns a callback that executes [cb] inside [action].
+/// Runs [cb] while keeping providers read inside it alive until completion.
 ///
-/// This is equivalent to writing `() => action(cb)`.
-Future<T> Function() voidAction<T>(Future<T> Function() cb) => () => action(cb);
+/// Providers accessed through [Ref.read] or [ProviderContainer.read] while the
+/// callback is pending are kept alive and active for the duration of the
+/// run callback.
+Future<ResultT> run<ResultT>(Future<ResultT> Function() cb) => _runInternal(cb);
+
+/// Returns a callback that executes [cb] inside [run].
+///
+/// This is equivalent to writing `() => run(cb)`.
+Future<T> Function() voidRun<T>(Future<T> Function() cb) =>
+    () => _runInternal(cb);
 
 final class _ActionExecution {
   var _closed = false;
@@ -50,7 +58,7 @@ final class _ActionExecution {
   final _subscriptions = <ProviderSubscription>[];
 
   void register(ProviderSubscription subscription) {
-    assert(!_closed, 'Cannot register subscriptions on a closed action');
+    assert(!_closed, 'Cannot register subscriptions on a closed run');
     _subscriptions.add(subscription);
   }
 

--- a/packages/riverpod/lib/src/core/mutations.dart
+++ b/packages/riverpod/lib/src/core/mutations.dart
@@ -347,14 +347,17 @@ sealed class Mutation<ResultT>
   /// [MutationSuccess] or [MutationError] depending on whether the callback
   /// completes successfully or throws an error.
   ///
-  /// [run] executes [cb] inside an [action].
+  /// [run] executes [cb] inside a top-level `run` callback.
   /// This means imperative APIs such as [ProviderContainer.read] and [Ref.read]
   /// automatically keep touched providers alive for the duration of [cb].
-  /// Any action-managed subscriptions created during the callback are closed
+  /// Any run-managed subscriptions created during the callback are closed
   /// when the mutation completes.
   ///
   /// Use [MutationTransaction.get] inside [cb] to interact with providers while
   /// keeping them alive for the duration of the mutation.
+  ///
+  /// See also:
+  /// - top-level `run`, to keep providers alive without using a mutation.
   @Deprecated('use run2')
   Future<ResultT> run(
     MutationTarget target,
@@ -368,11 +371,14 @@ sealed class Mutation<ResultT>
   /// [MutationSuccess] or [MutationError] depending on whether the callback
   /// completes successfully or throws an error.
   ///
-  /// [run2] executes [cb] inside an [action].
+  /// [run2] executes [cb] inside a top-level `run` callback.
   /// This means imperative APIs such as [ProviderContainer.read] and [Ref.read]
   /// automatically keep touched providers alive for the duration of [cb].
-  /// Any action-managed subscriptions created during the callback are closed
+  /// Any run-managed subscriptions created during the callback are closed
   /// when the mutation completes.
+  ///
+  /// See also:
+  /// - top-level `run`, to keep providers alive without using a mutation.
   Future<ResultT> run2(MutationTarget target, Future<ResultT> Function() cb);
 
   /// Resets the mutation to its initial state ([MutationIdle]).
@@ -437,7 +443,7 @@ final class MutationImpl<ResultT>
       try {
         mut._mutationStart(sub, ref);
 
-        final result = await action(() => cb(ref));
+        final result = await _runInternal(() => cb(ref));
 
         mut._mutationSuccess(sub, ref, result);
 

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -708,7 +708,7 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   /// ```
   StateT watch<StateT>(ProviderListenable<StateT> listenable) {
     _throwIfInvalidUsage();
-    assert(!$isInAction(), 'Cannot use Ref.watch inside action callbacks.');
+    assert(!$isInAction(), 'Cannot use Ref.watch inside run callbacks.');
     late ProviderSubscription<StateT> sub;
     sub = _element.listen<StateT>(
       listenable,

--- a/packages/riverpod/test/src/core/action_test.dart
+++ b/packages/riverpod/test/src/core/action_test.dart
@@ -8,7 +8,7 @@ import '../matrix.dart';
 import '../utils.dart';
 
 void main() {
-  group('action', () {
+  group('run', () {
     test('keeps autoDispose providers active while pending', () async {
       final container = ProviderContainer.test();
       final completer = Completer<int>();
@@ -19,7 +19,7 @@ void main() {
         return completer.future;
       });
 
-      final future = action(() async {
+      final future = run(() async {
         return container.read(provider.future);
       });
 
@@ -60,7 +60,7 @@ void main() {
 
         container.read(holder);
 
-        final future = action(() async => notifier.ref.read(provider.future));
+        final future = run(() async => notifier.ref.read(provider.future));
 
         final element = container.readProviderElement(provider);
         expect(element.isActive, true);
@@ -80,7 +80,7 @@ void main() {
       },
     );
 
-    test('deduplicates reads of the same provider within an action', () async {
+    test('deduplicates reads of the same provider within a run', () async {
       final container = ProviderContainer.test();
       var buildCount = 0;
       final provider = Provider.autoDispose((ref) {
@@ -88,7 +88,7 @@ void main() {
         return 42;
       });
 
-      final result = action(() async {
+      final result = run(() async {
         expect(container.read(provider), 42);
         expect(container.read(provider), 42);
         return container.read(provider);
@@ -102,7 +102,7 @@ void main() {
       expect(container.pointerManager.readPointer(provider), isNull);
     });
 
-    test('throws if Ref.watch is used inside an action', () async {
+    test('throws if Ref.watch is used inside a run', () async {
       final container = ProviderContainer.test();
       final notifier = DeferredNotifier<int>((ref, self) => 0);
       final holder = NotifierProvider<DeferredNotifier<int>, int>(
@@ -113,20 +113,20 @@ void main() {
       container.read(holder);
 
       await expectLater(
-        action(() async => notifier.ref.watch(provider)),
+        run(() async => notifier.ref.watch(provider)),
         throwsA(isA<AssertionError>()),
       );
     });
 
     test(
-      'does not treat Ref.watch from providers initialized in an action as part of the action',
+      'does not treat Ref.watch from providers initialized in a run as part of the run',
       () async {
         final container = ProviderContainer.test();
         final dep = StateProvider((ref) => 42);
         final provider = Provider.autoDispose((ref) => ref.watch(dep));
 
         await expectLater(
-          action(() async => container.read(provider)),
+          run(() async => container.read(provider)),
           completion(42),
         );
 
@@ -137,11 +137,11 @@ void main() {
     );
 
     test(
-      'does not treat Ref.read from providers initialized in an action as part of the action',
+      'does not treat Ref.read from providers initialized in a run as part of the run',
       () async {
         final container = ProviderContainer.test();
         final providerCompleter = Completer<int>();
-        final actionCompleter = Completer<void>();
+        final runCompleter = Completer<void>();
         final onDispose = OnDisposeMock();
 
         final dep = FutureProvider.autoDispose<int>((ref) {
@@ -152,9 +152,9 @@ void main() {
           (ref) => ref.read(dep.future),
         );
 
-        final future = action(() async {
+        final future = run(() async {
           container.read(provider);
-          await actionCompleter.future;
+          await runCompleter.future;
         });
 
         await container.pump();
@@ -163,7 +163,7 @@ void main() {
         expect(container.pointerManager.readPointer(provider), isNotNull);
         expect(container.pointerManager.readPointer(dep), isNull);
 
-        actionCompleter.complete();
+        runCompleter.complete();
         await future;
 
         providerCompleter.complete(42);
@@ -171,10 +171,10 @@ void main() {
     );
 
     test(
-      'does not close Ref.listen from providers initialized in an action when the action ends',
+      'does not close Ref.listen from providers initialized in a run when the run ends',
       () async {
         final container = ProviderContainer.test();
-        final actionCompleter = Completer<void>();
+        final runCompleter = Completer<void>();
         final listener = Listener<int>();
         final dep = StateProvider((ref) => 0);
 
@@ -183,16 +183,16 @@ void main() {
           return 42;
         });
 
-        final future = action(() async {
+        final future = run(() async {
           expect(container.read(provider), 42);
-          await actionCompleter.future;
+          await runCompleter.future;
         });
 
         await container.pump();
 
         final keepAlive = container.listen(provider, (_, _) {});
 
-        actionCompleter.complete();
+        runCompleter.complete();
         await future;
 
         container.read(dep.notifier).state++;
@@ -204,14 +204,14 @@ void main() {
     );
 
     test(
-      'closes ProviderContainer.listen subscriptions when the action ends',
+      'closes ProviderContainer.listen subscriptions when the run ends',
       () async {
         final container = ProviderContainer.test();
         final completer = Completer<void>();
         final listener = Listener<int>();
         final dep = StateProvider((ref) => 0);
 
-        final future = action(() async {
+        final future = run(() async {
           container.listen(dep, listener.call);
           await completer.future;
         });
@@ -229,7 +229,7 @@ void main() {
       },
     );
 
-    test('closes Ref.listen subscriptions when the action ends', () async {
+    test('closes Ref.listen subscriptions when the run ends', () async {
       final container = ProviderContainer.test();
       final completer = Completer<void>();
       final listener = Listener<int>();
@@ -241,7 +241,7 @@ void main() {
 
       container.read(holder);
 
-      final future = action(() async {
+      final future = run(() async {
         notifier.ref.listen(dep, listener.call);
         await completer.future;
       });
@@ -259,8 +259,8 @@ void main() {
     });
   });
 
-  group('voidAction', () {
-    test('returns a callback that runs inside action', () async {
+  group('voidRun', () {
+    test('returns a callback that runs inside run', () async {
       final container = ProviderContainer.test();
       final completer = Completer<int>();
       final onDispose = OnDisposeMock();
@@ -270,7 +270,7 @@ void main() {
         return completer.future;
       });
 
-      final callback = voidAction(() async {
+      final callback = voidRun(() async {
         await container.read(provider.future);
       });
 

--- a/website/docs/concepts2/actions.mdx
+++ b/website/docs/concepts2/actions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Actions (experimental)
+title: Runs (experimental)
 ---
 import CodeBlock from "@theme/CodeBlock";
 import { Link } from "/src/components/Link";
@@ -21,8 +21,8 @@ other event handlers where using `watch` would be inappropriate.
 
 Riverpod exposes two top-level helpers:
 
-- `action`, which returns a value.
-- `voidAction`, a shorthand for actions that return `void`.
+- `run`, which returns a value.
+- `voidRun`, a shorthand for actions that return `void`.
 
 ## Running an action
 
@@ -31,7 +31,7 @@ Use an action from an imperative callback, then interact with providers through
 
 <CodeBlock>{trimSnippet(runningAction)}</CodeBlock>
 
-If you need a result, use `action` instead:
+If you need a result, use `run` instead:
 
 <CodeBlock>{trimSnippet(returningResult)}</CodeBlock>
 

--- a/website/docs/concepts2/actions/keeping_alive.dart
+++ b/website/docs/concepts2/actions/keeping_alive.dart
@@ -19,8 +19,9 @@ final currentUserProvider = FutureProvider.autoDispose<User>((ref) {
 });
 
 Future<User> loadCurrentUser(ProviderContainer container) {
-  return action(() async {
+  return run(() async {
     return await container.read(currentUserProvider.future);
   });
 }
+
 /* SNIPPET END */

--- a/website/docs/concepts2/actions/returning_result.dart
+++ b/website/docs/concepts2/actions/returning_result.dart
@@ -24,8 +24,9 @@ class TodoListNotifier extends Notifier<List<Todo>> {
 
 /* SNIPPET START */
 Future<Todo> createTodo(WidgetRef ref, String title) {
-  return action(() {
+  return run(() {
     return ref.read(todoListProvider.notifier).addTodo(title);
   });
 }
+
 /* SNIPPET END */

--- a/website/docs/concepts2/actions/running_action.dart
+++ b/website/docs/concepts2/actions/running_action.dart
@@ -22,7 +22,7 @@ class AddTodoButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return ElevatedButton(
-      onPressed: voidAction(() async {
+      onPressed: voidRun(() async {
         await ref.read(todoListProvider.notifier).addTodo('Eat a cookie');
       }),
       child: const Text('Add todo'),

--- a/website/docs/whats_new.mdx
+++ b/website/docs/whats_new.mdx
@@ -265,7 +265,7 @@ onPressed: () {
 ```
 
 :::note
-`run2` executes the callback inside an action.  
+`run2` executes the callback inside <Link documentID="concepts2/actions" />.  
 Imperative reads such as [Ref.read] keep touched providers alive until the
 mutation completes.
 :::

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/whats_new.mdx
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/whats_new.mdx
@@ -254,7 +254,7 @@ onPressed: () {
 ```
 
 :::note
-`run2`는 콜백을 action 내부에서 실행합니다.  
+`run2`는 콜백을 `run` 내부에서 실행합니다.  
 [Ref.read] 같은 명령형 읽기는 Mutation이 완료될 때까지 사용한 Provider를 유지합니다.
 :::
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed mutation operation APIs from `action`/`voidAction` to `run`/`voidRun` for improved naming consistency.

* **Documentation**
  * Updated all guides and code examples to reflect the new `run`/`voidRun` API names.

* **Tests**
  * Updated test suite to use the new API naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->