### PR TITLE
Fix ProviderScope refresh during widget build

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Fixes assertion error when providers are unpaused.
 - Fixes assertion error when invalidating a provider after an autoDispose
   provider schedules disposal. (thanks to @a1573595)
+- Fixes assertion error when resuming a widget subscription after an async
+  provider emits while unlistened. (thanks to @a1573595)
 
 ## 3.3.2-dev.2 - 2026-05-06
 ### Dependency changes

--- a/packages/flutter_riverpod/lib/src/core.dart
+++ b/packages/flutter_riverpod/lib/src/core.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart' hide describeIdentity;
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart' as flutter_test;
 import 'package:meta/meta.dart';
 

--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -315,9 +315,23 @@ final class _UncontrolledProviderScopeState
     _cancelAsyncTask?.call();
     _cancelAsyncTask = null;
 
-    setState(() {
-      _task = task;
-    });
+    _task = task;
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      assert(() {
+        try {
+          setState(() {});
+          // Flutter throws when the scope cannot be marked dirty during the
+          // current build. In that case, the timer below will defer the refresh.
+          // ignore: avoid_catching_errors
+        } on FlutterError {
+          // Defer to the timer below.
+        }
+        return true;
+      }(), 'ProviderScope refresh scheduling should not fail');
+    } else {
+      setState(() {});
+    }
 
     _vsyncTimer?.cancel();
     _vsyncTimer = Timer(Duration.zero, () {

--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -324,7 +324,12 @@ final class _UncontrolledProviderScopeState
           // Flutter throws when the scope cannot be marked dirty during the
           // current build. In that case, the timer below will defer the refresh.
           // ignore: avoid_catching_errors
-        } on FlutterError {
+        } on FlutterError catch (err) {
+          final summary = err.diagnostics.first.toDescription();
+          if (summary !=
+              'setState() or markNeedsBuild() called during build.') {
+            rethrow;
+          }
           // Defer to the timer below.
         }
       }

--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -318,7 +318,7 @@ final class _UncontrolledProviderScopeState
     _task = task;
     if (SchedulerBinding.instance.schedulerPhase ==
         SchedulerPhase.persistentCallbacks) {
-      assert(() {
+      if (kDebugMode) {
         try {
           setState(() {});
           // Flutter throws when the scope cannot be marked dirty during the
@@ -327,8 +327,7 @@ final class _UncontrolledProviderScopeState
         } on FlutterError {
           // Defer to the timer below.
         }
-        return true;
-      }(), 'ProviderScope refresh scheduling should not fail');
+      }
     } else {
       setState(() {});
     }
