### PR TITLE
Fix async notifier dependency disposal during rebuild

### DIFF
--- a/examples/counter/lib/main.g.dart
+++ b/examples/counter/lib/main.g.dart
@@ -63,7 +63,7 @@ abstract class _$Counter extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -73,6 +73,6 @@ abstract class _$Counter extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/examples/pub/lib/detail.g.dart
+++ b/examples/pub/lib/detail.g.dart
@@ -270,7 +270,7 @@ abstract class _$PackageMetrics extends $AsyncNotifier<PackageMetricsScore> {
   FutureOr<PackageMetricsScore> build({required String packageName});
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<AsyncValue<PackageMetricsScore>, PackageMetricsScore>;
     final element =
@@ -281,6 +281,6 @@ abstract class _$PackageMetrics extends $AsyncNotifier<PackageMetricsScore> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(packageName: _$args));
+    return element.handleCreate(ref, () => build(packageName: _$args));
   }
 }

--- a/other_projects/devtool_debug_app/lib/main.g.dart
+++ b/other_projects/devtool_debug_app/lib/main.g.dart
@@ -63,7 +63,7 @@ abstract class _$Counter extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -73,6 +73,6 @@ abstract class _$Counter extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased fix
+
+- Fix `AsyncNotifierProvider`/`StreamNotifierProvider` disposing dependencies
+  watched after an asynchronous gap during rebuild. (thanks to @a1573595)
+
 ## Unreleased build
 
 - Fixes assertion error when providers are unpaused.

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,11 +1,8 @@
-## Unreleased fix
-
-- Fix `AsyncNotifierProvider`/`StreamNotifierProvider` disposing dependencies
-  watched after an asynchronous gap during rebuild. (thanks to @a1573595)
-
 ## Unreleased build
 
 - Fixes assertion error when providers are unpaused.
+- Fix `AsyncNotifierProvider`/`StreamNotifierProvider` disposing dependencies
+  watched after an asynchronous gap during rebuild. (thanks to @a1573595)
 
 ## 3.3.2-dev.2 - 2026-05-06
 

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -32,6 +32,7 @@ void Function()? debugCanModifyProviders;
 
 /// A Future-like that support synchronous completion.
 @internal
+@publicInCodegen
 typedef WhenComplete = void Function(void Function() cb)?;
 
 /// Mixin to help implement logic for listening to [Future]s/[Stream]s and setup

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -159,7 +159,7 @@ abstract class AnyNotifier<StateT, ValueT> {
   /// The benefit of this method is that it applies on all notifiers,
   /// regardless of whether they use arguments or not.
   @mustCallSuper
-  void runBuild();
+  WhenComplete runBuild();
 
   void _debugAssertNoDuplicateKey(
     Object? key,
@@ -566,7 +566,7 @@ abstract class $ClassProviderElement<
                 () => override(ref, result.value),
               );
             case null:
-              result.value.runBuild();
+              whenComplete = result.value.runBuild();
           }
         } catch (err, stack) {
           handleError(ref, err, stack);

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -537,6 +537,7 @@ abstract class $ClassProviderElement<
   RunNotifierBuild<NotifierT, CreatedT>? _runNotifierBuildOverride;
 
   final classListenable = $Observable<NotifierT>();
+  WhenComplete _notifierBuildCompletion;
 
   @mustCallSuper
   @override
@@ -555,6 +556,7 @@ abstract class $ClassProviderElement<
           return notifier;
         });
 
+    _notifierBuildCompletion = null;
     switch (result) {
       case $ResultData():
         try {
@@ -571,10 +573,18 @@ abstract class $ClassProviderElement<
         handleError(ref, result.error, result.stackTrace);
     }
 
-    return null;
+    final completion = _notifierBuildCompletion;
+    _notifierBuildCompletion = null;
+    return completion;
   }
 
-  void handleCreate(Ref ref, CreatedT Function() created);
+  void handleCreate(Ref ref, CreatedT Function() created) {
+    _notifierBuildCompletion = runNotifierBuild(ref, created);
+  }
+
+  @protected
+  WhenComplete runNotifierBuild(Ref ref, CreatedT Function() created);
+
   void handleError(Ref ref, Object error, StackTrace stackTrace);
 
   @override

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -537,7 +537,6 @@ abstract class $ClassProviderElement<
   RunNotifierBuild<NotifierT, CreatedT>? _runNotifierBuildOverride;
 
   final classListenable = $Observable<NotifierT>();
-  WhenComplete _notifierBuildCompletion;
 
   @mustCallSuper
   @override
@@ -556,13 +555,16 @@ abstract class $ClassProviderElement<
           return notifier;
         });
 
-    _notifierBuildCompletion = null;
+    WhenComplete whenComplete;
     switch (result) {
       case $ResultData():
         try {
           switch (_runNotifierBuildOverride) {
             case final override?:
-              handleCreate(ref, () => override(ref, result.value));
+              whenComplete = handleCreate(
+                ref,
+                () => override(ref, result.value),
+              );
             case null:
               result.value.runBuild();
           }
@@ -573,17 +575,10 @@ abstract class $ClassProviderElement<
         handleError(ref, result.error, result.stackTrace);
     }
 
-    final completion = _notifierBuildCompletion;
-    _notifierBuildCompletion = null;
-    return completion;
+    return whenComplete;
   }
 
-  void handleCreate(Ref ref, CreatedT Function() created) {
-    _notifierBuildCompletion = runNotifierBuild(ref, created);
-  }
-
-  @protected
-  WhenComplete runNotifierBuild(Ref ref, CreatedT Function() created);
+  WhenComplete handleCreate(Ref ref, CreatedT Function() created);
 
   void handleError(Ref ref, Object error, StackTrace stackTrace);
 

--- a/packages/riverpod/lib/src/providers/async_notifier.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier.dart
@@ -85,7 +85,7 @@ class $AsyncNotifierProviderElement<
   $AsyncNotifierProviderElement(super.pointer);
 
   @override
-  WhenComplete runNotifierBuild(Ref ref, FutureOr<ValueT> Function() created) {
+  WhenComplete handleCreate(Ref ref, FutureOr<ValueT> Function() created) {
     return handleFuture(ref, created);
   }
 }

--- a/packages/riverpod/lib/src/providers/async_notifier.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier.dart
@@ -85,7 +85,7 @@ class $AsyncNotifierProviderElement<
   $AsyncNotifierProviderElement(super.pointer);
 
   @override
-  void handleCreate(Ref ref, FutureOr<ValueT> Function() created) {
-    handleFuture(ref, created);
+  WhenComplete runNotifierBuild(Ref ref, FutureOr<ValueT> Function() created) {
+    return handleFuture(ref, created);
   }
 }

--- a/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/async_notifier/orphan.dart
@@ -34,9 +34,7 @@ abstract class AsyncNotifier<StateT> extends $AsyncNotifier<StateT> {
 
   @mustCallSuper
   @override
-  void runBuild() {
-    requireElement().handleCreate(ref, build);
-  }
+  WhenComplete runBuild() => requireElement().handleCreate(ref, build);
 }
 
 /// {@template riverpod.async_notifier_provider}

--- a/packages/riverpod/lib/src/providers/notifier.dart
+++ b/packages/riverpod/lib/src/providers/notifier.dart
@@ -89,7 +89,7 @@ class $NotifierProviderElement<
       setValue(AsyncError<ValueT>(error, stackTrace));
 
   @override
-  WhenComplete runNotifierBuild(Ref ref, ValueT Function() created) {
+  WhenComplete handleCreate(Ref ref, ValueT Function() created) {
     setValue(AsyncData(created()));
     return null;
   }

--- a/packages/riverpod/lib/src/providers/notifier.dart
+++ b/packages/riverpod/lib/src/providers/notifier.dart
@@ -89,6 +89,8 @@ class $NotifierProviderElement<
       setValue(AsyncError<ValueT>(error, stackTrace));
 
   @override
-  void handleCreate(Ref ref, ValueT Function() created) =>
-      setValue(AsyncData(created()));
+  WhenComplete runNotifierBuild(Ref ref, ValueT Function() created) {
+    setValue(AsyncData(created()));
+    return null;
+  }
 }

