### PR TITLE
fix: Fix TapGestureRecognizer leak in devtool state inspector

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Fixes assertion error when providers are unpaused.
 - Fix `AsyncNotifierProvider`/`StreamNotifierProvider` disposing dependencies
   watched after an asynchronous gap during rebuild. (thanks to @a1573595)
+- Devtool-only:
+  Fixed a `TapGestureRecognizer` leak in the state inspector, where the
+  recognizer was recreated on every rebuild and never disposed. (thanks to @Gyeony95)
 
 ## 3.3.2-dev.2 - 2026-05-06
 

--- a/packages/riverpod_devtool/lib/src/state_inspector/inspector.dart
+++ b/packages/riverpod_devtool/lib/src/state_inspector/inspector.dart
@@ -581,7 +581,7 @@ class _ResolvedVariableTile extends StatelessWidget {
   }
 }
 
-class _ExpansibleTile extends StatelessWidget {
+class _ExpansibleTile extends StatefulWidget {
   const _ExpansibleTile({
     super.key,
     required this.isExpanded,
@@ -594,10 +594,31 @@ class _ExpansibleTile extends StatelessWidget {
   final Widget child;
 
   @override
+  State<_ExpansibleTile> createState() => _ExpansibleTileState();
+}
+
+class _ExpansibleTileState extends State<_ExpansibleTile> {
+  late final _recognizer = TapGestureRecognizer()..onTap = widget.onPressed;
+
+  @override
+  void didUpdateWidget(_ExpansibleTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.onPressed != widget.onPressed) {
+      _recognizer.onTap = widget.onPressed;
+    }
+  }
+
+  @override
+  void dispose() {
+    _recognizer.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final size = DefaultTextStyle.of(context).style.fontSize ?? 14.0;
 
-    final icon = isExpanded ? Icons.expand_more : Icons.chevron_right;
+    final icon = widget.isExpanded ? Icons.expand_more : Icons.chevron_right;
 
     return Row(
       crossAxisAlignment: .start,
@@ -605,7 +626,7 @@ class _ExpansibleTile extends StatelessWidget {
         Text.rich(
           TextSpan(
             text: String.fromCharCode(icon.codePoint),
-            recognizer: TapGestureRecognizer()..onTap = onPressed,
+            recognizer: _recognizer,
             style: TextStyle(
               fontFamily: icon.fontFamily,
               package: icon.fontPackage,
@@ -613,7 +634,7 @@ class _ExpansibleTile extends StatelessWidget {
             ),
           ),
         ),
-        Expanded(child: child),
+        Expanded(child: widget.child),
       ],
     );
   }


### PR DESCRIPTION
## Related Issues

fixes #4770

This PR fixes a `TapGestureRecognizer` lifecycle leak in the `riverpod_devtool`
state inspector.

`_ExpansibleTile` was a `StatelessWidget` that created a new
`TapGestureRecognizer` inside `build()` and assigned it to
`TextSpan.recognizer`. Because `TextSpan` does not take ownership of the
recognizer and a `StatelessWidget` has no `dispose()`, the recognizer was
allocated on every rebuild and never disposed. This:

- Violates Flutter's gesture recognizer disposal contract (the leak tracker
  reports undisposed objects).
- Churns allocations — a recognizer is created and thrown away on every rebuild
  of every expandable node in the inspector tree.
- Can retain the recognizer indefinitely if a rebuild discards it mid-gesture,
  via global references in `GestureBinding` and pending `Timer`s.

### Changes

- Converted `_ExpansibleTile` from `StatelessWidget` to `StatefulWidget`.
- Created the `TapGestureRecognizer` once in the `State` (`late final _recognizer`)
  and reused it across rebuilds.
- Disposed the recognizer in `State.dispose()`.
- Updated `_recognizer.onTap` in `didUpdateWidget` when the `onPressed`
  callback changes.
- Updated field references to use `widget.` accordingly
  (`widget.isExpanded`, `widget.child`).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
      (Not applicable — this is an internal bug fix with no behavior or API change.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak in the state inspector where gesture recognizers were not properly disposed on rebuild, improving application stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->