### PR TITLE
docs: fix provider name inconsistency in example

### DIFF
--- a/website/docs/concepts2/refs.mdx
+++ b/website/docs/concepts2/refs.mdx
@@ -174,7 +174,7 @@ For example, we could create a provider that returns "is tick divisible by 4?":
   }
   `}
   raw={`
-  final isDivisibleBy4 = Provider<bool>((ref) {
+  final isDivisibleBy4Provider = Provider<bool>((ref) {
     final tick = ref.watch(tickProvider);
     return tick % 4 == 0;
   });


### PR DESCRIPTION
## Related Issues

N/A

### Summary

Renamed `isDivisibleBy4` to `isDivisibleBy4Provider` in the `ref` example so it matches the subsequent usage with `ref.watch(isDivisibleBy4Provider)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved code example clarity with refined variable naming conventions for provider variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rrousselGit/riverpod/pull/4776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->