### PR TITLE
fix: Cancel in-flight Mutation.run on reset

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Devtool-only:
   Fixed a `TapGestureRecognizer` leak in the state inspector, where the
   recognizer was recreated on every rebuild and never disposed. (thanks to @Gyeony95)
+- Fix `Mutation.reset` not cancelling an in-flight `run`. The pending run could
+  previously write its result back over the reset state once it completed.
+  (thanks to @Gyeony95)
 
 ## 3.3.2-dev.2 - 2026-05-06
 

--- a/packages/riverpod/lib/src/core/mutations.dart
+++ b/packages/riverpod/lib/src/core/mutations.dart
@@ -443,10 +443,15 @@ final class MutationImpl<ResultT>
     final ref = getRef();
     if (ref == null) return;
 
-    setState(MutationIdle<ResultT>._(), ref);
-    // Invalidate the active transaction so that an in-flight `run` can no
-    // longer write its result over the reset state once it completes.
-    setRef(MutationTransaction._(container));
+    // Rotate the active transaction *before* publishing the idle state.
+    // `setState` notifies listeners/observers synchronously, so a listener
+    // could start a new `run` during this call. Rotating first means that
+    // new run installs its own transaction *after* ours, and is therefore
+    // not invalidated. Any `run` that was already in-flight before the reset
+    // keeps its now-stale transaction and can no longer overwrite the state.
+    final resetRef = MutationTransaction._(container);
+    setRef(resetRef);
+    setState(MutationIdle<ResultT>._(), resetRef);
   }
 
   void _mutationStart(

--- a/packages/riverpod/lib/src/core/mutations.dart
+++ b/packages/riverpod/lib/src/core/mutations.dart
@@ -437,13 +437,16 @@ final class MutationImpl<ResultT>
   @override
   void reset(MutationTarget target) {
     final container = target.container;
-    final _MutationNotifier(:state, :setState, :getRef) = container
+    final _MutationNotifier(:state, :setState, :getRef, :setRef) = container
         .read<_MutationNotifier<ResultT>>(_MutationProvider(this));
 
     final ref = getRef();
     if (ref == null) return;
 
     setState(MutationIdle<ResultT>._(), ref);
+    // Invalidate the active transaction so that an in-flight `run` can no
+    // longer write its result over the reset state once it completes.
+    setRef(MutationTransaction._(container));
   }
 
   void _mutationStart(

--- a/packages/riverpod/test/feature/mutation_test.dart
+++ b/packages/riverpod/test/feature/mutation_test.dart
@@ -230,37 +230,40 @@ void main() {
         verifyNoMoreInteractions(listener);
       });
 
-      test('a run started by a synchronous reset listener is not invalidated', () async {
-        // `reset` rotates the active transaction. Because `setState` notifies
-        // listeners synchronously, a listener may start a new `run` during the
-        // reset. That new run must remain valid and able to publish its result.
-        final mut = Mutation<int>();
-        final container = ProviderContainer.test();
-        final firstRun = Completer<int>();
-        final secondRun = Completer<int>();
-        Future<int>? reentrantRun;
+      test(
+        'a run started by a synchronous reset listener is not invalidated',
+        () async {
+          // `reset` rotates the active transaction. Because `setState` notifies
+          // listeners synchronously, a listener may start a new `run` during the
+          // reset. That new run must remain valid and able to publish its result.
+          final mut = Mutation<int>();
+          final container = ProviderContainer.test();
+          final firstRun = Completer<int>();
+          final secondRun = Completer<int>();
+          Future<int>? reentrantRun;
 
-        container.listen<MutationState<int>>(mut, (prev, next) {
-          if (next is MutationIdle<int> &&
-              prev is MutationPending<int> &&
-              reentrantRun == null) {
-            reentrantRun = mut.run(container, (_) => secondRun.future);
-          }
-        });
+          container.listen<MutationState<int>>(mut, (prev, next) {
+            if (next is MutationIdle<int> &&
+                prev is MutationPending<int> &&
+                reentrantRun == null) {
+              reentrantRun = mut.run(container, (_) => secondRun.future);
+            }
+          });
 
-        final first = mut.run(container, (_) => firstRun.future);
-        mut.reset(container);
+          final first = mut.run(container, (_) => firstRun.future);
+          mut.reset(container);
 
-        expect(container.read(mut), isMutationPending<int>());
+          expect(container.read(mut), isMutationPending<int>());
 
-        secondRun.complete(7);
-        await reentrantRun;
+          secondRun.complete(7);
+          await reentrantRun;
 
-        expect(container.read(mut), isMutationSuccess<int>(7));
+          expect(container.read(mut), isMutationSuccess<int>(7));
 
-        firstRun.complete(1);
-        await first.catchError((_) => 0);
-      });
+          firstRun.complete(1);
+          await first.catchError((_) => 0);
+        },
+      );
     });
 
     test('overrides ==/hashCode', () {

--- a/packages/riverpod/test/feature/mutation_test.dart
+++ b/packages/riverpod/test/feature/mutation_test.dart
@@ -229,6 +229,38 @@ void main() {
         expect(container.read(mut), isMutationIdle<int>());
         verifyNoMoreInteractions(listener);
       });
+
+      test('a run started by a synchronous reset listener is not invalidated', () async {
+        // `reset` rotates the active transaction. Because `setState` notifies
+        // listeners synchronously, a listener may start a new `run` during the
+        // reset. That new run must remain valid and able to publish its result.
+        final mut = Mutation<int>();
+        final container = ProviderContainer.test();
+        final firstRun = Completer<int>();
+        final secondRun = Completer<int>();
+        Future<int>? reentrantRun;
+
+        container.listen<MutationState<int>>(mut, (prev, next) {
+          if (next is MutationIdle<int> &&
+              prev is MutationPending<int> &&
+              reentrantRun == null) {
+            reentrantRun = mut.run(container, (_) => secondRun.future);
+          }
+        });
+
+        final first = mut.run(container, (_) => firstRun.future);
+        mut.reset(container);
+
+        expect(container.read(mut), isMutationPending<int>());
+
+        secondRun.complete(7);
+        await reentrantRun;
+
+        expect(container.read(mut), isMutationSuccess<int>(7));
+
+        firstRun.complete(1);
+        await first.catchError((_) => 0);
+      });
     });
 
     test('overrides ==/hashCode', () {

--- a/packages/riverpod/test/feature/mutation_test.dart
+++ b/packages/riverpod/test/feature/mutation_test.dart
@@ -194,6 +194,41 @@ void main() {
 
         expect(container.read(mut), isMutationIdle<int>());
       });
+
+      test('an in-flight run does not override the reset state', () async {
+        final mut = Mutation<int>();
+        final container = ProviderContainer.test();
+        final completer = Completer<int>();
+        final listener = Listener<MutationState<int>>();
+
+        container.listen(mut, listener.call);
+
+        final future = mut.run(container, (_) => completer.future);
+        verifyOnly(
+          listener,
+          listener(
+            argThat(isMutationIdle<int>()),
+            argThat(isMutationPending<int>()),
+          ),
+        );
+
+        mut.reset(container);
+        verifyOnly(
+          listener,
+          listener(
+            argThat(isMutationPending<int>()),
+            argThat(isMutationIdle<int>()),
+          ),
+        );
+
+        // The run completes after the reset. Its result must not be applied,
+        // as the mutation has been explicitly reset to idle in the meantime.
+        completer.complete(42);
+        await future;
+
+        expect(container.read(mut), isMutationIdle<int>());
+        verifyNoMoreInteractions(listener);
+      });
     });
 
     test('overrides ==/hashCode', () {


### PR DESCRIPTION
## Related Issues

fixes #4772 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
      (Not applicable — internal bug fix, no API or behavior change beyond the fix.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reset behavior so a pending operation cannot later overwrite the reset state.

* **Tests**
  * Added tests verifying in-flight operations don’t override state after reset and that a new operation started during reset completes and publishes correctly.

* **Documentation**
  * Updated changelog entry describing the reset fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->