### PR TITLE
Fix .future notifying too much

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -22,10 +22,12 @@
   ```
 
   Which allows for users to invalidate only the providers they care about, while implementation details can be handled privately. (thanks to @TekExplorer)
+
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.
 - Refactored internal scheduling mechanism to solve some markNeedsBuild error.
 - Removed `@internal` for `ProviderFamily.new`
 - Added various life-cycles to `ProviderObserver`
+- Fix `.future` incorrectly notifying listeners even when `AsyncValue` doesn't change.
 
 ## 3.3.1 - 2026-03-09
 

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -22,10 +22,12 @@
   ```
 
   Which allows for users to invalidate only the providers they care about, while implementation details can be handled privately. (thanks to @TekExplorer)
+
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.
 - Refactored internal scheduling mechanism to solve some markNeedsBuild error.
 - Removed `@internal` for `ProviderFamily.new`
 - Added various life-cycles to `ProviderObserver`
+- Fix `.future` incorrectly notifying listeners even when `AsyncValue` doesn't change.
 
 ## 3.3.0 - 2026-03-09
 

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -22,10 +22,12 @@
   ```
 
   Which allows for users to invalidate only the providers they care about, while implementation details can be handled privately. (thanks to @TekExplorer)
+
 - Added `ProviderContainer.allProviders()`, to obtain all providers accessible from said container. You can optionally specify `allProviders(family: myFamily)` to only include providers from said family.
 - Refactored internal scheduling mechanism to solve some markNeedsBuild error.
 - Removed `@internal` for `ProviderFamily.new`
 - Added various life-cycles to `ProviderObserver`
+- Fix `.future` incorrectly notifying listeners even when `AsyncValue` doesn't change.
 
 ## 3.2.1 - 2026-02-03
 

--- a/packages/riverpod/lib/src/common/listenable.dart
+++ b/packages/riverpod/lib/src/common/listenable.dart
@@ -56,7 +56,7 @@ final class $Observable<ValueT> extends _ValueListenable<ValueT> {
     $Result<ValueT> newResult, {
     required bool shouldNotify,
   }) {
-    if (shouldNotify) {
+    if (shouldNotify || hasSkippedNotification) {
       result = newResult;
     } else {
       _result = newResult;
@@ -66,6 +66,8 @@ final class $Observable<ValueT> extends _ValueListenable<ValueT> {
 
 final class _ValueListenable<ValueT> {
   void Function()? onCancel;
+
+  bool get hasSkippedNotification => _skippedNotification != null;
 
   var _count = 0;
   // The _listeners is intentionally set to a fixed-length _GrowableList instead

--- a/packages/riverpod/lib/src/common/listenable.dart
+++ b/packages/riverpod/lib/src/common/listenable.dart
@@ -52,7 +52,7 @@ final class $Observable<ValueT> extends _ValueListenable<ValueT> {
     return result;
   }
 
-  void setResultAndMaybeModify(
+  void setResultAndMaybeNotify(
     $Result<ValueT> newResult, {
     required bool shouldNotify,
   }) {

--- a/packages/riverpod/lib/src/common/listenable.dart
+++ b/packages/riverpod/lib/src/common/listenable.dart
@@ -51,6 +51,17 @@ final class $Observable<ValueT> extends _ValueListenable<ValueT> {
     }
     return result;
   }
+
+  void setResultAndMaybeModify(
+    $Result<ValueT> newResult, {
+    required bool shouldNotify,
+  }) {
+    if (shouldNotify) {
+      result = newResult;
+    } else {
+      _result = newResult;
+    }
+  }
 }
 
 final class _ValueListenable<ValueT> {

--- a/packages/riverpod/lib/src/common/listenable.dart
+++ b/packages/riverpod/lib/src/common/listenable.dart
@@ -67,7 +67,8 @@ final class $Observable<ValueT> extends _ValueListenable<ValueT> {
 final class _ValueListenable<ValueT> {
   void Function()? onCancel;
 
-  bool get hasSkippedNotification => _skippedNotification != null;
+  bool get hasSkippedNotification =>
+      _skippedNotification?.data != null || _skippedNotification?.error != null;
 
   var _count = 0;
   // The _listeners is intentionally set to a fixed-length _GrowableList instead

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -464,8 +464,8 @@ abstract class ProviderElement<StateT, ValueT> {
       final previousResult = resultForValue(previous);
       final nextResult = resultForValue(next);
       final updateShouldNotify = _callUpdateShouldNotifyFromResults(
-        previousResult,
-        nextResult!,
+        previous: previousResult,
+        next: nextResult!,
       );
 
       _notifyListeners(
@@ -520,13 +520,13 @@ depending on itself.
     return state;
   }
 
-  bool _callUpdateShouldNotifyFromResults(
-    $Result<StateT>? previousState,
-    $Result<StateT> newState,
-  ) {
-    if (previousState == null) return true;
+  bool _callUpdateShouldNotifyFromResults({
+    required $Result<StateT>? previous,
+    required $Result<StateT> next,
+  }) {
+    if (previous == null) return true;
 
-    switch ((previousState, newState)) {
+    switch ((previous, next)) {
       case (
         $ResultData(value: final previousValue),
         $ResultData(value: final newValue),
@@ -647,8 +647,8 @@ depending on itself.
           valueResult!,
           previousValueResult,
           updateShouldNotifyResult: _callUpdateShouldNotifyFromResults(
-            previousValueResult,
-            valueResult,
+            previous: previousValueResult,
+            next: valueResult,
           ),
         );
 

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -69,12 +69,12 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
 
   @override
   @protected
-  set value(AsyncValue<ValueT> newState) {
-    newState.map(loading: onLoading, error: onError, data: onData);
+  bool setValue(AsyncValue<ValueT> value) {
+    return value.map(loading: onLoading, error: onError, data: onData);
   }
 
   @internal
-  void onLoading(AsyncLoading<ValueT> value, {bool seamless = false}) {
+  bool onLoading(AsyncLoading<ValueT> value, {bool seamless = false}) {
     final notified = asyncTransition(value, seamless: seamless);
     if (_futureCompleter == null) {
       final completer = _futureCompleter = Completer();
@@ -83,6 +83,8 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
         shouldNotify: notified,
       );
     }
+
+    return notified;
   }
 
   void onValue(AsyncValue<ValueT> value, {bool seamless = false}) {
@@ -101,7 +103,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
   /// Might be invoked after the element is disposed in the case where `provider.future`
   /// has yet to complete.
   @internal
-  void onError(AsyncError<ValueT> value, {bool seamless = false}) {
+  bool onError(AsyncError<ValueT> value, {bool seamless = false}) {
     final notified = asyncTransition(value, seamless: seamless);
 
     final result = resultForValue(value);
@@ -129,6 +131,8 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
         shouldNotify: notified,
       );
     }
+
+    return notified;
   }
 
   /// Life-cycle for when a data from the provider's "build" method is received.
@@ -136,7 +140,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
   /// Might be invoked after the element is disposed in the case where `provider.future`
   /// has yet to complete.
   @internal
-  void onData(AsyncData<ValueT> value, {bool seamless = false}) {
+  bool onData(AsyncData<ValueT> value, {bool seamless = false}) {
     final notified = asyncTransition(value, seamless: seamless);
 
     final completer = _futureCompleter;
@@ -149,6 +153,8 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
         shouldNotify: notified,
       );
     }
+
+    return notified;
   }
 
   /// Listens to a [Stream] and convert it into an [AsyncValue].

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -80,7 +80,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
       final completer = _futureCompleter = Completer();
       futureNotifier.setResultAndMaybeNotify(
         $ResultData(completer.future),
-        shouldNotify: notified,
+        shouldNotify: true,
       );
     }
 

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -80,7 +80,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
       final completer = _futureCompleter = Completer();
       futureNotifier.setResultAndMaybeNotify(
         $ResultData(completer.future),
-        shouldNotify: true,
+        shouldNotify: notified,
       );
     }
 
@@ -483,7 +483,8 @@ abstract class ProviderElement<StateT, ValueT> {
       return updateShouldNotify;
     }
 
-    return false;
+    // True so that weak listeners are correctly notified of the first state set.
+    return true;
   }
 
   set value(AsyncValue<ValueT> value) {

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -78,7 +78,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
     final notified = asyncTransition(value, seamless: seamless);
     if (_futureCompleter == null) {
       final completer = _futureCompleter = Completer();
-      futureNotifier.setResultAndMaybeModify(
+      futureNotifier.setResultAndMaybeNotify(
         $ResultData(completer.future),
         shouldNotify: notified,
       );
@@ -124,7 +124,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
         ..completeError(value.error, value.stackTrace);
       _futureCompleter = null;
     } else {
-      futureNotifier.setResultAndMaybeModify(
+      futureNotifier.setResultAndMaybeNotify(
         $Result.data(Future.error(value.error, value.stackTrace)..ignore()),
         shouldNotify: notified,
       );
@@ -144,7 +144,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
       completer.complete(value.value);
       _futureCompleter = null;
     } else {
-      futureNotifier.setResultAndMaybeModify(
+      futureNotifier.setResultAndMaybeNotify(
         $Result.data(Future.value(value.value)),
         shouldNotify: notified,
       );

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -76,10 +76,12 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
   @internal
   void onLoading(AsyncLoading<ValueT> value, {bool seamless = false}) {
     final notified = asyncTransition(value, seamless: seamless);
-    if (_futureCompleter == null &&
-        (futureNotifier.result == null || notified)) {
+    if (_futureCompleter == null && (futureNotifier.result == null)) {
       final completer = _futureCompleter = Completer();
-      futureNotifier.result = $ResultData(completer.future);
+      futureNotifier.setResultAndMaybeModify(
+        $ResultData(completer.future),
+        shouldNotify: notified,
+      );
     }
   }
 
@@ -121,9 +123,10 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
         ..future.ignore()
         ..completeError(value.error, value.stackTrace);
       _futureCompleter = null;
-    } else if (futureNotifier.result == null || notified) {
-      futureNotifier.result = $Result.data(
-        Future.error(value.error, value.stackTrace)..ignore(),
+    } else {
+      futureNotifier.setResultAndMaybeModify(
+        $Result.data(Future.error(value.error, value.stackTrace)..ignore()),
+        shouldNotify: notified,
       );
     }
   }
@@ -140,8 +143,11 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
     if (completer != null) {
       completer.complete(value.value);
       _futureCompleter = null;
-    } else if (futureNotifier.result == null || notified) {
-      futureNotifier.result = $Result.data(Future.value(value.value));
+    } else {
+      futureNotifier.setResultAndMaybeModify(
+        $Result.data(Future.value(value.value)),
+        shouldNotify: notified,
+      );
     }
   }
 

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -469,8 +469,8 @@ abstract class ProviderElement<StateT, ValueT> {
       );
 
       _notifyListeners(
-        nextResult,
-        previousResult,
+        next: nextResult,
+        previous: previousResult,
         updateShouldNotifyResult: updateShouldNotify,
       );
 
@@ -581,8 +581,8 @@ depending on itself.
       if (kDebugMode) _debugCurrentlyBuildingElement = null;
 
       _notifyListeners(
-        resultForValue(value)!,
-        resultForValue(initialState),
+        next: resultForValue(value)!,
+        previous: resultForValue(initialState),
         isFirstBuild: true,
         updateShouldNotifyResult: null,
       );
@@ -644,8 +644,8 @@ depending on itself.
         final valueResult = resultForValue(value);
         final previousValueResult = resultForValue(previousValue);
         _notifyListeners(
-          valueResult!,
-          previousValueResult,
+          next: valueResult!,
+          previous: previousValueResult,
           updateShouldNotifyResult: _callUpdateShouldNotifyFromResults(
             previous: previousValueResult,
             next: valueResult,
@@ -837,18 +837,18 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     );
   }
 
-  void _notifyListeners(
-    $Result<StateT> newState,
-    $Result<StateT>? previousStateResult, {
+  void _notifyListeners({
+    required $Result<StateT> next,
+    required $Result<StateT>? previous,
     bool isFirstBuild = false,
     required bool? updateShouldNotifyResult,
   }) {
     if (kDebugMode && !isFirstBuild) _debugAssertNotificationAllowed();
 
-    final previousState = previousStateResult?.value;
+    final previousState = previous?.value;
 
     // listenSelf listeners do not respect updateShouldNotify
-    switch (newState) {
+    switch (next) {
       case final $ResultData<StateT> newState:
         final onChangeSelfListeners = ref?._onChangeSelfListeners;
         if (onChangeSelfListeners != null) {
@@ -876,7 +876,7 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     if (updateShouldNotifyResult != null && !updateShouldNotifyResult) return;
 
     final listeners = [...weakDependents, if (!isFirstBuild) ...?dependents];
-    switch (newState) {
+    switch (next) {
       case final $ResultData<StateT> newState:
         for (var i = 0; i < listeners.length; i++) {
           final listener = listeners[i];
@@ -907,25 +907,25 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
           container.runBinaryGuarded(
             observer.didAddProvider,
             _currentObserverContext(),
-            newState.value,
+            next.value,
           );
         } else {
           container.runTernaryGuarded(
             observer.didUpdateProvider,
             _currentObserverContext(),
             previousState,
-            newState.value,
+            next.value,
           );
         }
       }
 
       for (final observer in container.observers) {
-        if (newState is $ResultError<StateT>) {
+        if (next is $ResultError<StateT>) {
           container.runTernaryGuarded(
             observer.providerDidFail,
             _currentObserverContext(),
-            newState.error,
-            newState.stackTrace,
+            next.error,
+            next.stackTrace,
           );
         }
       }

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -76,7 +76,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
   @internal
   void onLoading(AsyncLoading<ValueT> value, {bool seamless = false}) {
     final notified = asyncTransition(value, seamless: seamless);
-    if (_futureCompleter == null && (futureNotifier.result == null)) {
+    if (_futureCompleter == null) {
       final completer = _futureCompleter = Completer();
       futureNotifier.setResultAndMaybeModify(
         $ResultData(completer.future),
@@ -463,20 +463,21 @@ abstract class ProviderElement<StateT, ValueT> {
     if (_didBuild) {
       final previousResult = resultForValue(previous);
       final nextResult = resultForValue(next);
-
-      return _notifyListeners(
-        nextResult!,
+      final updateShouldNotify = _callUpdateShouldNotifyFromResults(
         previousResult,
-        updateShouldNotifyResult: _callUpdateShouldNotifyFromResults(
-          previousResult,
-          nextResult,
-        ),
+        nextResult!,
       );
+
+      _notifyListeners(
+        nextResult,
+        previousResult,
+        updateShouldNotifyResult: updateShouldNotify,
+      );
+
+      return updateShouldNotify;
     }
 
-    // First build always count as notification, so that .future & co can
-    // properly initialize.
-    return true;
+    return false;
   }
 
   set value(AsyncValue<ValueT> value) {
@@ -836,7 +837,7 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     );
   }
 
-  bool _notifyListeners(
+  void _notifyListeners(
     $Result<StateT> newState,
     $Result<StateT>? previousStateResult, {
     bool isFirstBuild = false,
@@ -872,9 +873,7 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
         }
     }
 
-    if (updateShouldNotifyResult != null && !updateShouldNotifyResult) {
-      return false;
-    }
+    if (updateShouldNotifyResult != null && !updateShouldNotifyResult) return;
 
     final listeners = [...weakDependents, if (!isFirstBuild) ...?dependents];
     switch (newState) {
@@ -931,8 +930,6 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
         }
       }
     }
-
-    return true;
   }
 
   void _markDependencyMayHaveChanged() {

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -55,17 +55,15 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
   /// [seamless] controls how the previous state is preserved:
   /// - seamless:true => import previous state and skip loading
   /// - seamless:false => import previous state and prefer loading
-  void asyncTransition(AsyncValue<ValueT> newState, {required bool seamless}) {
+  bool asyncTransition(AsyncValue<ValueT> newState, {required bool seamless}) {
     final previous = value;
 
     if (newState._isMultiState) {
-      super.value = newState;
-      return;
+      return super.setValue(newState);
     }
 
-    super.value = newState.cast<ValueT>().copyWithPrevious(
-      previous,
-      isRefresh: seamless,
+    return super.setValue(
+      newState.cast<ValueT>().copyWithPrevious(previous, isRefresh: seamless),
     );
   }
 
@@ -77,8 +75,9 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
 
   @internal
   void onLoading(AsyncLoading<ValueT> value, {bool seamless = false}) {
-    asyncTransition(value, seamless: seamless);
-    if (_futureCompleter == null) {
+    final notified = asyncTransition(value, seamless: seamless);
+    if (_futureCompleter == null &&
+        (futureNotifier.result == null || notified)) {
       final completer = _futureCompleter = Completer();
       futureNotifier.result = $ResultData(completer.future);
     }
@@ -101,7 +100,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
   /// has yet to complete.
   @internal
   void onError(AsyncError<ValueT> value, {bool seamless = false}) {
-    asyncTransition(value, seamless: seamless);
+    final notified = asyncTransition(value, seamless: seamless);
 
     final result = resultForValue(value);
     if (result is! $ResultError<StateT> && !origin._isSynthetic) {
@@ -122,7 +121,7 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
         ..future.ignore()
         ..completeError(value.error, value.stackTrace);
       _futureCompleter = null;
-    } else {
+    } else if (futureNotifier.result == null || notified) {
       futureNotifier.result = $Result.data(
         Future.error(value.error, value.stackTrace)..ignore(),
       );
@@ -135,13 +134,13 @@ mixin ElementWithFuture<StateT, ValueT> on ProviderElement<StateT, ValueT> {
   /// has yet to complete.
   @internal
   void onData(AsyncData<ValueT> value, {bool seamless = false}) {
-    asyncTransition(value, seamless: seamless);
+    final notified = asyncTransition(value, seamless: seamless);
 
     final completer = _futureCompleter;
     if (completer != null) {
       completer.complete(value.value);
       _futureCompleter = null;
-    } else {
+    } else if (futureNotifier.result == null || notified) {
       futureNotifier.result = $Result.data(Future.value(value.value));
     }
   }
@@ -449,15 +448,33 @@ abstract class ProviderElement<StateT, ValueT> {
   /* STATE */
   var _value = AsyncValue<ValueT>.loading();
   AsyncValue<ValueT> get value => _value;
-  set value(AsyncValue<ValueT> value) {
+  bool setValue(AsyncValue<ValueT> value) {
     if (kDebugMode) _debugDidSetState = true;
 
-    final previousResult = this.value;
-    final result = _value = value;
+    final previous = this.value;
+    final next = _value = value;
 
     if (_didBuild) {
-      _notifyListeners(result, previousResult);
+      final previousResult = resultForValue(previous);
+      final nextResult = resultForValue(next);
+
+      return _notifyListeners(
+        nextResult!,
+        previousResult,
+        updateShouldNotifyResult: _callUpdateShouldNotifyFromResults(
+          previousResult,
+          nextResult,
+        ),
+      );
     }
+
+    // First build always count as notification, so that .future & co can
+    // properly initialize.
+    return true;
+  }
+
+  set value(AsyncValue<ValueT> value) {
+    setValue(value);
   }
 
   $Result<StateT>? stateResult() => resultForValue(value);
@@ -494,6 +511,24 @@ depending on itself.
     }
 
     return state;
+  }
+
+  bool _callUpdateShouldNotifyFromResults(
+    $Result<StateT>? previousState,
+    $Result<StateT> newState,
+  ) {
+    if (previousState == null) return true;
+
+    switch ((previousState, newState)) {
+      case (
+        $ResultData(value: final previousValue),
+        $ResultData(value: final newValue),
+      ):
+        return updateShouldNotify(previousValue, newValue);
+      case ($ResultError(), _):
+      case ($ResultData<StateT>(), $ResultError<StateT>()):
+        return true;
+    }
   }
 
   /// Called when a provider is rebuilt. Used for providers to not notify their
@@ -539,10 +574,10 @@ depending on itself.
       if (kDebugMode) _debugCurrentlyBuildingElement = null;
 
       _notifyListeners(
-        value,
-        initialState,
+        resultForValue(value)!,
+        resultForValue(initialState),
         isFirstBuild: true,
-        checkUpdateShouldNotify: false,
+        updateShouldNotifyResult: null,
       );
     } finally {
       if (kDebugMode) {
@@ -599,7 +634,16 @@ depending on itself.
           _debugCurrentlyBuildingElement = null;
         }
 
-        _notifyListeners(value, previousValue);
+        final valueResult = resultForValue(value);
+        final previousValueResult = resultForValue(previousValue);
+        _notifyListeners(
+          valueResult!,
+          previousValueResult,
+          updateShouldNotifyResult: _callUpdateShouldNotifyFromResults(
+            previousValueResult,
+            valueResult,
+          ),
+        );
 
         if (kDebugMode) {
           _debugSkipNotifyListenersAsserts = false;
@@ -687,7 +731,7 @@ depending on itself.
     } catch (err, stack) {
       if (kDebugMode) _debugDidSetState = true;
 
-      value = triggerRetry(err, stack);
+      setValue(triggerRetry(err, stack));
     } finally {
       _insideBuildFrame = false;
       _didBuild = true;
@@ -786,17 +830,13 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     );
   }
 
-  void _notifyListeners(
-    AsyncValue<ValueT> newStateValue,
-    AsyncValue<ValueT>? previousStateValue, {
-    bool checkUpdateShouldNotify = true,
+  bool _notifyListeners(
+    $Result<StateT> newState,
+    $Result<StateT>? previousStateResult, {
     bool isFirstBuild = false,
+    required bool? updateShouldNotifyResult,
   }) {
     if (kDebugMode && !isFirstBuild) _debugAssertNotificationAllowed();
-
-    final newState = resultForValue(newStateValue)!;
-    final previousStateResult =
-        previousStateValue != null ? resultForValue(previousStateValue) : null;
 
     final previousState = previousStateResult?.value;
 
@@ -826,15 +866,8 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
         }
     }
 
-    if (checkUpdateShouldNotify) {
-      switch ((previousStateResult, newState)) {
-        case ((null, _)):
-        case (($ResultError(), _)):
-        case ((_, $ResultError())):
-          break;
-        case (($ResultData() && final prev, $ResultData() && final next)):
-          if (!updateShouldNotify(prev.value, next.value)) return;
-      }
+    if (updateShouldNotifyResult != null && !updateShouldNotifyResult) {
+      return false;
     }
 
     final listeners = [...weakDependents, if (!isFirstBuild) ...?dependents];
@@ -892,6 +925,8 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
         }
       }
     }
+
+    return true;
   }
 
   void _markDependencyMayHaveChanged() {
@@ -1373,5 +1408,5 @@ mixin SyncProviderElement<ValueT> on ProviderElement<ValueT, ValueT> {
   }
 
   @override
-  void setValueFromState(ValueT state) => value = AsyncData(state);
+  void setValueFromState(ValueT state) => setValue(AsyncData(state));
 }

--- a/packages/riverpod/lib/src/core/mutations.dart
+++ b/packages/riverpod/lib/src/core/mutations.dart
@@ -126,12 +126,14 @@ class _MutationElement<StateT>
       final prevState = value;
       if (prevState.value?.state == state) return;
 
-      value = AsyncData(
-        _MutationNotifier(
-          state,
-          setState,
-          (ref) => activeRef = ref,
-          () => activeRef,
+      setValue(
+        AsyncData(
+          _MutationNotifier(
+            state,
+            setState,
+            (ref) => activeRef = ref,
+            () => activeRef,
+          ),
         ),
       );
       switch (state) {

--- a/packages/riverpod/lib/src/core/override_with_value.dart
+++ b/packages/riverpod/lib/src/core/override_with_value.dart
@@ -120,7 +120,7 @@ class _SyncValueProviderElement<ValueT>
 
   @override
   void _setValue(ValueT value) {
-    this.value = AsyncData(value);
+    setValue(AsyncData(value));
   }
 }
 

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -127,7 +127,7 @@ abstract class AnyNotifier<StateT, ValueT> {
   ///
   /// You can override this method to provide a custom comparison logic,
   /// such as using [identical] to use a more efficient comparison.
-  /// 
+  ///
   /// **Note:**
   /// This also affects whether [AsyncNotifier.future] notifies.
   /// If [updateShouldNotify] returns false, then [AsyncNotifier.future] will not notify

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -127,6 +127,11 @@ abstract class AnyNotifier<StateT, ValueT> {
   ///
   /// You can override this method to provide a custom comparison logic,
   /// such as using [identical] to use a more efficient comparison.
+  /// 
+  /// **Note:**
+  /// This also affects whether [AsyncNotifier.future] notifies.
+  /// If [updateShouldNotify] returns false, then [AsyncNotifier.future] will not notify
+  /// when the state changes. However, the future will still resolve with the new state.
   @visibleForOverriding
   bool updateShouldNotify(StateT previous, StateT next) {
     return ProviderElement.defaultUpdateShouldNotify(previous, next);

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -415,13 +415,14 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
   void notifyListeners() {
     _throwIfInvalidUsage();
 
-    final currentValue = _element.value;
-
     if (_element._didBuild) {
+      final currentValue = _element.value;
+      final currentValueResult = _element.resultForValue(currentValue);
+
       _element._notifyListeners(
-        currentValue,
-        currentValue,
-        checkUpdateShouldNotify: false,
+        currentValueResult!,
+        currentValueResult,
+        updateShouldNotifyResult: null,
       );
     }
   }

--- a/packages/riverpod/lib/src/core/ref.dart
+++ b/packages/riverpod/lib/src/core/ref.dart
@@ -420,8 +420,8 @@ final <yourProvider> = Provider(dependencies: [<dependency>]);
       final currentValueResult = _element.resultForValue(currentValue);
 
       _element._notifyListeners(
-        currentValueResult!,
-        currentValueResult,
+        next: currentValueResult!,
+        previous: currentValueResult,
         updateShouldNotifyResult: null,
       );
     }

--- a/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_notifier_provider.dart
@@ -170,7 +170,7 @@ class _StateNotifierProviderElement<
         _notifierNotifier.result = $Result.guard(() => provider.create(ref));
 
     _removeListener = notifier.valueOrRawException.addListener(
-      (newState) => value = AsyncData(newState),
+      (newState) => setValue(AsyncData(newState)),
       fireImmediately: true,
     );
 

--- a/packages/riverpod/lib/src/providers/legacy/state_provider.dart
+++ b/packages/riverpod/lib/src/providers/legacy/state_provider.dart
@@ -117,7 +117,7 @@ class _StateProviderElement<ValueT>
 
     _removeListener = controller.addListener(fireImmediately: true, (state) {
       _stateNotifier.result = _controllerNotifier.result;
-      value = AsyncData(state);
+      setValue(AsyncData(state));
     });
 
     return null;

--- a/packages/riverpod/lib/src/providers/notifier.dart
+++ b/packages/riverpod/lib/src/providers/notifier.dart
@@ -86,9 +86,9 @@ class $NotifierProviderElement<
 
   @override
   void handleError(Ref ref, Object error, StackTrace stackTrace) =>
-      value = AsyncError<ValueT>(error, stackTrace);
+      setValue(AsyncError<ValueT>(error, stackTrace));
 
   @override
   void handleCreate(Ref ref, ValueT Function() created) =>
-      value = AsyncData(created());
+      setValue(AsyncData(created()));
 }

--- a/packages/riverpod/lib/src/providers/provider.dart
+++ b/packages/riverpod/lib/src/providers/provider.dart
@@ -340,7 +340,7 @@ class $ProviderElement<ValueT>
 
   @override
   WhenComplete create(Ref ref) {
-    value = AsyncData(provider.create(ref));
+    setValue(AsyncData(provider.create(ref)));
 
     return null;
   }

--- a/packages/riverpod/lib/src/providers/stream_provider.dart
+++ b/packages/riverpod/lib/src/providers/stream_provider.dart
@@ -174,21 +174,21 @@ class $StreamProviderElement<ValueT>
   }
 
   @override
-  void onData(AsyncData<ValueT> value, {bool seamless = false}) {
+  bool onData(AsyncData<ValueT> value, {bool seamless = false}) {
     if (!_streamController.isClosed) {
       // The controller might be closed if onData is executed post dispose. Cf onData
       _streamController.add(value.value);
     }
-    super.onData(value, seamless: seamless);
+    return super.onData(value, seamless: seamless);
   }
 
   @override
-  void onError(AsyncError<ValueT> value, {bool seamless = false}) {
+  bool onError(AsyncError<ValueT> value, {bool seamless = false}) {
     if (!_streamController.isClosed) {
       // The controller might be closed if onError is executed post dispose. Cf onError
       _streamController.addError(value.error, value.stackTrace);
     }
-    super.onError(value, seamless: seamless);
+    return super.onError(value, seamless: seamless);
   }
 }
 

--- a/packages/riverpod/test/src/providers/async_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/async_notifier_test.dart
@@ -1016,16 +1016,32 @@ void main() {
 
     group('AsyncNotifier.future', () {
       test('does not notify when updateShouldNotify returns false', () async {
-        final notifier = factory.deferredNotifier<int>((ref, _) => 0);
-        final provider = factory.provider<int>(() => notifier);
+        final provider = factory.deferredProvider<int>(
+          (ref, _) => 0,
+          updateShouldNotify: (a, b) => false,
+        );
         final container = ProviderContainer.test();
         final listener = Listener<Future<int>>();
+        final notifier = container.read(provider.notifier);
 
         container.listen(provider.future, listener.call);
 
-        notifier.state = AsyncData(0);
+        notifier.state = AsyncData(42);
+        expect(
+          container.read(provider.future),
+          completion(42),
+          reason:
+              'Even though no notification happened, the state is still updated',
+        );
+
+        notifier.state = AsyncError(42, StackTrace.empty);
+        expect(container.read(provider.future), throwsA(42));
 
         verifyZeroInteractions(listener);
+
+        // Loading notifies anyway
+        notifier.state = AsyncLoading();
+        verifyOnly(listener, listener(any, any));
       });
 
       test('can be used inside Notifier.build', () async {

--- a/packages/riverpod/test/src/providers/async_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/async_notifier_test.dart
@@ -1015,6 +1015,19 @@ void main() {
     });
 
     group('AsyncNotifier.future', () {
+      test('does not notify when updateShouldNotify returns false', () async {
+        final notifier = factory.deferredNotifier<int>((ref, _) => 0);
+        final provider = factory.provider<int>(() => notifier);
+        final container = ProviderContainer.test();
+        final listener = Listener<Future<int>>();
+
+        container.listen(provider.future, listener.call);
+
+        notifier.state = AsyncData(0);
+
+        verifyZeroInteractions(listener);
+      });
+
       test('can be used inside Notifier.build', () async {
         final provider = factory.simpleTestProvider<int>((ref, self) {
           return self.future;

--- a/packages/riverpod/test/src/providers/async_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/async_notifier_test.dart
@@ -1037,11 +1037,9 @@ void main() {
         notifier.state = AsyncError(42, StackTrace.empty);
         expect(container.read(provider.future), throwsA(42));
 
-        verifyZeroInteractions(listener);
-
-        // Loading notifies anyway
         notifier.state = AsyncLoading();
-        verifyOnly(listener, listener(any, any));
+
+        verifyZeroInteractions(listener);
       });
 
       test('can be used inside Notifier.build', () async {


### PR DESCRIPTION
fixes #4755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `.future` no longer notifies listeners when the underlying async value hasn’t changed; notification behavior across providers has been refined to prevent spurious updates.
* **Documentation**
  * Changelogs updated across packages to document the fix and recent provider/container improvements.
* **Tests**
  * New test added to verify `provider.future` does not emit notifications when updates should be suppressed while still resolving/rejecting correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->