### PR TITLE
docs(faq): eager dependent recompute before unmount + workaround

### DIFF
--- a/website/docs/root/faq.mdx
+++ b/website/docs/root/faq.mdx
@@ -157,13 +157,15 @@ ElevatedButton(
 )
 ```
 
-## Why does a provider recompute (and sometimes throw) right before its widget is removed?
+## Known caveat: a provider may recompute (and throw) one frame before its widget is removed
+
+This is a known limitation of eager recomputation, with no clean fix yet.
 
 When a provider's dependency changes, every dependent provider that still has a
 listener recomputes **immediately**, before the next frame in which the listening
 widgets would rebuild or be removed.
 
-If the same change is also what removes the listener (logging out, or a filter
+So if the same change is also what removes the listener (logging out, or a filter
 shrinking a list), the dependent still recomputes once against the new value
 before its widget is unmounted. If that computation assumed the previous value,
 it throws:
@@ -175,9 +177,11 @@ final userNameProvider = Provider((ref) {
 });
 ```
 
-There is currently no way to skip this last recompute. The workaround is to make
-the computation total: return `null` (or a sentinel) for the transient state
-instead of throwing.
+:::caution
+There is currently no way to skip this last recompute. Until there is, the
+recommended workaround is to make the computation total: return `null` (or a
+sentinel) for the transient state instead of throwing.
+:::
 
 ```dart
 final userNameProvider = Provider((ref) {

--- a/website/docs/root/faq.mdx
+++ b/website/docs/root/faq.mdx
@@ -156,3 +156,36 @@ ElevatedButton(
   }
 )
 ```
+
+## Why does a provider recompute (and sometimes throw) right before its widget is removed?
+
+When a provider's dependency changes, every dependent provider that still has a
+listener recomputes **immediately**, before the next frame in which the listening
+widgets would rebuild or be removed.
+
+If the same change is also what removes the listener (logging out, or a filter
+shrinking a list), the dependent still recomputes once against the new value
+before its widget is unmounted. If that computation assumed the previous value,
+it throws:
+
+```dart
+final userNameProvider = Provider((ref) {
+  final user = ref.watch(userProvider);
+  return user!.name; // throws on logout, the frame before the screen is removed
+});
+```
+
+There is currently no way to skip this last recompute. The workaround is to make
+the computation total: return `null` (or a sentinel) for the transient state
+instead of throwing.
+
+```dart
+final userNameProvider = Provider((ref) {
+  final user = ref.watch(userProvider);
+  if (user == null) return null; // handles the brief invalid window
+  return user.name;
+});
+```
+
+This is noisy, but it avoids the exception. Keep `throw` for states that are
+genuinely impossible rather than merely transient.


### PR DESCRIPTION
## Description

Adds a FAQ entry documenting a caveat that currently lives only in GitHub issues (#943, #1385, #646) and Discord: when a provider's dependency changes, dependent providers that still have a listener recompute **eagerly** — one frame before the listening widgets rebuild or unmount. If the same change is what removes the listener (logout, a filter shrinking a list), the dependent recomputes once against the new value before its widget is gone, and throws if the computation assumed the previous value (`user!.name`, `list[index]`).

The new entry explains the mechanism and the current workaround (make the computation total — return `null`/sentinel for the transient state instead of throwing), placed right after the existing "Using `ref` … unmounted is unsafe" entry, which is the widget-side sibling of the same disposal-ordering hazard.

Docs-only change, no new imports.

Refs: #943, #1385, #646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ subsection (“Known caveat”) explaining that during eager recomputation, a provider may run its final recompute (and potentially throw) one frame before a listening widget is removed when unsubscribe and recomputation are triggered by the same change.
  * Included a Dart example demonstrating how an exception can occur during transient invalid states (e.g., logout).
  * Recommended making provider logic “total” by returning a sentinel value for temporary invalid state, using `throw` only for truly impossible states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->