--- a/packages/riverpod/lib/src/providers/notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/notifier/orphan.dart
@@ -66,9 +66,7 @@ abstract class Notifier<ValueT> extends $Notifier<ValueT> {
 
   @mustCallSuper
   @override
-  void runBuild() {
-    requireElement().handleCreate(ref, build);
-  }
+  WhenComplete runBuild() => requireElement().handleCreate(ref, build);
 }
 
 /// {@template riverpod.notifier_provider}

--- a/packages/riverpod/lib/src/providers/stream_notifier.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier.dart
@@ -81,7 +81,7 @@ class $StreamNotifierProviderElement<
   $StreamNotifierProviderElement(super.pointer);
 
   @override
-  void handleCreate(Ref ref, Stream<ValueT> Function() created) {
-    handleStream(ref, created);
+  WhenComplete runNotifierBuild(Ref ref, Stream<ValueT> Function() created) {
+    return handleStream(ref, created);
   }
 }

--- a/packages/riverpod/lib/src/providers/stream_notifier.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier.dart
@@ -81,7 +81,7 @@ class $StreamNotifierProviderElement<
   $StreamNotifierProviderElement(super.pointer);
 
   @override
-  WhenComplete runNotifierBuild(Ref ref, Stream<ValueT> Function() created) {
+  WhenComplete handleCreate(Ref ref, Stream<ValueT> Function() created) {
     return handleStream(ref, created);
   }
 }

--- a/packages/riverpod/lib/src/providers/stream_notifier/orphan.dart
+++ b/packages/riverpod/lib/src/providers/stream_notifier/orphan.dart
@@ -21,9 +21,7 @@ abstract class StreamNotifier<ValueT> extends $StreamNotifier<ValueT> {
 
   @mustCallSuper
   @override
-  void runBuild() {
-    requireElement().handleCreate(ref, build);
-  }
+  WhenComplete runBuild() => requireElement().handleCreate(ref, build);
 }
 
 /// {@template riverpod.stream_notifier_provider}

--- a/packages/riverpod/test/src/providers/async_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/async_notifier_test.dart
@@ -80,6 +80,42 @@ void main() {
       expect(sub.read().isRefreshing, true);
     });
 
