### PR TITLE
fix(flutter_riverpod): guard scheduleRefresh setState against the build phase

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased fix
+
+- Fix `setState() called during build` crash in `ProviderScope` when a
+  provider's refresh is scheduled during the build phase (e.g. a dirty provider
+  first read during a widget build, or a paused subscription resuming during a
+  route transition). `scheduleRefresh` no longer calls `setState` synchronously
+  during the build phase. (thanks to @alkoschuster)
+
 ## 3.3.2 - 2026-06-10
 
 - Fixes assertion error when providers are unpaused.

--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -315,9 +315,20 @@ final class _UncontrolledProviderScopeState
     _cancelAsyncTask?.call();
     _cancelAsyncTask = null;
 
-    setState(() {
+    // Marking the scope dirty is illegal while the framework is building, e.g.
+    // a dirty provider flushed during a widget build, or a paused subscription
+    // resuming during a route transition. Marking it directly throws
+    // "setState() called during build" there. The legal case (an ancestor is
+    // currently building) still runs synchronously; the illegal case stores
+    // the task and lets the zero-duration vsync timers below re-mark the scope
+    // from a timer context and run it. (Restores the guard removed by #4653.)
+    try {
+      setState(() {
+        _task = task;
+      });
+    } on Object catch (_) {
       _task = task;
-    });
+    }
 
     _vsyncTimer?.cancel();
     _vsyncTimer = Timer(Duration.zero, () {


### PR DESCRIPTION
## Related Issues

fixes #4781 

## Checklist
- [x] I have updated the `CHANGELOG.md` of the relevant packages.
- [x] If this contains new features or behavior changes, I have updated the documentation to match those changes. (No public API or behavior change; this fixes a crash. Nothing to document.)

`_UncontrolledProviderScopeState.scheduleRefresh` calls `setState` synchronously. When a refresh is scheduled while the framework is building, a dirty provider first read during a widget build, or a paused subscription resuming during a route transition; this throws `setState() or markNeedsBuild() called during build` and aborts scheduling halfway. Before #4653 it was masked by a `try/catch` around the `setState`.

Fix: restore a narrowly-scoped guard around just this `setState`. The legal case (an ancestor is currently building) still runs synchronously; on failure the task is stored and the existing zero-duration vsync timer re-marks the scope from a timer context and runs it. This passes the full `flutter_riverpod` suite including the #3498 regression test; a blanket "skip `setState` in `persistentCallbacks`" approach regresses that test. Likely also closes a source of the "Only one task can be scheduled at a time" assert, since the previous throw aborted `scheduleRefresh` mid-registration. (#4653 deliberately removed this `try/catch`, so the maintainer may prefer a different shape.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in `ProviderScope` that occurred when refresh operations were scheduled during the app's build phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->