### PR TITLE
git commit -m "Fix provider_parameters false positive for extension t…

### DIFF
--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased fix
+
+- Fixed `provider_parameters` false positive for extension type arguments.
+
 ## 3.1.4 - 2026-06-10
 ### Dependency changes
 
@@ -371,4 +375,3 @@ Fix quick-fix for provider_dependencies
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-

--- a/packages/riverpod_lint/lib/src/lints/provider_parameters.dart
+++ b/packages/riverpod_lint/lib/src/lints/provider_parameters.dart
@@ -78,9 +78,18 @@ class _Visitor extends SimpleAstVisitor<void> {
       } else if (value is InstanceCreationExpression && !value.isConst) {
         final instantiatedObject = value.constructorName.element
             ?.applyRedirectedConstructors();
-        final instantiatedType = instantiatedObject?.enclosingElement;
+        var instantiatedType = instantiatedObject?.enclosingElement;
 
-        if (instantiatedType is ExtensionTypeElement) return;
+        // Extension types don't have their own identity/equality. Unwrap
+        // them (including generic ones, e.g. `Box<Foo>`) to check the
+        // underlying representation type instead.
+        if (instantiatedType is ExtensionTypeElement) {
+          final erasureElement =
+              value.staticType?.extensionTypeErasure.element;
+          instantiatedType = erasureElement is InterfaceElement
+              ? erasureElement
+              : null;
+        }
 
         final operatorEqual = instantiatedType?.recursiveGetMethod('==');
 

--- a/packages/riverpod_lint/lib/src/lints/provider_parameters.dart
+++ b/packages/riverpod_lint/lib/src/lints/provider_parameters.dart
@@ -78,9 +78,11 @@ class _Visitor extends SimpleAstVisitor<void> {
       } else if (value is InstanceCreationExpression && !value.isConst) {
         final instantiatedObject = value.constructorName.element
             ?.applyRedirectedConstructors();
+        final instantiatedType = instantiatedObject?.enclosingElement;
 
-        final operatorEqual = instantiatedObject?.enclosingElement
-            .recursiveGetMethod('==');
+        if (instantiatedType is ExtensionTypeElement) return;
+
+        final operatorEqual = instantiatedType?.recursiveGetMethod('==');
 
         if (operatorEqual == null) {
           // Doing `provider(new Class())` is bad if the class does not override ==

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.dart
@@ -43,6 +43,7 @@ final dep = Provider((ref) {
   ref.watch(legacy(const Object()));
   ref.watch(legacy(FreezedExample()));
   ref.watch(legacy(ClassicFreezed(42)));
+  ref.watch(legacy(TypeId(1)));
 
   void fn() {}
 
@@ -72,6 +73,7 @@ final dep = Provider((ref) {
   // ignore: riverpod_lint/provider_parameters
   ref.watch(generatorProvider(value: Object()));
   ref.watch(generatorProvider(value: const Object()));
+  ref.watch(generatorProvider(value: TypeId(1)));
 
   ref.watch(generatorProvider(value: ClassThatOverridesEqual()));
   ref.watch(generatorProvider(value: const ClassThatOverridesEqual()));
@@ -143,6 +145,7 @@ class MyWidget extends ConsumerWidget {
     // ignore: riverpod_lint/provider_parameters
     ref.watch(legacy(Object()));
     ref.watch(legacy(const Object()));
+    ref.watch(legacy(TypeId(1)));
 
     ref.watch(legacy(ClassThatOverridesEqual()));
     ref.watch(legacy(const ClassThatOverridesEqual()));
@@ -171,6 +174,7 @@ class MyWidget extends ConsumerWidget {
     // ignore: riverpod_lint/provider_parameters
     ref.watch(generatorProvider(value: Object()));
     ref.watch(generatorProvider(value: const Object()));
+    ref.watch(generatorProvider(value: TypeId(1)));
 
     ref.watch(generatorProvider(value: ClassThatOverridesEqual()));
     ref.watch(generatorProvider(value: const ClassThatOverridesEqual()));
@@ -190,6 +194,8 @@ class MyWidget extends ConsumerWidget {
     return const Placeholder();
   }
 }
+
+extension type TypeId(int id) {}
 
 // Regression test for https://github.com/rrousselGit/riverpod/issues/3302
 mixin Equatable {

--- a/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.dart
+++ b/packages/riverpod_lint_flutter_test/test/lints/provider_parameters.dart
@@ -45,6 +45,36 @@ final dep = Provider((ref) {
   ref.watch(legacy(ClassicFreezed(42)));
   ref.watch(legacy(TypeId(1)));
 
+  // Extension types are unwrapped to check the underlying representation type.
+  ref.watch(legacy(GoodTypeId(ClassThatOverridesEqual())));
+  ref.watch(legacy(GoodTypeId(const ClassThatOverridesEqual())));
+  // ignore: riverpod_lint/provider_parameters
+  ref.watch(legacy(BadTypeId(NoEqualsClass())));
+  // Nested extension types are unwrapped recursively.
+  ref.watch(legacy(NestedGoodTypeId(GoodTypeId(ClassThatOverridesEqual()))));
+  // ignore: riverpod_lint/provider_parameters
+  ref.watch(legacy(NestedBadTypeId(BadTypeId(NoEqualsClass()))));
+
+  // Generic extension types are unwrapped using the substituted type argument.
+  ref.watch(legacy(Box<ClassThatOverridesEqual>(ClassThatOverridesEqual())));
+  // ignore: riverpod_lint/provider_parameters
+  ref.watch(legacy(Box<NoEqualsClass>(NoEqualsClass())));
+
+  // Triple-nested extension types are unwrapped recursively.
+  ref.watch(
+    legacy(TripleGoodTypeId(NestedGoodTypeId(GoodTypeId(ClassThatOverridesEqual())))),
+  );
+  // ignore: riverpod_lint/provider_parameters
+  ref.watch(
+    legacy(TripleBadTypeId(NestedBadTypeId(BadTypeId(NoEqualsClass())))),
+  );
+
+  // A generic extension type wrapping another generic extension type is
+  // unwrapped recursively too.
+  ref.watch(legacy(Box<Box<ClassThatOverridesEqual>>(Box(ClassThatOverridesEqual()))));
+  // ignore: riverpod_lint/provider_parameters
+  ref.watch(legacy(Box<Box<NoEqualsClass>>(Box(NoEqualsClass()))));
+
   void fn() {}
 
   // ignore: riverpod_lint/provider_parameters
@@ -196,6 +226,18 @@ class MyWidget extends ConsumerWidget {
 }
 
 extension type TypeId(int id) {}
+
+class NoEqualsClass {
+  NoEqualsClass();
+}
+
+extension type GoodTypeId(ClassThatOverridesEqual value) {}
+extension type BadTypeId(NoEqualsClass value) {}
+extension type NestedGoodTypeId(GoodTypeId value) {}
+extension type NestedBadTypeId(BadTypeId value) {}
+extension type TripleGoodTypeId(NestedGoodTypeId value) {}
+extension type TripleBadTypeId(NestedBadTypeId value) {}
+extension type Box<T>(T value) {}
 
 // Regression test for https://github.com/rrousselGit/riverpod/issues/3302
 mixin Equatable {


### PR DESCRIPTION
## Related Issues

fixes #4796

## Checklist

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a false positive in the `provider_parameters` lint when extension type arguments are used.
  - The lint now more accurately determines whether `==` is overridden for these extension-type scenarios.

- **Tests**
  - Expanded lint coverage to include additional extension type shapes (including nested and generic extension types) and updated watch assertion cases.

- **Documentation**
  - Added an “Unreleased fix” entry to the lint changelog describing the resolved false positive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->