@@ -377,11 +376,13 @@ final class _UncontrolledProviderScopeState
   }
 
   void _debugCanModifyProviders() {
+    // coverage:ignore-start
     if (!kDebugMode) {
       throw StateError(
         'debugCanModifyProviders should not be called outside of debug mode',
       );
     }
+    // coverage:ignore-end
     try {
       setState(() {});
     } catch (err) {

--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -309,6 +309,24 @@ final class _UncontrolledProviderScopeState
     assert(mounted, 'Cannot schedule a task on an unmounted element');
   }
 
+  bool _debugCanMarkNeedsBuild() {
+    if (!kDebugMode) return true;
+    if (SchedulerBinding.instance.schedulerPhase !=
+        SchedulerPhase.persistentCallbacks) {
+      return true;
+    }
+    if (context.owner?.debugBuilding != true) return true;
+    if (context.debugDoingBuild) return true;
+
+    var ancestorIsBuilding = false;
+    context.visitAncestorElements((element) {
+      ancestorIsBuilding = element.debugDoingBuild;
+      return !ancestorIsBuilding;
+    });
+
+    return ancestorIsBuilding;
+  }
+
   @override
   void Function()? scheduleRefresh(Task task) {
     _debugAssertCanScheduleTask(task);
@@ -316,24 +334,7 @@ final class _UncontrolledProviderScopeState
     _cancelAsyncTask = null;
 
     _task = task;
-    if (SchedulerBinding.instance.schedulerPhase ==
-        SchedulerPhase.persistentCallbacks) {
-      if (kDebugMode) {
-        try {
-          setState(() {});
-          // Flutter throws when the scope cannot be marked dirty during the
-          // current build. In that case, the timer below will defer the refresh.
-          // ignore: avoid_catching_errors
-        } on FlutterError catch (err) {
-          final summary = err.diagnostics.first.toDescription();
-          if (summary !=
-              'setState() or markNeedsBuild() called during build.') {
-            rethrow;
-          }
-          // Defer to the timer below.
-        }
-      }
-    } else {
+    if (_debugCanMarkNeedsBuild()) {
       setState(() {});
     }
 

--- a/packages/flutter_riverpod/test/framework_test.dart
+++ b/packages/flutter_riverpod/test/framework_test.dart
@@ -750,16 +750,18 @@ void main() {
 
     expect(find.text('1'), findsOneWidget);
 
-    key.currentState!.pushReplacement<void, void>(
-      PageRouteBuilder<void>(
-        pageBuilder: (_, _, _) {
-          return Consumer(
-            builder: (context, ref, _) {
-              final count = ref.watch(counterProvider);
-              return Text('new $count');
-            },
-          );
-        },
+    unawaited(
+      key.currentState!.pushReplacement<void, void>(
+        PageRouteBuilder<void>(
+          pageBuilder: (_, _, _) {
+            return Consumer(
+              builder: (context, ref, _) {
+                final count = ref.watch(counterProvider);
+                return Text('new $count');
+              },
+            );
+          },
+        ),
       ),
     );
 

--- a/packages/flutter_riverpod/test/framework_test.dart
+++ b/packages/flutter_riverpod/test/framework_test.dart
@@ -750,18 +750,16 @@ void main() {
 
     expect(find.text('1'), findsOneWidget);
 
-    unawaited(
-      key.currentState!.pushReplacement<void, void>(
-        PageRouteBuilder<void>(
-          pageBuilder: (_, _, _) {
-            return Consumer(
-              builder: (context, ref, _) {
-                final count = ref.watch(counterProvider);
-                return Text('new $count');
-              },
-            );
-          },
-        ),
+    final pendingRoute = key.currentState!.pushReplacement<void, void>(
+      PageRouteBuilder<void>(
+        pageBuilder: (_, _, _) {
+          return Consumer(
+            builder: (context, ref, _) {
+              final count = ref.watch(counterProvider);
+              return Text('new $count');
+            },
+          );
+        },
       ),
     );
 

--- a/packages/flutter_riverpod/test/src/core/consumer_test.dart
+++ b/packages/flutter_riverpod/test/src/core/consumer_test.dart
@@ -12,7 +12,89 @@ import 'package:riverpod/src/internals.dart'
 
 import 'provider_subscription_test.dart';
 
+final _issue4765ProviderA = Provider<int>((ref) {
+  return ref.watch(_issue4765ProviderB);
+});
+
+final _issue4765ProviderB = Provider<int>((ref) {
+  return ref.watch(_issue4765ProviderC).value ?? 0;
+});
+
+final _issue4765ProviderC = AsyncNotifierProvider<_Issue4765Notifier, int>(
+  _Issue4765Notifier.new,
+);
+
+late StreamController<int> _issue4765Stream;
+
+class _Issue4765Notifier extends AsyncNotifier<int> {
+  @override
+  Future<int> build() {
+    final subscription = _issue4765Stream.stream.listen((value) {
+      state = AsyncData(value);
+    });
+
+    ref.onDispose(subscription.cancel);
+
+    return _issue4765Stream.stream.first;
+  }
+}
+
+class _Issue4765Widget extends ConsumerStatefulWidget {
+  const _Issue4765Widget();
+
+  @override
+  ConsumerState<_Issue4765Widget> createState() => _Issue4765WidgetState();
+}
+
+class _Issue4765WidgetState extends ConsumerState<_Issue4765Widget> {
+  var _show = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      textDirection: TextDirection.ltr,
+      children: [
+        OutlinedButton(
+          onPressed: () => setState(() => _show = !_show),
+          child: const Text('press'),
+        ),
+        if (_show) Text('${ref.watch(_issue4765ProviderA)}'),
+      ],
+    );
+  }
+}
+
 void main() {
+  testWidgets(
+    'resuming provider chain after missed async notifier event does not assert',
+    (tester) async {
+      // Regression test for https://github.com/rrousselGit/riverpod/issues/4765
+      _issue4765Stream = StreamController<int>.broadcast(sync: true);
+      addTearDown(_issue4765Stream.close);
+
+      await tester.pumpWidget(
+        const ProviderScope(child: MaterialApp(home: _Issue4765Widget())),
+      );
+
+      await tester.tap(find.text('press'));
+      await tester.pump();
+      _issue4765Stream.add(1);
+      await tester.pump();
+
+      expect(find.text('1'), findsOneWidget);
+
+      await tester.tap(find.text('press'));
+      await tester.pump();
+      _issue4765Stream.add(2);
+
+      await tester.tap(find.text('press'));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('2'), findsOneWidget);
+    },
+  );
+
   testWidgets('TickerMode + mutation triggers assertion', (tester) async {
     // Regression test for https://github.com/rrousselGit/riverpod/issues/4709
     final container = ProviderContainer.test();
@@ -113,7 +195,7 @@ void main() {
         ),
       );
 
-      navigator.pushNamed('/detail');
+      unawaited(navigator.pushNamed('/detail'));
       await tester.pump();
 
       expect(

--- a/packages/flutter_riverpod/test/src/core/consumer_test.dart
+++ b/packages/flutter_riverpod/test/src/core/consumer_test.dart
@@ -69,7 +69,7 @@ void main() {
     'resuming provider chain after missed async notifier event does not assert',
     (tester) async {
       // Regression test for https://github.com/rrousselGit/riverpod/issues/4765
-      _issue4765Stream = StreamController<int>.broadcast(sync: true);
+      _issue4765Stream = StreamController<int>.broadcast();
       addTearDown(_issue4765Stream.close);
 
       await tester.pumpWidget(

--- a/packages/flutter_riverpod/test/src/core/consumer_test.dart
+++ b/packages/flutter_riverpod/test/src/core/consumer_test.dart
@@ -195,7 +195,7 @@ void main() {
         ),
       );
 
-      unawaited(navigator.pushNamed('/detail'));
+      final pendingRoute = navigator.pushNamed('/detail');
       await tester.pump();
 
       expect(

--- a/packages/flutter_riverpod/test/src/core/provider_subscription_test.dart
+++ b/packages/flutter_riverpod/test/src/core/provider_subscription_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -25,12 +27,12 @@ void main() {
     final container = tester.container();
     final navigator = tester.state<NavigatorState>(find.byType(Navigator));
 
-    navigator.pushNamed('/settings');
+    unawaited(navigator.pushNamed('/settings'));
     await tester.pumpAndSettle();
 
     container.read(dep.notifier).state++;
 
-    navigator.maybePop();
+    unawaited(navigator.maybePop());
     await tester.pumpAndSettle();
 
     expect(find.text('1'), findsOneWidget);

--- a/packages/flutter_riverpod/test/src/core/provider_subscription_test.dart
+++ b/packages/flutter_riverpod/test/src/core/provider_subscription_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -27,12 +25,12 @@ void main() {
     final container = tester.container();
     final navigator = tester.state<NavigatorState>(find.byType(Navigator));
 
-    unawaited(navigator.pushNamed('/settings'));
+    final pendingPush = navigator.pushNamed('/settings');
     await tester.pumpAndSettle();
 
     container.read(dep.notifier).state++;
 
-    unawaited(navigator.maybePop());
+    final pendingPop = navigator.maybePop();
     await tester.pumpAndSettle();
 
     expect(find.text('1'), findsOneWidget);

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Fixes assertion error when providers are unpaused.
 - Fixes assertion error when invalidating a provider after an autoDispose
   provider schedules disposal. (thanks to @a1573595)
+- Fixes assertion error when resuming a widget subscription after an async
+  provider emits while unlistened. (thanks to @a1573595)
 
 ## 3.3.2-dev.2 - 2026-05-06
 ### Dependency changes


### PR DESCRIPTION
## Related Issues

fixes #4765

This fixes a Flutter lifecycle assertion when a paused provider chain resumes after missing an async notifier update.

Problem:
- A hidden/unlistened provider chain can miss an async update while paused.
- When the widget listens again, Riverpod replays the missed event during rebuild.
- That replay can schedule a ProviderScope refresh while Flutter is already building a descendant widget, triggering `setState() or markNeedsBuild() called during build`.

Fix:
- Avoid swallowing Flutter errors in `ProviderScope.scheduleRefresh`.
- Before synchronously marking `ProviderScope` dirty, check whether Flutter currently allows it during the build phase.
- If it cannot be marked dirty safely, keep the scheduled task and let the existing timer-based refresh path run after the current build/frame.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an assertion when resuming widget subscriptions after async providers emitted while unlistened, preventing exceptions during provider resume/unpause.

* **Tests**
  * Added regression and integration tests validating provider resume/unpause behavior and UI updates after missed async emissions.

* **Documentation**
  * Updated changelogs to note the fix and adjusted trailing content markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->