### PR TITLE
fix(flutter_riverpod): defer scheduleRefresh setState during the build phase

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased fix
+
+- Fix `setState() called during build` crash in `ProviderScope` when a
+  provider's refresh is scheduled during the build phase (e.g. a dirty provider
+  first read during a widget build, or a paused subscription resuming during a
+  route transition). `scheduleRefresh` no longer calls `setState` synchronously
+  during the build phase. (thanks to @alkoschuster)
+
 ## 3.3.2 - 2026-06-10
 
 - Fixes assertion error when providers are unpaused.

--- a/packages/flutter_riverpod/lib/src/core.dart
+++ b/packages/flutter_riverpod/lib/src/core.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart' hide describeIdentity;
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart' as flutter_scheduler;
 import 'package:flutter_test/flutter_test.dart' as flutter_test;
 import 'package:meta/meta.dart';
 

--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -315,9 +315,22 @@ final class _UncontrolledProviderScopeState
     _cancelAsyncTask?.call();
     _cancelAsyncTask = null;
 
-    setState(() {
+    // A provider can be flushed synchronously during the widget build phase:
+    // e.g. when a dirty provider is read or listened to while a route is
+    // mounting, or when a paused subscription resumes during a TickerMode
+    // change in a route transition. Calling setState from such a flush throws
+    // "setState() or markNeedsBuild() called during build" and aborts
+    // scheduling halfway. Storing the task without the synchronous setState is
+    // enough here: the zero-duration vsync timers below re-mark the scope from
+    // a timer context and invoke the task either way.
+    final phase = flutter_scheduler.SchedulerBinding.instance.schedulerPhase;
+    if (phase == flutter_scheduler.SchedulerPhase.persistentCallbacks) {
       _task = task;
-    });
+    } else {
+      setState(() {
+        _task = task;
+      });
+    }
 
     _vsyncTimer?.cancel();
     _vsyncTimer = Timer(Duration.zero, () {


### PR DESCRIPTION
## Related Issues

fixes #4781

## Checklist
- [x] I have updated the `CHANGELOG.md` of the relevant packages.
- [x] If this contains new features or behavior changes, I have updated the documentation to match those changes. (No public API or behavior change; this fixes a crash. Nothing to document.)


`_UncontrolledProviderScopeState.scheduleRefresh` calls `setState` synchronously. When a refresh is scheduled during the build phase (`SchedulerPhase.persistentCallbacks`) — a dirty provider first read during a widget build, or a paused subscription resuming during a route transition — this throws `setState() or markNeedsBuild() called during build` and aborts scheduling halfway. Before #4653 it was masked by a `try/catch` around the `setState`.

Fix: guard the `setState` by scheduler phase. During `persistentCallbacks`, store the task without `setState`; the existing zero-duration vsync timer already re-marks the scope from a timer context and invokes the task, so behavior outside the build phase is unchanged. Likely also closes a source of the "Only one task can be scheduled at a time" assert, since the previous throw aborted `scheduleRefresh` mid-registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when provider refresh was scheduled during the widget build phase, preventing "setState() called during build" errors in ProviderScope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->