+    test('keeps post-await dependencies alive during rebuild', () async {
+      final container = ProviderContainer.test();
+      var dependencyDisposeCount = 0;
+      var gate = Completer<void>();
+      addTearDown(() {
+        if (!gate.isCompleted) gate.complete();
+      });
+
+      final dependency = NotifierProvider.autoDispose<Issue4761Counter, int>(
+        () => Issue4761Counter(() => dependencyDisposeCount++),
+      );
+      final provider = factory.simpleTestProvider<int>((ref, _) async {
+        ref.keepAlive();
+        await gate.future;
+
+        return ref.watch(dependency);
+      });
+
+      final sub = container.listen(provider, (previous, next) {});
+
+      gate.complete();
+      await expectLater(container.read(provider.future), completion(0));
+      expect(sub.read(), const AsyncData<int>(0));
+
+      gate = Completer<void>();
+      container.read(dependency.notifier).increment();
+      await container.pump();
+
+      expect(dependencyDisposeCount, 0);
+
+      gate.complete();
+      await expectLater(container.read(provider.future), completion(1));
+      expect(sub.read(), const AsyncData<int>(1));
+      expect(dependencyDisposeCount, 0);
+    });
+
     test(
       'Calling state= followed by returning .future does not cause a double notification',
       () async {
@@ -1514,4 +1550,18 @@ class Equal<BoxedT> {
 class CtorNotifier extends AsyncNotifier<int> {
   @override
   FutureOr<int> build() => 0;
+}
+
+class Issue4761Counter extends Notifier<int> {
+  Issue4761Counter(this._onDispose);
+
+  final void Function() _onDispose;
+
+  @override
+  int build() {
+    ref.onDispose(_onDispose);
+    return 0;
+  }
+
+  void increment() => state++;
 }

--- a/packages/riverpod/test/src/providers/async_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/async_notifier_test.dart
@@ -88,31 +88,31 @@ void main() {
         if (!gate.isCompleted) gate.complete();
       });
 
-      final dependency = NotifierProvider.autoDispose<Issue4761Counter, int>(
-        () => Issue4761Counter(() => dependencyDisposeCount++),
+      final dependency = NotifierProvider.autoDispose(
+        () => DeferredNotifier<int>((ref, _) {
+          ref.onDispose(() => dependencyDisposeCount++);
+          return 0;
+        }),
       );
       final provider = factory.simpleTestProvider<int>((ref, _) async {
-        ref.keepAlive();
         await gate.future;
 
         return ref.watch(dependency);
       });
 
-      final sub = container.listen(provider, (previous, next) {});
+      container.listen(provider, (previous, next) {});
 
       gate.complete();
       await expectLater(container.read(provider.future), completion(0));
-      expect(sub.read(), const AsyncData<int>(0));
 
       gate = Completer<void>();
-      container.read(dependency.notifier).increment();
+      container.read(dependency.notifier).state++;
       await container.pump();
 
       expect(dependencyDisposeCount, 0);
 
       gate.complete();
       await expectLater(container.read(provider.future), completion(1));
-      expect(sub.read(), const AsyncData<int>(1));
       expect(dependencyDisposeCount, 0);
     });
 
@@ -1550,18 +1550,4 @@ class Equal<BoxedT> {
 class CtorNotifier extends AsyncNotifier<int> {
   @override
   FutureOr<int> build() => 0;
-}
-
-class Issue4761Counter extends Notifier<int> {
-  Issue4761Counter(this._onDispose);
-
-  final void Function() _onDispose;
-
-  @override
-  int build() {
-    ref.onDispose(_onDispose);
-    return 0;
-  }
-
-  void increment() => state++;
 }

--- a/packages/riverpod/test/src/providers/async_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/async_notifier_test.dart
@@ -117,6 +117,51 @@ void main() {
     });
 
     test(
+      'keeps post-await dependencies alive during rebuild (overrideWithBuild)',
+      () async {
+        var dependencyDisposeCount = 0;
+        var gate = Completer<void>();
+        addTearDown(() {
+          if (!gate.isCompleted) gate.complete();
+        });
+
+        final dependency = NotifierProvider.autoDispose(
+          () => DeferredNotifier<int>((ref, _) {
+            ref.onDispose(() => dependencyDisposeCount++);
+            return 0;
+          }),
+        );
+        final provider = factory.simpleTestProvider<int>((ref, _) async {
+          throw UnimplementedError();
+        });
+        final container = ProviderContainer.test(
+          overrides: [
+            provider.overrideWithBuild((ref, self) async {
+              await gate.future;
+
+              return ref.watch(dependency);
+            }),
+          ],
+        );
+
+        container.listen(provider, (previous, next) {});
+
+        gate.complete();
+        await expectLater(container.read(provider.future), completion(0));
+
+        gate = Completer<void>();
+        container.read(dependency.notifier).state++;
+        await container.pump();
+
+        expect(dependencyDisposeCount, 0);
+
+        gate.complete();
+        await expectLater(container.read(provider.future), completion(1));
+        expect(dependencyDisposeCount, 0);
+      },
+    );
+
+    test(
       'Calling state= followed by returning .future does not cause a double notification',
       () async {
         final provider = factory.simpleTestProvider<int>((ref, self) async {

--- a/packages/riverpod/test/src/providers/stream_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/stream_notifier_test.dart
@@ -122,31 +122,31 @@ void main() {
         if (!gate.isCompleted) gate.complete();
       });
 
-      final dependency = NotifierProvider.autoDispose<Issue4761Counter, int>(
-        () => Issue4761Counter(() => dependencyDisposeCount++),
+      final dependency = NotifierProvider.autoDispose(
+        () => DeferredNotifier<int>((ref, _) {
+          ref.onDispose(() => dependencyDisposeCount++);
+          return 0;
+        }),
       );
       final provider = factory.simpleTestProvider<int>((ref, _) async* {
-        ref.keepAlive();
         await gate.future;
 
         yield ref.watch(dependency);
       });
 
-      final sub = container.listen(provider, (previous, next) {});
+      container.listen(provider, (previous, next) {});
 
       gate.complete();
       await expectLater(container.read(provider.future), completion(0));
-      expect(sub.read(), const AsyncData<int>(0));
 
       gate = Completer<void>();
-      container.read(dependency.notifier).increment();
+      container.read(dependency.notifier).state++;
       await container.pump();
 
       expect(dependencyDisposeCount, 0);
 
       gate.complete();
       await expectLater(container.read(provider.future), completion(1));
-      expect(sub.read(), const AsyncData<int>(1));
       expect(dependencyDisposeCount, 0);
     });
 
@@ -1228,18 +1228,4 @@ class Equal<BoxedT> {
 class CtorNotifier extends StreamNotifier<int> {
   @override
   Stream<int> build() => Stream.value(0);
-}
-
-class Issue4761Counter extends Notifier<int> {
-  Issue4761Counter(this._onDispose);
-
-  final void Function() _onDispose;
-
-  @override
-  int build() {
-    ref.onDispose(_onDispose);
-    return 0;
-  }
-
-  void increment() => state++;
 }

--- a/packages/riverpod/test/src/providers/stream_notifier_test.dart
+++ b/packages/riverpod/test/src/providers/stream_notifier_test.dart
@@ -113,6 +113,43 @@ void main() {
       verifyOnly(onSubResume, onSubResume());
       verifyNoMoreInteractions(onSubPause);
     });
+
+    test('keeps post-await dependencies alive during rebuild', () async {
+      final container = ProviderContainer.test();
+      var dependencyDisposeCount = 0;
+      var gate = Completer<void>();
+      addTearDown(() {
+        if (!gate.isCompleted) gate.complete();
+      });
+
+      final dependency = NotifierProvider.autoDispose<Issue4761Counter, int>(
+        () => Issue4761Counter(() => dependencyDisposeCount++),
+      );
+      final provider = factory.simpleTestProvider<int>((ref, _) async* {
+        ref.keepAlive();
+        await gate.future;
+
+        yield ref.watch(dependency);
+      });
+
+      final sub = container.listen(provider, (previous, next) {});
+
+      gate.complete();
+      await expectLater(container.read(provider.future), completion(0));
+      expect(sub.read(), const AsyncData<int>(0));
+
+      gate = Completer<void>();
+      container.read(dependency.notifier).increment();
+      await container.pump();
+
+      expect(dependencyDisposeCount, 0);
+
+      gate.complete();
+      await expectLater(container.read(provider.future), completion(1));
+      expect(sub.read(), const AsyncData<int>(1));
+      expect(dependencyDisposeCount, 0);
+    });
+
     group('retry', () {
       test(
         'handles retry',
@@ -1191,4 +1228,18 @@ class Equal<BoxedT> {
 class CtorNotifier extends StreamNotifier<int> {
   @override
   Stream<int> build() => Stream.value(0);
+}
+
+class Issue4761Counter extends Notifier<int> {
+  Issue4761Counter(this._onDispose);
+
+  final void Function() _onDispose;
+
+  @override
+  int build() {
+    ref.onDispose(_onDispose);
+    return 0;
+  }
+
+  void increment() => state++;
 }

--- a/packages/riverpod_annotation/CHANGELOG.md
+++ b/packages/riverpod_annotation/CHANGELOG.md
@@ -1,4 +1,10 @@
+## Unreleased build
+
+- Fix `AsyncNotifierProvider`/`StreamNotifierProvider` disposing dependencies
+  watched after an asynchronous gap during rebuild. (thanks to @a1573595)
+
 ## 4.0.3-dev.2 - 2026-05-06
+
 ### Dependency changes
 
 - `riverpod` upgraded to `3.3.2-dev.2`
@@ -352,4 +358,3 @@ Upgrade Riverpod version
 ## 1.0.0
 
 Initial release
-

--- a/packages/riverpod_annotation/lib/riverpod_annotation.dart
+++ b/packages/riverpod_annotation/lib/riverpod_annotation.dart
@@ -67,7 +67,8 @@ export './src/internal.dart'
         Raw,
         MissingScopeException,
         $FunctionalFamilyOverride,
-        $ClassFamilyOverride;
+        $ClassFamilyOverride,
+        WhenComplete;
 
 /// An implementation detail of `riverpod_generator`.
 /// Do not use.

--- a/packages/riverpod_generator/CHANGELOG.md
+++ b/packages/riverpod_generator/CHANGELOG.md
@@ -1,4 +1,10 @@
+## Unreleased build
+
+- Fix `AsyncNotifierProvider`/`StreamNotifierProvider` disposing dependencies
+  watched after an asynchronous gap during rebuild. (thanks to @a1573595)
+
 ## 4.0.4-dev.3 - 2026-05-06
+
 ### Dependency changes
 
 - `riverpod_annotation` upgraded to `4.0.3-dev.2`
@@ -481,4 +487,3 @@ Fix version conflict with Riverpod
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-

--- a/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
+++ b/packages/riverpod_generator/integration/build_yaml/lib/main.g.dart
@@ -153,7 +153,7 @@ abstract class _$CountNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -163,7 +163,7 @@ abstract class _$CountNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -198,7 +198,7 @@ abstract class _$CountAsyncNotifier extends $AsyncNotifier<int> {
   FutureOr<int> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element =
         ref.element
@@ -208,7 +208,7 @@ abstract class _$CountAsyncNotifier extends $AsyncNotifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -243,7 +243,7 @@ abstract class _$CountStreamNotifier extends $StreamNotifier<int> {
   Stream<int> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element =
         ref.element
@@ -253,7 +253,7 @@ abstract class _$CountStreamNotifier extends $StreamNotifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -546,7 +546,7 @@ abstract class _$CountNotifier2 extends $Notifier<int> {
   int build(int a);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -556,7 +556,7 @@ abstract class _$CountNotifier2 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -636,7 +636,7 @@ abstract class _$CountAsyncNotifier2 extends $AsyncNotifier<int> {
   FutureOr<int> build(int a);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element =
         ref.element
@@ -646,7 +646,7 @@ abstract class _$CountAsyncNotifier2 extends $AsyncNotifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -727,7 +727,7 @@ abstract class _$CountStreamNotifier2 extends $StreamNotifier<int> {
   Stream<int> build(int a);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element =
         ref.element
@@ -737,7 +737,7 @@ abstract class _$CountStreamNotifier2 extends $StreamNotifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -779,7 +779,7 @@ abstract class _$TimeController extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -789,7 +789,7 @@ abstract class _$TimeController extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -869,7 +869,7 @@ abstract class _$TimeController2 extends $Notifier<int> {
   int build(int a);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -879,6 +879,6 @@ abstract class _$TimeController2 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/packages/riverpod_generator/lib/src/templates/notifier.dart
+++ b/packages/riverpod_generator/lib/src/templates/notifier.dart
@@ -70,11 +70,11 @@ abstract class $notifierBaseName$genericsDefinition extends $baseClass {
     buffer.writeln('''
   @\$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as \$Ref<${provider.providerElement.exposedTypeNode}, ${provider.providerElement.valueTypeNode.toCode()}>;
     final element = ref.element as \$ClassProviderElement<AnyNotifier<${provider.providerElement.exposedTypeNode}, ${provider.providerElement.valueTypeNode.toCode()}>,
           ${provider.providerElement.exposedTypeNode}, Object?, Object?>;
-    element.handleCreate(ref, $buildVarUsage);
+    return element.handleCreate(ref, $buildVarUsage);
   }
 }
 ''');

--- a/packages/riverpod_generator/test/integration/annotated.g.dart
+++ b/packages/riverpod_generator/test/integration/annotated.g.dart
@@ -189,7 +189,7 @@ abstract class _$ClassBased extends $Notifier<String> {
   String build(@Deprecated('field') int id);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -199,7 +199,7 @@ abstract class _$ClassBased extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -371,7 +371,7 @@ abstract class _$NotCopiedClassBased extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -381,7 +381,7 @@ abstract class _$NotCopiedClassBased extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_generator/test/integration/async.g.dart
+++ b/packages/riverpod_generator/test/integration/async.g.dart
@@ -204,7 +204,7 @@ abstract class _$GenericClass<ObjT extends num>
   FutureOr<List<ObjT>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<ObjT>>, List<ObjT>>;
     final element =
         ref.element
@@ -214,7 +214,7 @@ abstract class _$GenericClass<ObjT extends num>
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -324,7 +324,7 @@ abstract class _$GenericArg<ObjT extends num> extends $AsyncNotifier<String> {
   FutureOr<String> build(ObjT arg);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -334,7 +334,7 @@ abstract class _$GenericArg<ObjT extends num> extends $AsyncNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -618,7 +618,7 @@ abstract class _$PublicClass extends $AsyncNotifier<String> {
   FutureOr<String> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -628,7 +628,7 @@ abstract class _$PublicClass extends $AsyncNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -662,7 +662,7 @@ abstract class _$PrivateClass extends $AsyncNotifier<String> {
   FutureOr<String> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -672,7 +672,7 @@ abstract class _$PrivateClass extends $AsyncNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -751,7 +751,7 @@ abstract class _$FamilyOrClass extends $AsyncNotifier<String> {
   FutureOr<String> build(int first);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -761,7 +761,7 @@ abstract class _$FamilyOrClass extends $AsyncNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -885,7 +885,7 @@ abstract class _$FamilyClass extends $AsyncNotifier<String> {
   });
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -895,7 +895,7 @@ abstract class _$FamilyClass extends $AsyncNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(
+    return element.handleCreate(
       ref,
       () => build(
         _$args.$1,
@@ -1051,7 +1051,7 @@ abstract class _$Regression3490<ModelT, SortT, CursorT>
   });
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<void, void>;
     final element =
         ref.element
@@ -1061,7 +1061,7 @@ abstract class _$Regression3490<ModelT, SortT, CursorT>
               Object?,
               Object?
             >;
-    element.handleCreate(
+    return element.handleCreate(
       ref,
       () => build(
         type: _$args.type,
@@ -1101,7 +1101,7 @@ abstract class _$VoidClass extends $AsyncNotifier<void> {
   FutureOr<void> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<void>, void>;
     final element =
         ref.element
@@ -1111,6 +1111,6 @@ abstract class _$VoidClass extends $AsyncNotifier<void> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_generator/test/integration/dependencies.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies.g.dart
@@ -162,7 +162,7 @@ abstract class _$Empty2 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -172,7 +172,7 @@ abstract class _$Empty2 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -251,7 +251,7 @@ abstract class _$EmptyFamily2 extends $Notifier<int> {
   int build(int id);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -261,7 +261,7 @@ abstract class _$EmptyFamily2 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -417,7 +417,7 @@ abstract class _$Dep2 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -427,7 +427,7 @@ abstract class _$Dep2 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -505,7 +505,7 @@ abstract class _$Family2 extends $Notifier<int> {
   int build(int id);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -515,7 +515,7 @@ abstract class _$Family2 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -681,7 +681,7 @@ abstract class _$Provider3 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -691,7 +691,7 @@ abstract class _$Provider3 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -785,7 +785,7 @@ abstract class _$Provider4 extends $Notifier<int> {
   int build(int id);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -795,7 +795,7 @@ abstract class _$Provider4 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -995,7 +995,7 @@ abstract class _$EmptyDependenciesClassBased extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1005,7 +1005,7 @@ abstract class _$EmptyDependenciesClassBased extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_generator/test/integration/dependencies2.g.dart
+++ b/packages/riverpod_generator/test/integration/dependencies2.g.dart
@@ -223,7 +223,7 @@ abstract class _$NotifierWithDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -233,7 +233,7 @@ abstract class _$NotifierWithDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -341,7 +341,7 @@ abstract class _$NotifierFamilyWithDependencies extends $Notifier<int> {
   int build({int? id});
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -351,7 +351,7 @@ abstract class _$NotifierFamilyWithDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(id: _$args));
+    return element.handleCreate(ref, () => build(id: _$args));
   }
 }
 

--- a/packages/riverpod_generator/test/integration/documented.g.dart
+++ b/packages/riverpod_generator/test/integration/documented.g.dart
@@ -109,7 +109,7 @@ abstract class _$ClassBased extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -119,7 +119,7 @@ abstract class _$ClassBased extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -317,7 +317,7 @@ abstract class _$ClassFamilyBased extends $Notifier<String> {
   String build(@annotation int id);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -327,6 +327,6 @@ abstract class _$ClassFamilyBased extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/packages/riverpod_generator/test/integration/generated.g.dart
+++ b/packages/riverpod_generator/test/integration/generated.g.dart
@@ -165,7 +165,7 @@ abstract class _$$DynamicClass extends $Notifier<dynamic> {
   dynamic build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<dynamic, dynamic>;
     final element =
         ref.element
@@ -175,7 +175,7 @@ abstract class _$$DynamicClass extends $Notifier<dynamic> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -263,7 +263,7 @@ abstract class _$$DynamicClassFamily extends $Notifier<dynamic> {
   dynamic build(dynamic test);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<dynamic, dynamic>;
     final element =
         ref.element
@@ -273,7 +273,7 @@ abstract class _$$DynamicClassFamily extends $Notifier<dynamic> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -512,7 +512,7 @@ abstract class _$AliasClass extends $Notifier<AsyncValue<int>> {
   AsyncValue<int> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, AsyncValue<int>>;
     final element =
         ref.element
@@ -522,7 +522,7 @@ abstract class _$AliasClass extends $Notifier<AsyncValue<int>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -609,7 +609,7 @@ abstract class _$AliasClassFamily extends $Notifier<AsyncValue<int>> {
   AsyncValue<int> build(AsyncValue<int> test);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, AsyncValue<int>>;
     final element =
         ref.element
@@ -619,6 +619,6 @@ abstract class _$AliasClassFamily extends $Notifier<AsyncValue<int>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/packages/riverpod_generator/test/integration/hash/hash1.g.dart
+++ b/packages/riverpod_generator/test/integration/hash/hash1.g.dart
@@ -126,7 +126,7 @@ abstract class _$SimpleClass extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -136,6 +136,6 @@ abstract class _$SimpleClass extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_generator/test/integration/offline.g.dart
+++ b/packages/riverpod_generator/test/integration/offline.g.dart
@@ -83,7 +83,7 @@ abstract class _$CustomAnnotationBase extends $AsyncNotifier<String> {
   FutureOr<String> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -93,7 +93,7 @@ abstract class _$CustomAnnotationBase extends $AsyncNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -176,7 +176,7 @@ abstract class _$JsonBase extends $AsyncNotifier<Map<String, List<int>>> {
   FutureOr<Map<String, List<int>>> build(String arg);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref
             as $Ref<AsyncValue<Map<String, List<int>>>, Map<String, List<int>>>;
@@ -191,7 +191,7 @@ abstract class _$JsonBase extends $AsyncNotifier<Map<String, List<int>>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -228,7 +228,7 @@ abstract class _$Json2Base extends $AsyncNotifier<Map<String, List<int>>> {
   FutureOr<Map<String, List<int>>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref
             as $Ref<AsyncValue<Map<String, List<int>>>, Map<String, List<int>>>;
@@ -243,7 +243,7 @@ abstract class _$Json2Base extends $AsyncNotifier<Map<String, List<int>>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -280,7 +280,7 @@ abstract class _$CustomJsonBase extends $AsyncNotifier<Map<String, Bar>> {
   FutureOr<Map<String, Bar>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<AsyncValue<Map<String, Bar>>, Map<String, Bar>>;
     final element =
@@ -291,7 +291,7 @@ abstract class _$CustomJsonBase extends $AsyncNotifier<Map<String, Bar>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -328,7 +328,7 @@ abstract class _$CustomKeyBase extends $AsyncNotifier<Map<String, Bar>> {
   FutureOr<Map<String, Bar>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<AsyncValue<Map<String, Bar>>, Map<String, Bar>>;
     final element =
@@ -339,7 +339,7 @@ abstract class _$CustomKeyBase extends $AsyncNotifier<Map<String, Bar>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -430,7 +430,7 @@ abstract class _$CustomJsonWithArgsBase
   FutureOr<Map<String, Bar>> build(int arg, String arg2, {int? arg3});
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<AsyncValue<Map<String, Bar>>, Map<String, Bar>>;
     final element =
@@ -441,7 +441,7 @@ abstract class _$CustomJsonWithArgsBase
               Object?,
               Object?
             >;
-    element.handleCreate(
+    return element.handleCreate(
       ref,
       () => build(_$args.$1, _$args.$2, arg3: _$args.arg3),
     );
@@ -484,7 +484,7 @@ abstract class _$PassEncodeDecodeByHandBase
   FutureOr<Map<String, String>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<AsyncValue<Map<String, String>>, Map<String, String>>;
     final element =
@@ -495,7 +495,7 @@ abstract class _$PassEncodeDecodeByHandBase
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_generator/test/integration/record.g.dart
+++ b/packages/riverpod_generator/test/integration/record.g.dart
@@ -168,7 +168,7 @@ abstract class _$Class extends $Notifier<(String,)> {
   (String,) build((String,) arg);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<(String,), (String,)>;
     final element =
         ref.element
@@ -178,7 +178,7 @@ abstract class _$Class extends $Notifier<(String,)> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -326,7 +326,7 @@ abstract class _$ClassAsync extends $AsyncNotifier<(String,)> {
   FutureOr<(String,)> build((String,) arg);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<(String,)>, (String,)>;
     final element =
         ref.element
@@ -336,7 +336,7 @@ abstract class _$ClassAsync extends $AsyncNotifier<(String,)> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -484,7 +484,7 @@ abstract class _$ClassStream extends $StreamNotifier<(String,)> {
   Stream<(String,)> build((String,) arg);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<(String,)>, (String,)>;
     final element =
         ref.element
@@ -494,6 +494,6 @@ abstract class _$ClassStream extends $StreamNotifier<(String,)> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/packages/riverpod_generator/test/integration/scopes.g.dart
+++ b/packages/riverpod_generator/test/integration/scopes.g.dart
@@ -46,7 +46,7 @@ abstract class _$ScopedClass extends $Notifier<int> {
   int build() => throw MissingScopeException(ref);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -56,7 +56,7 @@ abstract class _$ScopedClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -136,7 +136,7 @@ abstract class _$ScopedClassFamily extends $Notifier<int> {
   int build(int a) => throw MissingScopeException(ref);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -146,6 +146,6 @@ abstract class _$ScopedClassFamily extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/packages/riverpod_generator/test/integration/stream.g.dart
+++ b/packages/riverpod_generator/test/integration/stream.g.dart
@@ -209,7 +209,7 @@ abstract class _$GenericClass<StateT extends num>
   Stream<List<StateT>> build(StateT param);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<StateT>>, List<StateT>>;
     final element =
         ref.element
@@ -219,7 +219,7 @@ abstract class _$GenericClass<StateT extends num>
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -434,7 +434,7 @@ abstract class _$PublicClass extends $StreamNotifier<String> {
   Stream<String> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -444,7 +444,7 @@ abstract class _$PublicClass extends $StreamNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -478,7 +478,7 @@ abstract class _$PrivateClass extends $StreamNotifier<String> {
   Stream<String> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -488,7 +488,7 @@ abstract class _$PrivateClass extends $StreamNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -612,7 +612,7 @@ abstract class _$FamilyClass extends $StreamNotifier<String> {
   });
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -622,7 +622,7 @@ abstract class _$FamilyClass extends $StreamNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(
+    return element.handleCreate(
       ref,
       () => build(
         _$args.$1,

--- a/packages/riverpod_generator/test/integration/sync.g.dart
+++ b/packages/riverpod_generator/test/integration/sync.g.dart
@@ -337,7 +337,7 @@ abstract class _$GenericClass<ValueT extends num>
   List<ValueT> build(ValueT param);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<List<ValueT>, List<ValueT>>;
     final element =
         ref.element
@@ -347,7 +347,7 @@ abstract class _$GenericClass<ValueT extends num>
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -483,7 +483,7 @@ abstract class _$RawFutureClass extends $Notifier<Raw<Future<String>>> {
   Raw<Future<String>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<Raw<Future<String>>, Raw<Future<String>>>;
     final element =
         ref.element
@@ -493,7 +493,7 @@ abstract class _$RawFutureClass extends $Notifier<Raw<Future<String>>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -535,7 +535,7 @@ abstract class _$RawStreamClass extends $Notifier<Raw<Stream<String>>> {
   Raw<Stream<String>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<Raw<Stream<String>>, Raw<Stream<String>>>;
     final element =
         ref.element
@@ -545,7 +545,7 @@ abstract class _$RawStreamClass extends $Notifier<Raw<Stream<String>>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -799,7 +799,7 @@ abstract class _$RawFamilyFutureClass extends $Notifier<Raw<Future<String>>> {
   Raw<Future<String>> build(int id);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<Raw<Future<String>>, Raw<Future<String>>>;
     final element =
         ref.element
@@ -809,7 +809,7 @@ abstract class _$RawFamilyFutureClass extends $Notifier<Raw<Future<String>>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -897,7 +897,7 @@ abstract class _$RawFamilyStreamClass extends $Notifier<Raw<Stream<String>>> {
   Raw<Stream<String>> build(int id);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<Raw<Stream<String>>, Raw<Stream<String>>>;
     final element =
         ref.element
@@ -907,7 +907,7 @@ abstract class _$RawFamilyStreamClass extends $Notifier<Raw<Stream<String>>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -1211,7 +1211,7 @@ abstract class _$PublicClass extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -1221,7 +1221,7 @@ abstract class _$PublicClass extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1263,7 +1263,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -1273,7 +1273,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1414,7 +1414,7 @@ abstract class _$FamilyClass extends $Notifier<String> {
   });
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -1424,7 +1424,7 @@ abstract class _$FamilyClass extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(
+    return element.handleCreate(
       ref,
       () => build(
         _$args.$1,
@@ -1521,7 +1521,7 @@ abstract class _$LocalStaticDefault extends $Notifier<String> {
   String build({String arg = LocalStaticDefault.value});
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -1531,7 +1531,7 @@ abstract class _$LocalStaticDefault extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(arg: _$args));
+    return element.handleCreate(ref, () => build(arg: _$args));
   }
 }
 
@@ -1858,7 +1858,7 @@ abstract class _$Supports$InClassName<And$InT> extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -1868,7 +1868,7 @@ abstract class _$Supports$InClassName<And$InT> extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -2002,7 +2002,7 @@ abstract class _$Supports$InClassFamilyName<And$InT> extends $Notifier<String> {
   });
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -2012,7 +2012,7 @@ abstract class _$Supports$InClassFamilyName<And$InT> extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(
+    return element.handleCreate(
       ref,
       () => build(
         _$args.$1,
@@ -2225,7 +2225,7 @@ abstract class _$UnnecessaryCastClass extends $Notifier<String> {
   String build(Object? arg);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -2235,7 +2235,7 @@ abstract class _$UnnecessaryCastClass extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -2695,7 +2695,7 @@ abstract class _$VoidClass extends $Notifier<void> {
   void build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<void, void>;
     final element =
         ref.element
@@ -2705,7 +2705,7 @@ abstract class _$VoidClass extends $Notifier<void> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -2785,7 +2785,7 @@ abstract class _$VoidClassWithArgs extends $Notifier<void> {
   void build(int a);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<void, void>;
     final element =
         ref.element
@@ -2795,6 +2795,6 @@ abstract class _$VoidClassWithArgs extends $Notifier<void> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional.class_based_to_functional_provider-12.assist.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional.class_based_to_functional_provider-12.assist.g.dart
@@ -147,7 +147,7 @@ abstract class _$ExampleFamily extends $Notifier<int> {
   int build({required int a, String b = '42'});
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -157,7 +157,7 @@ abstract class _$ExampleFamily extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(a: _$args.a, b: _$args.b));
+    return element.handleCreate(ref, () => build(a: _$args.a, b: _$args.b));
   }
 }
 
@@ -271,7 +271,7 @@ abstract class _$Generic<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -281,6 +281,6 @@ abstract class _$Generic<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional.class_based_to_functional_provider-19.assist.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional.class_based_to_functional_provider-19.assist.g.dart
@@ -51,7 +51,7 @@ abstract class _$Example extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -61,7 +61,7 @@ abstract class _$Example extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -260,7 +260,7 @@ abstract class _$Generic<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -270,6 +270,6 @@ abstract class _$Generic<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional.class_based_to_functional_provider-28.assist.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional.class_based_to_functional_provider-28.assist.g.dart
@@ -51,7 +51,7 @@ abstract class _$Example extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -61,7 +61,7 @@ abstract class _$Example extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -159,7 +159,7 @@ abstract class _$ExampleFamily extends $Notifier<int> {
   int build({required int a, String b = '42'});
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -169,7 +169,7 @@ abstract class _$ExampleFamily extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(a: _$args.a, b: _$args.b));
+    return element.handleCreate(ref, () => build(a: _$args.a, b: _$args.b));
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_class_based_provider_to_functional.g.dart
@@ -51,7 +51,7 @@ abstract class _$Example extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -61,7 +61,7 @@ abstract class _$Example extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -159,7 +159,7 @@ abstract class _$ExampleFamily extends $Notifier<int> {
   int build({required int a, String b = '42'});
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -169,7 +169,7 @@ abstract class _$ExampleFamily extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(a: _$args.a, b: _$args.b));
+    return element.handleCreate(ref, () => build(a: _$args.a, b: _$args.b));
   }
 }
 
@@ -283,7 +283,7 @@ abstract class _$Generic<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -293,6 +293,6 @@ abstract class _$Generic<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based.functional_to_class_based_provider-12.assist.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based.functional_to_class_based_provider-12.assist.g.dart
@@ -51,7 +51,7 @@ abstract class _$Example extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -61,7 +61,7 @@ abstract class _$Example extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based.functional_to_class_based_provider-16.assist.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/assists/convert_functional_provider_to_class_based.functional_to_class_based_provider-16.assist.g.dart
@@ -147,7 +147,7 @@ abstract class _$ExampleFamily extends $Notifier<int> {
   int build({required int a, String b = '42'});
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -157,6 +157,6 @@ abstract class _$ExampleFamily extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(a: _$args.a, b: _$args.b));
+    return element.handleCreate(ref, () => build(a: _$args.a, b: _$args.b));
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/avoid_build_context_in_providers.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/avoid_build_context_in_providers.g.dart
@@ -178,7 +178,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   int build(BuildContext context1, {required BuildContext context2});
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -188,7 +188,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(
+    return element.handleCreate(
       ref,
       () => build(_$args.$1, context2: _$args.context2),
     );
@@ -233,7 +233,7 @@ abstract class _$Regression2959 extends $Notifier<void> {
   void build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<void, void>;
     final element =
         ref.element
@@ -243,6 +243,6 @@ abstract class _$Regression2959 extends $Notifier<void> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/avoid_public_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/avoid_public_notifier_properties.g.dart
@@ -85,7 +85,7 @@ abstract class _$GeneratedNotifier extends $Notifier<int> {
   int build(int param);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -95,6 +95,6 @@ abstract class _$GeneratedNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/incorrect_extends.notifier_extends-13.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/incorrect_extends.notifier_extends-13.fix.g.dart
@@ -46,7 +46,7 @@ abstract class _$WrongExtends extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -56,6 +56,6 @@ abstract class _$WrongExtends extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.g.dart
@@ -46,7 +46,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -56,7 +56,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -98,7 +98,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -108,7 +108,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -225,7 +225,7 @@ abstract class _$Generics<FirstT extends num, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -235,7 +235,7 @@ abstract class _$Generics<FirstT extends num, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -353,7 +353,7 @@ abstract class _$NoGenerics<FirstT extends num, SecondT>
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -363,7 +363,7 @@ abstract class _$NoGenerics<FirstT extends num, SecondT>
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -481,7 +481,7 @@ abstract class _$MissingGenerics<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -491,7 +491,7 @@ abstract class _$MissingGenerics<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -605,7 +605,7 @@ abstract class _$WrongOrder<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -615,6 +615,6 @@ abstract class _$WrongOrder<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.notifier_extends-31.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.notifier_extends-31.fix.g.dart
@@ -46,7 +46,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -56,7 +56,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -98,7 +98,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -108,7 +108,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -225,7 +225,7 @@ abstract class _$Generics<FirstT extends num, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -235,7 +235,7 @@ abstract class _$Generics<FirstT extends num, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -353,7 +353,7 @@ abstract class _$NoGenerics<FirstT extends num, SecondT>
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -363,7 +363,7 @@ abstract class _$NoGenerics<FirstT extends num, SecondT>
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -481,7 +481,7 @@ abstract class _$MissingGenerics<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -491,7 +491,7 @@ abstract class _$MissingGenerics<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -605,7 +605,7 @@ abstract class _$WrongOrder<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -615,6 +615,6 @@ abstract class _$WrongOrder<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.notifier_extends-37.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.notifier_extends-37.fix.g.dart
@@ -46,7 +46,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -56,7 +56,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -98,7 +98,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -108,7 +108,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -225,7 +225,7 @@ abstract class _$Generics<FirstT extends num, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -235,7 +235,7 @@ abstract class _$Generics<FirstT extends num, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -353,7 +353,7 @@ abstract class _$NoGenerics<FirstT extends num, SecondT>
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -363,7 +363,7 @@ abstract class _$NoGenerics<FirstT extends num, SecondT>
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -481,7 +481,7 @@ abstract class _$MissingGenerics<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -491,7 +491,7 @@ abstract class _$MissingGenerics<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -605,7 +605,7 @@ abstract class _$WrongOrder<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -615,6 +615,6 @@ abstract class _$WrongOrder<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.notifier_extends-43.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/notifier_extends/notifier_extends.notifier_extends-43.fix.g.dart
@@ -46,7 +46,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -56,7 +56,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -98,7 +98,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -108,7 +108,7 @@ abstract class _$PrivateClass extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -225,7 +225,7 @@ abstract class _$Generics<FirstT extends num, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -235,7 +235,7 @@ abstract class _$Generics<FirstT extends num, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -353,7 +353,7 @@ abstract class _$NoGenerics<FirstT extends num, SecondT>
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -363,7 +363,7 @@ abstract class _$NoGenerics<FirstT extends num, SecondT>
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -481,7 +481,7 @@ abstract class _$MissingGenerics<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -491,7 +491,7 @@ abstract class _$MissingGenerics<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -605,7 +605,7 @@ abstract class _$WrongOrder<FirstT, SecondT> extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -615,6 +615,6 @@ abstract class _$WrongOrder<FirstT, SecondT> extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/only_use_keep_alive_inside_keep_alive.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/only_use_keep_alive_inside_keep_alive.g.dart
@@ -87,7 +87,7 @@ abstract class _$KeepAliveClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -97,7 +97,7 @@ abstract class _$KeepAliveClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -179,7 +179,7 @@ abstract class _$AutoDisposeClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -189,7 +189,7 @@ abstract class _$AutoDisposeClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/protected_notifier_properties.g.dart
@@ -46,7 +46,7 @@ abstract class _$A extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -56,7 +56,7 @@ abstract class _$A extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -97,7 +97,7 @@ abstract class _$A2 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -107,7 +107,7 @@ abstract class _$A2 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -183,7 +183,7 @@ abstract class _$A3 extends $Notifier<int> {
   int build(int param);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -193,7 +193,7 @@ abstract class _$A3 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -269,7 +269,7 @@ abstract class _$A4 extends $Notifier<int> {
   int build(int param);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -279,7 +279,7 @@ abstract class _$A4 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -347,7 +347,7 @@ abstract class _$A5 extends $AsyncNotifier<int> {
   FutureOr<int> build(int param);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element =
         ref.element
@@ -357,7 +357,7 @@ abstract class _$A5 extends $AsyncNotifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -425,7 +425,7 @@ abstract class _$A6 extends $AsyncNotifier<int> {
   FutureOr<int> build(int param);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element =
         ref.element
@@ -435,7 +435,7 @@ abstract class _$A6 extends $AsyncNotifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -503,7 +503,7 @@ abstract class _$A7 extends $StreamNotifier<int> {
   Stream<int> build(int param);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element =
         ref.element
@@ -513,7 +513,7 @@ abstract class _$A7 extends $StreamNotifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -581,7 +581,7 @@ abstract class _$A8 extends $StreamNotifier<int> {
   Stream<int> build(int param);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element =
         ref.element
@@ -591,7 +591,7 @@ abstract class _$A8 extends $StreamNotifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -632,7 +632,7 @@ abstract class _$B extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -642,7 +642,7 @@ abstract class _$B extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -683,7 +683,7 @@ abstract class _$B2 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -693,6 +693,6 @@ abstract class _$B2 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/generator_regression.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/generator_regression.g.dart
@@ -161,7 +161,7 @@ abstract class _$Dep2 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -171,7 +171,7 @@ abstract class _$Dep2 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -249,7 +249,7 @@ abstract class _$Family2 extends $Notifier<int> {
   int build(int id);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -259,7 +259,7 @@ abstract class _$Family2 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -425,7 +425,7 @@ abstract class _$Provider3 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -435,7 +435,7 @@ abstract class _$Provider3 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -529,7 +529,7 @@ abstract class _$Provider4 extends $Notifier<int> {
   int build(int id);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -539,7 +539,7 @@ abstract class _$Provider4 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }
 
@@ -739,7 +739,7 @@ abstract class _$EmptyDependenciesClassBased extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -749,7 +749,7 @@ abstract class _$EmptyDependenciesClassBased extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-126.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-126.fix.g.dart
@@ -856,7 +856,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -866,7 +866,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -956,7 +956,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -966,7 +966,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1209,7 +1209,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1219,7 +1219,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1266,7 +1266,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1276,7 +1276,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-142.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-142.fix.g.dart
@@ -859,7 +859,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -869,7 +869,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -959,7 +959,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -969,7 +969,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1212,7 +1212,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1222,7 +1222,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1269,7 +1269,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1279,7 +1279,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-223.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-223.fix.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-228.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-228.fix.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-231.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-231.fix.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-251.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-251.fix.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-255.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-255.fix.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-263.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-263.fix.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-280.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-280.fix.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-311.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-311.fix.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-327.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-327.fix.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-340.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-340.fix.g.dart
@@ -861,7 +861,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -871,7 +871,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -961,7 +961,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -971,7 +971,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1214,7 +1214,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1224,7 +1224,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1271,7 +1271,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1281,7 +1281,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-36.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-36.fix.g.dart
@@ -866,7 +866,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -876,7 +876,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -966,7 +966,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -976,7 +976,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1219,7 +1219,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1229,7 +1229,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1276,7 +1276,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1286,7 +1286,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-62.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-62.fix.g.dart
@@ -866,7 +866,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -876,7 +876,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -966,7 +966,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -976,7 +976,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1219,7 +1219,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1229,7 +1229,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1276,7 +1276,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1286,7 +1286,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-92.fix.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_dependencies/missing_dependencies2.provider_dependencies-92.fix.g.dart
@@ -864,7 +864,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -874,7 +874,7 @@ abstract class _$ClassWatchGeneratedRootButMissingDependencies
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -964,7 +964,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -974,7 +974,7 @@ abstract class _$Regression2417 extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1217,7 +1217,7 @@ abstract class _$AliasClass extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1227,7 +1227,7 @@ abstract class _$AliasClass extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -1274,7 +1274,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -1284,7 +1284,7 @@ abstract class _$RiverpodDependencies extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/scoped_providers_should_specify_dependencies.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/scoped_providers_should_specify_dependencies.g.dart
@@ -48,7 +48,7 @@ abstract class _$UnimplementedScoped extends $Notifier<int> {
   int build() => throw MissingScopeException(ref);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -58,7 +58,7 @@ abstract class _$UnimplementedScoped extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_lint_flutter_test/test/lints/unsupported_provider_value.g.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/unsupported_provider_value.g.dart
@@ -170,7 +170,7 @@ abstract class _$StateNotifierClass extends $Notifier<MyStateNotifier> {
   MyStateNotifier build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<MyStateNotifier, MyStateNotifier>;
     final element =
         ref.element
@@ -180,7 +180,7 @@ abstract class _$StateNotifierClass extends $Notifier<MyStateNotifier> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -254,7 +254,7 @@ abstract class _$SelfNotifier extends $AsyncNotifier<SelfNotifier> {
   FutureOr<SelfNotifier> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<SelfNotifier>, SelfNotifier>;
     final element =
         ref.element
@@ -264,7 +264,7 @@ abstract class _$SelfNotifier extends $AsyncNotifier<SelfNotifier> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -306,7 +306,7 @@ abstract class _$SyncSelfNotifier extends $Notifier<SyncSelfNotifier> {
   SyncSelfNotifier build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<SyncSelfNotifier, SyncSelfNotifier>;
     final element =
         ref.element
@@ -316,7 +316,7 @@ abstract class _$SyncSelfNotifier extends $Notifier<SyncSelfNotifier> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -352,7 +352,7 @@ abstract class _$StreamSelfNotifier
   Stream<StreamSelfNotifier> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<AsyncValue<StreamSelfNotifier>, StreamSelfNotifier>;
     final element =
@@ -363,7 +363,7 @@ abstract class _$StreamSelfNotifier
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -399,7 +399,7 @@ abstract class _$StateNotifierClassAsync
   FutureOr<MyStateNotifier> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<MyStateNotifier>, MyStateNotifier>;
     final element =
         ref.element
@@ -409,7 +409,7 @@ abstract class _$StateNotifierClassAsync
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -498,7 +498,7 @@ abstract class _$ChangeNotifierClass extends $Notifier<MyChangeNotifier> {
   MyChangeNotifier build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<MyChangeNotifier, MyChangeNotifier>;
     final element =
         ref.element
@@ -508,7 +508,7 @@ abstract class _$ChangeNotifierClass extends $Notifier<MyChangeNotifier> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -639,7 +639,7 @@ abstract class _$NotifierClass extends $Notifier<MyNotifier> {
   MyNotifier build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<MyNotifier, MyNotifier>;
     final element =
         ref.element
@@ -649,7 +649,7 @@ abstract class _$NotifierClass extends $Notifier<MyNotifier> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -734,7 +734,7 @@ abstract class _$AsyncNotifierClass extends $Notifier<MyAsyncNotifier> {
   MyAsyncNotifier build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<MyAsyncNotifier, MyAsyncNotifier>;
     final element =
         ref.element
@@ -744,7 +744,7 @@ abstract class _$AsyncNotifierClass extends $Notifier<MyAsyncNotifier> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/packages/riverpod_sqflite/example/lib/generated.g.dart
+++ b/packages/riverpod_sqflite/example/lib/generated.g.dart
@@ -99,7 +99,7 @@ abstract class _$TodosNotifierBase extends $AsyncNotifier<List<Todo>> {
   FutureOr<List<Todo>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element =
         ref.element
@@ -109,7 +109,7 @@ abstract class _$TodosNotifierBase extends $AsyncNotifier<List<Todo>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/website/docs/concepts/about_codegen/provider_type/async_class_future.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_class_future.g.dart
@@ -40,7 +40,7 @@ abstract class _$Example extends $AsyncNotifier<String> {
   FutureOr<String> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -50,6 +50,6 @@ abstract class _$Example extends $AsyncNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/concepts/about_codegen/provider_type/async_class_stream.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/async_class_stream.g.dart
@@ -40,7 +40,7 @@ abstract class _$Example extends $StreamNotifier<String> {
   Stream<String> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<String>, String>;
     final element =
         ref.element
@@ -50,6 +50,6 @@ abstract class _$Example extends $StreamNotifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/concepts/about_codegen/provider_type/family_class.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/family_class.g.dart
@@ -94,7 +94,7 @@ abstract class _$Example extends $Notifier<String> {
   String build(int param1, {String param2 = 'foo'});
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -104,6 +104,9 @@ abstract class _$Example extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args.$1, param2: _$args.param2));
+    return element.handleCreate(
+      ref,
+      () => build(_$args.$1, param2: _$args.param2),
+    );
   }
 }

--- a/website/docs/concepts/about_codegen/provider_type/sync_class.g.dart
+++ b/website/docs/concepts/about_codegen/provider_type/sync_class.g.dart
@@ -48,7 +48,7 @@ abstract class _$Example extends $Notifier<String> {
   String build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<String, String>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$Example extends $Notifier<String> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/concepts2/family/notifier/codegen.g.dart
+++ b/website/docs/concepts2/family/notifier/codegen.g.dart
@@ -86,7 +86,7 @@ abstract class _$UserNotifier extends $AsyncNotifier<User> {
   FutureOr<User> build(String id);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<User>, User>;
     final element =
         ref.element
@@ -96,6 +96,6 @@ abstract class _$UserNotifier extends $AsyncNotifier<User> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/website/docs/concepts2/offline/custom_duration.g.dart
+++ b/website/docs/concepts2/offline/custom_duration.g.dart
@@ -60,7 +60,7 @@ abstract class _$TodoListBase extends $AsyncNotifier<List<Todo>> {
   FutureOr<List<Todo>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element =
         ref.element
@@ -70,7 +70,7 @@ abstract class _$TodoListBase extends $AsyncNotifier<List<Todo>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/website/docs/concepts2/offline/destroy_key/codegen.g.dart
+++ b/website/docs/concepts2/offline/destroy_key/codegen.g.dart
@@ -60,7 +60,7 @@ abstract class _$TodoListBase extends $AsyncNotifier<List<Todo>> {
   FutureOr<List<Todo>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element =
         ref.element
@@ -70,7 +70,7 @@ abstract class _$TodoListBase extends $AsyncNotifier<List<Todo>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/website/docs/concepts2/offline/json_persist.g.dart
+++ b/website/docs/concepts2/offline/json_persist.g.dart
@@ -55,7 +55,7 @@ abstract class _$TodoListBase extends $AsyncNotifier<List<Todo>> {
   FutureOr<List<Todo>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element =
         ref.element
@@ -65,7 +65,7 @@ abstract class _$TodoListBase extends $AsyncNotifier<List<Todo>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/website/docs/concepts2/offline/manual_persist/codegen.g.dart
+++ b/website/docs/concepts2/offline/manual_persist/codegen.g.dart
@@ -41,7 +41,7 @@ abstract class _$TodoList extends $AsyncNotifier<List<Todo>> {
   FutureOr<List<Todo>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element =
         ref.element
@@ -51,6 +51,6 @@ abstract class _$TodoList extends $AsyncNotifier<List<Todo>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/concepts2/offline/wait_persist.g.dart
+++ b/website/docs/concepts2/offline/wait_persist.g.dart
@@ -60,7 +60,7 @@ abstract class _$TodoListBase extends $AsyncNotifier<List<Todo>> {
   FutureOr<List<Todo>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element =
         ref.element
@@ -70,7 +70,7 @@ abstract class _$TodoListBase extends $AsyncNotifier<List<Todo>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }
 

--- a/website/docs/how_to/testing/notifier_mock/codegen.g.dart
+++ b/website/docs/how_to/testing/notifier_mock/codegen.g.dart
@@ -48,7 +48,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$MyNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/migration/from_change_notifier/declaration/declaration.g.dart
+++ b/website/docs/migration/from_change_notifier/declaration/declaration.g.dart
@@ -41,7 +41,7 @@ abstract class _$MyNotifier extends $AsyncNotifier<List<Todo>> {
   FutureOr<List<Todo>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element =
         ref.element
@@ -51,6 +51,6 @@ abstract class _$MyNotifier extends $AsyncNotifier<List<Todo>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/migration/from_change_notifier/initialization/initialization.g.dart
+++ b/website/docs/migration/from_change_notifier/initialization/initialization.g.dart
@@ -41,7 +41,7 @@ abstract class _$MyNotifier extends $AsyncNotifier<List<Todo>> {
   FutureOr<List<Todo>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element =
         ref.element
@@ -51,6 +51,6 @@ abstract class _$MyNotifier extends $AsyncNotifier<List<Todo>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/migration/from_change_notifier/migrated/migrated.g.dart
+++ b/website/docs/migration/from_change_notifier/migrated/migrated.g.dart
@@ -41,7 +41,7 @@ abstract class _$MyNotifier extends $AsyncNotifier<List<Todo>> {
   FutureOr<List<Todo>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element =
         ref.element
@@ -51,6 +51,6 @@ abstract class _$MyNotifier extends $AsyncNotifier<List<Todo>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/migration/from_state_notifier/add_listener/add_listener.g.dart
+++ b/website/docs/migration/from_state_notifier/add_listener/add_listener.g.dart
@@ -48,7 +48,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$MyNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/migration/from_state_notifier/async_notifier/async_notifier.g.dart
+++ b/website/docs/migration/from_state_notifier/async_notifier/async_notifier.g.dart
@@ -42,7 +42,7 @@ abstract class _$AsyncTodosNotifier extends $AsyncNotifier<List<Todo>> {
   FutureOr<List<Todo>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<Todo>>, List<Todo>>;
     final element =
         ref.element
@@ -52,6 +52,6 @@ abstract class _$AsyncTodosNotifier extends $AsyncNotifier<List<Todo>> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/migration/from_state_notifier/build_init/build_init.g.dart
+++ b/website/docs/migration/from_state_notifier/build_init/build_init.g.dart
@@ -49,7 +49,7 @@ abstract class _$CounterNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -59,6 +59,6 @@ abstract class _$CounterNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
+++ b/website/docs/migration/from_state_notifier/family_and_dispose/family_and_dispose.g.dart
@@ -130,7 +130,7 @@ abstract class _$BugsEncounteredNotifier extends $AsyncNotifier<int> {
   FutureOr<int> build(String featureId);
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<int>, int>;
     final element =
         ref.element
@@ -140,6 +140,6 @@ abstract class _$BugsEncounteredNotifier extends $AsyncNotifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, () => build(_$args));
+    return element.handleCreate(ref, () => build(_$args));
   }
 }

--- a/website/docs/migration/from_state_notifier/from_state_provider/from_state_provider.g.dart
+++ b/website/docs/migration/from_state_notifier/from_state_provider/from_state_provider.g.dart
@@ -49,7 +49,7 @@ abstract class _$CounterNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -59,6 +59,6 @@ abstract class _$CounterNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/migration/from_state_notifier/old_lifecycles/old_lifecycles.g.dart
+++ b/website/docs/migration/from_state_notifier/old_lifecycles/old_lifecycles.g.dart
@@ -48,7 +48,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$MyNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/docs/migration/from_state_notifier/old_lifecycles_final/old_lifecycles_final.g.dart
+++ b/website/docs/migration/from_state_notifier/old_lifecycles_final/old_lifecycles_final.g.dart
@@ -130,7 +130,7 @@ abstract class _$MyNotifier extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -140,6 +140,6 @@ abstract class _$MyNotifier extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/website/static/snippets/declare.g.dart
+++ b/website/static/snippets/declare.g.dart
@@ -48,7 +48,7 @@ abstract class _$Count extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$Count extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }


### PR DESCRIPTION
## Related Issues

fixes #4761

`AsyncNotifierProvider`/`StreamNotifierProvider` could prematurely dispose an
autoDispose dependency when the dependency was first watched after an async gap
during `build`.

The root cause was that class-based providers did not propagate the async
completion callback returned by `handleFuture`/`handleStream` back to the core
provider element. As a result, inactive dependencies from the previous rebuild
were closed at the end of the synchronous build frame instead of after the new
async build completed.

This PR keeps the notifier build completion wired through `$ClassProviderElement`,
matching the lifecycle behavior of `FutureProvider`/`StreamProvider`, and adds
regression coverage for post-await dependencies across AsyncNotifier and
StreamNotifier variants.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited in the form:

      ```md
      ## Unreleased fix/major/minor

      - Description of your change. (thanks to @yourGithubId)
      ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an assert error that could occur when providers are unpaused.
  * Fixed AsyncNotifierProvider and StreamNotifierProvider so watched dependencies are disposed correctly after async gaps during rebuilds.

* **Tests**
  * Added tests ensuring dependencies watched after await remain alive through rebuilds until post-await work completes.

* **Documentation**
  * Updated changelogs to record these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->