### PR TITLE
Fix stale ProviderScope dispose task

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased build
 
 - Fixes assertion error when providers are unpaused.
+- Fixes assertion error when invalidating a provider after an autoDispose
+  provider schedules disposal. (thanks to @a1573595)
 
 ## 3.3.2-dev.2 - 2026-05-06
 ### Dependency changes
@@ -1559,4 +1561,3 @@ The behavior is the same. Only the syntax changed.
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-

--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -356,6 +356,7 @@ final class _UncontrolledProviderScopeState
     return () {
       canceled = true;
       if (identical(_task, task)) {
+        _task = null;
         _cancelAsyncTask = null;
       }
     };

--- a/packages/flutter_riverpod/test/provider_scope_test.dart
+++ b/packages/flutter_riverpod/test/provider_scope_test.dart
@@ -2,8 +2,53 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+final _issue4766Provider =
+    NotifierProvider.autoDispose<_Issue4766Notifier, int>(
+      _Issue4766Notifier.new,
+    );
+
+final _issue4766OtherProvider =
+    NotifierProvider.autoDispose<_Issue4766OtherNotifier, int>(
+      _Issue4766OtherNotifier.new,
+    );
+
+class _Issue4766Notifier extends Notifier<int> {
+  @override
+  int build() => 1;
+
+  void doSomething() {
+    ref.read(_issue4766OtherProvider);
+  }
+}
+
+class _Issue4766OtherNotifier extends Notifier<int> {
+  @override
+  int build() => 2;
+}
+
 void main() {
   group('ProviderScope', () {
+    testWidgets(
+      'reading an autoDispose notifier then invalidating a watched provider does not assert',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            child: Consumer(
+              builder: (context, ref, child) {
+                ref.watch(_issue4766OtherProvider);
+                return const Placeholder();
+              },
+            ),
+          ),
+        );
+
+        final container = tester.container();
+
+        container.read(_issue4766Provider.notifier).doSomething();
+        container.invalidate(_issue4766OtherProvider);
+      },
+    );
+
     testWidgets(
       'If ProviderScope does not rebuild after a few frames, flush the scheduler',
       (tester) async {

--- a/packages/flutter_riverpod/test/provider_scope_test.dart
+++ b/packages/flutter_riverpod/test/provider_scope_test.dart
@@ -2,35 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-final _issue4766Provider =
-    NotifierProvider.autoDispose<_Issue4766Notifier, int>(
-      _Issue4766Notifier.new,
-    );
-
-final _issue4766OtherProvider =
-    NotifierProvider.autoDispose<_Issue4766OtherNotifier, int>(
-      _Issue4766OtherNotifier.new,
-    );
-
-class _Issue4766Notifier extends Notifier<int> {
-  @override
-  int build() => 1;
-
-  void doSomething() {
-    ref.read(_issue4766OtherProvider);
-  }
-}
-
-class _Issue4766OtherNotifier extends Notifier<int> {
-  @override
-  int build() => 2;
-}
+import 'src/core/provider_subscription_test.dart';
 
 void main() {
   group('ProviderScope', () {
     testWidgets(
       'reading an autoDispose notifier then invalidating a watched provider does not assert',
       (tester) async {
+        final _issue4766Provider = NotifierProvider.autoDispose(
+          () => DeferredNotifier((ref, self) => 1),
+        );
+
+        final _issue4766OtherProvider = NotifierProvider.autoDispose(
+          () => DeferredNotifier((ref, self) => 2),
+        );
+
         await tester.pumpWidget(
           ProviderScope(
             child: Consumer(
@@ -44,7 +30,10 @@ void main() {
 
         final container = tester.container();
 
-        container.read(_issue4766Provider.notifier).doSomething();
+        container
+            .read(_issue4766Provider.notifier)
+            .ref
+            .read(_issue4766OtherProvider);
         container.invalidate(_issue4766OtherProvider);
       },
     );

--- a/packages/flutter_riverpod/test/src/core/provider_subscription_test.dart
+++ b/packages/flutter_riverpod/test/src/core/provider_subscription_test.dart
@@ -43,6 +43,9 @@ class DeferredNotifier<StateT> extends Notifier<StateT> {
   final StateT Function(Ref ref, DeferredNotifier<StateT> self) _build;
 
   @override
+  Ref get ref;
+
+  @override
   StateT build() {
     return _build(ref, this);
   }

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased build
 
 - Fixes assertion error when providers are unpaused.
+- Fixes assertion error when invalidating a provider after an autoDispose
+  provider schedules disposal. (thanks to @a1573595)
 
 ## 3.3.2-dev.2 - 2026-05-06
 ### Dependency changes
@@ -1760,4 +1762,3 @@ The behavior is the same. Only the syntax changed.
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-


### PR DESCRIPTION
## Related Issues

fixes #4766

This PR fixes a `ProviderScope` scheduling assertion caused by a canceled autoDispose dispose task remaining stored in `_task`.

When the scheduler upgrades a pending dispose task into a refresh task, `scheduleDispose` cancels the async disposal but previously left the canceled task in `_task`. The next `scheduleRefresh` then sees the stale unfinished task and throws `Only one task can be scheduled at a time`.

The fix clears `_task` when canceling the matching pending dispose task, allowing the refresh task to be scheduled normally. A regression test covers the minimal reproduction from the issue.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assertion errors when invalidating a provider after an autoDispose provider has scheduled disposal.
  * Fixed assertion errors when resuming paused providers.

* **Tests**
  * Added a regression test covering interaction between two auto-dispose notifier-backed providers to prevent the assertion.

* **Documentation**
  * Updated changelogs to document the fixes above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->