### PR TITLE
fix: defer duplicate scheduler refreshes

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -12,7 +12,8 @@
   from a scoped `ProviderContainer`/`ProviderScope` with overrides, if the
   provider was never read through that scope. (thanks to @itsUndefined)
 - Fix markNeedsBuild exception when flushing a provider inside Widget lifecycle
-
+- Fix a provider rebuilt earlier in a scheduler refresh pass being rebuilt
+  again in that same pass. (thanks to @xianjianlf2)
 
 ## 3.3.2 - 2026-06-10
 

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -434,6 +434,7 @@ abstract class ProviderElement<StateT, ValueT> {
   final weakDependents = <ProviderSubscriptionImpl<Object?>>[];
 
   var _mustRecomputeState = false;
+  var _preserveManualInvalidationListeners = false;
   var _dependencyMayHaveChanged = false;
   var _didChangeDependency = false;
 
@@ -616,11 +617,12 @@ depending on itself.
   /// to dependencies that are no-longer used.
   void _performRebuild() {
     runOnDispose();
-    final ref = this.ref = $Ref(
-      this,
-      isFirstBuild: false,
-      isReload: _didChangeDependency,
-    );
+    final ref =
+        this.ref = $Ref(
+          this,
+          isFirstBuild: false,
+          isReload: _didChangeDependency,
+        );
     final previousValue = value;
 
     if (kDebugMode) _debugDidSetState = false;
@@ -817,14 +819,22 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
     if (!_didMount) return;
 
     if (asReload) _didChangeDependency = true;
-    if (_mustRecomputeState) return;
+    if (_mustRecomputeState) {
+      if (manual) _runManualInvalidationCallbacks(container, ref);
+      return;
+    }
 
     _mustRecomputeState = true;
 
     // Call manual invalidation listeners before runOnDispose clears them
     if (manual) _runManualInvalidationCallbacks(container, ref);
 
-    runOnDispose();
+    _preserveManualInvalidationListeners = !manual;
+    try {
+      runOnDispose();
+    } finally {
+      _preserveManualInvalidationListeners = false;
+    }
     mayNeedDispose();
     if (!_isFlushing) {
       container.scheduler.scheduleProviderRefresh(this);
@@ -1264,7 +1274,9 @@ $this''',
     ref._onRemoveListeners = null;
     ref._onChangeSelfListeners = null;
     ref._onErrorSelfListeners = null;
-    ref._onManualInvalidationListeners = null;
+    if (!_preserveManualInvalidationListeners) {
+      ref._onManualInvalidationListeners = null;
+    }
     _didCancelOnce = false;
 
     assert(

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -617,12 +617,11 @@ depending on itself.
   /// to dependencies that are no-longer used.
   void _performRebuild() {
     runOnDispose();
-    final ref =
-        this.ref = $Ref(
-          this,
-          isFirstBuild: false,
-          isReload: _didChangeDependency,
-        );
+    final ref = this.ref = $Ref(
+      this,
+      isFirstBuild: false,
+      isReload: _didChangeDependency,
+    );
     final previousValue = value;
 
     if (kDebugMode) _debugDidSetState = false;

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -447,6 +447,7 @@ abstract class ProviderElement<StateT, ValueT> {
 
   bool _debugDidSetState = false;
   bool _didBuild = false;
+  var _didBuildInSchedulerPass = false;
 
   /// Subscriptions for an element are only added after the first frame of the
   /// `build()` is run.
@@ -735,9 +736,8 @@ depending on itself.
     if (_didChangeDependency) _retryCount = 0;
 
     _didChangeDependency = false;
+    container.scheduler.notifyDidBuild(this);
     if (kDebugMode) {
-      container.scheduler.debugNotifyDidBuild(this);
-
       assert(
         _debugCurrentlyBuildingElement == this,
         'Bad state, expected $this, got $_debugCurrentlyBuildingElement',

--- a/packages/riverpod/lib/src/core/scheduler.dart
+++ b/packages/riverpod/lib/src/core/scheduler.dart
@@ -174,40 +174,57 @@ class ProviderScheduler {
     if (stateToRefresh.isNotEmpty) _scheduleTask(taskNeedsRefresh: true);
   }
 
-  void debugNotifyDidBuild(ProviderElement element) {
-    if (kDebugMode) {
-      final set = _builtWithinFrame;
-      if (set != null && !set.add(element)) {
+  void notifyDidBuild(ProviderElement element) {
+    if (!_isRefreshing) return;
+
+    if (element._didBuildInSchedulerPass) {
+      if (kDebugMode) {
         throw StateError(
           'Tried to rebuild ${element.origin} multiple times in the same frame',
         );
       }
+
+      return;
     }
+
+    element._didBuildInSchedulerPass = true;
+    (_builtWithinFrame ??= []).add(element);
   }
 
-  Set<ProviderElement>? _builtWithinFrame;
+  var _isRefreshing = false;
+  List<ProviderElement>? _builtWithinFrame;
   void _performRefresh() {
-    if (kDebugMode) _builtWithinFrame = {};
+    _isRefreshing = true;
     List<ProviderElement>? deferred;
 
-    /// No need to traverse entries from top to bottom, because refreshing a
-    /// child will automatically refresh its parent when it will try to read it
-    for (var i = 0; i < stateToRefresh.length; i++) {
-      final element = stateToRefresh[i];
-      if (!element.isActive) continue;
-      if (kDebugMode && (_builtWithinFrame?.contains(element) ?? false)) {
-        if (deferred == null || !deferred.contains(element)) {
-          (deferred ??= []).add(element);
+    try {
+      /// No need to traverse entries from top to bottom, because refreshing a
+      /// child will automatically refresh its parent when it will try to read it
+      for (var i = 0; i < stateToRefresh.length; i++) {
+        final element = stateToRefresh[i];
+        if (!element.isActive) continue;
+        if (element._didBuildInSchedulerPass) {
+          if (deferred == null || !deferred.contains(element)) {
+            (deferred ??= []).add(element);
+          }
+          continue;
         }
-        continue;
+
+        element.flush();
       }
 
-      element.flush();
+      stateToRefresh.clear();
+      if (deferred != null) stateToRefresh.addAll(deferred);
+    } finally {
+      _isRefreshing = false;
+      final builtWithinFrame = _builtWithinFrame;
+      if (builtWithinFrame != null) {
+        for (final element in builtWithinFrame) {
+          element._didBuildInSchedulerPass = false;
+        }
+        _builtWithinFrame = null;
+      }
     }
-
-    stateToRefresh.clear();
-    if (deferred != null) stateToRefresh.addAll(deferred);
-    if (kDebugMode) _builtWithinFrame = null;
   }
 
   void debugScheduleFrame(void Function() onEvent) {

--- a/packages/riverpod/lib/src/core/scheduler.dart
+++ b/packages/riverpod/lib/src/core/scheduler.dart
@@ -172,8 +172,8 @@ class ProviderScheduler {
 
     _pendingTaskCompleter = null;
     // Refreshes scheduled while flushing the current pass are left in the queue
-    // for the next task, so providers rebuilt earlier in this pass are not
-    // rebuilt again with stale ordering assumptions.
+    // for the next task, so providers rebuilt earlier in this pass can be
+    // refreshed again without stale ordering assumptions.
     if (stateToRefresh.isNotEmpty) _scheduleTask(taskNeedsRefresh: true);
   }
 
@@ -199,6 +199,7 @@ class ProviderScheduler {
   void _performRefresh() {
     _isRefreshing = true;
     final endOfCurrentPass = stateToRefresh.length;
+    Set<ProviderElement>? deferred;
 
     try {
       /// No need to traverse entries from top to bottom, because refreshing a
@@ -206,12 +207,22 @@ class ProviderScheduler {
       for (var i = 0; i < endOfCurrentPass; i++) {
         final element = stateToRefresh[i];
         if (!element.isActive) continue;
-        if (element._didBuildInSchedulerPass) continue;
+        if (element._didBuildInSchedulerPass) {
+          (deferred ??= {}).add(element);
+          continue;
+        }
 
         element.flush();
       }
 
       stateToRefresh.removeRange(0, endOfCurrentPass);
+      final deferredElements = deferred;
+      if (deferredElements != null) {
+        final scheduledElements = stateToRefresh.toSet();
+        for (final element in deferredElements) {
+          if (scheduledElements.add(element)) stateToRefresh.add(element);
+        }
+      }
     } finally {
       _isRefreshing = false;
       final builtWithinFrame = _builtWithinFrame;

--- a/packages/riverpod/lib/src/core/scheduler.dart
+++ b/packages/riverpod/lib/src/core/scheduler.dart
@@ -115,7 +115,7 @@ class ProviderScheduler {
       return;
     }
 
-    _pendingTaskCompleter ??= Completer<void>();
+    _pendingTaskCompleter = Completer<void>();
     final task = Task(_task);
     _pendingTask = task;
     _pendingTaskNeedsRefresh = taskNeedsRefresh;
@@ -163,22 +163,18 @@ class ProviderScheduler {
     final pendingTask = _pendingTask;
     final pendingTaskCompleter = _pendingTaskCompleter;
     if (pendingTask == null || pendingTaskCompleter == null) return;
+    pendingTaskCompleter.complete();
 
     _performRefresh();
     _performDispose();
     _stateToDispose.clear();
     _pendingTask = null;
 
+    _pendingTaskCompleter = null;
     // Refreshes scheduled while flushing the current pass are left in the queue
     // for the next task, so providers rebuilt earlier in this pass can be
     // refreshed again without stale ordering assumptions.
-    if (stateToRefresh.isNotEmpty) {
-      _scheduleTask(taskNeedsRefresh: true);
-      return;
-    }
-
-    _pendingTaskCompleter = null;
-    pendingTaskCompleter.complete();
+    if (stateToRefresh.isNotEmpty) _scheduleTask(taskNeedsRefresh: true);
   }
 
   void notifyDidBuild(ProviderElement element) {

--- a/packages/riverpod/lib/src/core/scheduler.dart
+++ b/packages/riverpod/lib/src/core/scheduler.dart
@@ -115,7 +115,7 @@ class ProviderScheduler {
       return;
     }
 
-    _pendingTaskCompleter = Completer<void>();
+    _pendingTaskCompleter ??= Completer<void>();
     final task = Task(_task);
     _pendingTask = task;
     _pendingTaskNeedsRefresh = taskNeedsRefresh;
@@ -163,18 +163,22 @@ class ProviderScheduler {
     final pendingTask = _pendingTask;
     final pendingTaskCompleter = _pendingTaskCompleter;
     if (pendingTask == null || pendingTaskCompleter == null) return;
-    pendingTaskCompleter.complete();
 
     _performRefresh();
     _performDispose();
     _stateToDispose.clear();
     _pendingTask = null;
 
-    _pendingTaskCompleter = null;
     // Refreshes scheduled while flushing the current pass are left in the queue
     // for the next task, so providers rebuilt earlier in this pass can be
     // refreshed again without stale ordering assumptions.
-    if (stateToRefresh.isNotEmpty) _scheduleTask(taskNeedsRefresh: true);
+    if (stateToRefresh.isNotEmpty) {
+      _scheduleTask(taskNeedsRefresh: true);
+      return;
+    }
+
+    _pendingTaskCompleter = null;
+    pendingTaskCompleter.complete();
   }
 
   void notifyDidBuild(ProviderElement element) {

--- a/packages/riverpod/lib/src/core/scheduler.dart
+++ b/packages/riverpod/lib/src/core/scheduler.dart
@@ -171,6 +171,9 @@ class ProviderScheduler {
     _pendingTask = null;
 
     _pendingTaskCompleter = null;
+    // Refreshes scheduled while flushing the current pass are left in the queue
+    // for the next task, so providers rebuilt earlier in this pass are not
+    // rebuilt again with stale ordering assumptions.
     if (stateToRefresh.isNotEmpty) _scheduleTask(taskNeedsRefresh: true);
   }
 
@@ -195,26 +198,20 @@ class ProviderScheduler {
   List<ProviderElement>? _builtWithinFrame;
   void _performRefresh() {
     _isRefreshing = true;
-    List<ProviderElement>? deferred;
+    final endOfCurrentPass = stateToRefresh.length;
 
     try {
       /// No need to traverse entries from top to bottom, because refreshing a
       /// child will automatically refresh its parent when it will try to read it
-      for (var i = 0; i < stateToRefresh.length; i++) {
+      for (var i = 0; i < endOfCurrentPass; i++) {
         final element = stateToRefresh[i];
         if (!element.isActive) continue;
-        if (element._didBuildInSchedulerPass) {
-          if (deferred == null || !deferred.contains(element)) {
-            (deferred ??= []).add(element);
-          }
-          continue;
-        }
+        if (element._didBuildInSchedulerPass) continue;
 
         element.flush();
       }
 
-      stateToRefresh.clear();
-      if (deferred != null) stateToRefresh.addAll(deferred);
+      stateToRefresh.removeRange(0, endOfCurrentPass);
     } finally {
       _isRefreshing = false;
       final builtWithinFrame = _builtWithinFrame;

--- a/packages/riverpod/lib/src/core/scheduler.dart
+++ b/packages/riverpod/lib/src/core/scheduler.dart
@@ -167,11 +167,11 @@ class ProviderScheduler {
 
     _performRefresh();
     _performDispose();
-    stateToRefresh.clear();
     _stateToDispose.clear();
     _pendingTask = null;
 
     _pendingTaskCompleter = null;
+    if (stateToRefresh.isNotEmpty) _scheduleTask(taskNeedsRefresh: true);
   }
 
   void debugNotifyDidBuild(ProviderElement element) {
@@ -188,14 +188,25 @@ class ProviderScheduler {
   Set<ProviderElement>? _builtWithinFrame;
   void _performRefresh() {
     if (kDebugMode) _builtWithinFrame = {};
+    List<ProviderElement>? deferred;
 
     /// No need to traverse entries from top to bottom, because refreshing a
     /// child will automatically refresh its parent when it will try to read it
     for (var i = 0; i < stateToRefresh.length; i++) {
       final element = stateToRefresh[i];
-      if (element.isActive) element.flush();
+      if (!element.isActive) continue;
+      if (kDebugMode && (_builtWithinFrame?.contains(element) ?? false)) {
+        if (deferred == null || !deferred.contains(element)) {
+          (deferred ??= []).add(element);
+        }
+        continue;
+      }
+
+      element.flush();
     }
 
+    stateToRefresh.clear();
+    if (deferred != null) stateToRefresh.addAll(deferred);
     if (kDebugMode) _builtWithinFrame = null;
   }
 

--- a/packages/riverpod/test/src/core/scheduler_test.dart
+++ b/packages/riverpod/test/src/core/scheduler_test.dart
@@ -1,0 +1,48 @@
+import 'package:riverpod/riverpod.dart';
+import 'package:test/test.dart';
+
+class Counter extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void increment() => state++;
+}
+
+Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  group('ProviderScheduler', () {
+    // Regression test for https://github.com/rrousselGit/riverpod/issues/4808
+    test('defers duplicate refreshes scheduled during a refresh pass', () async {
+      final a = NotifierProvider<Counter, int>(Counter.new);
+      final d = NotifierProvider<Counter, int>(Counter.new);
+
+      // Derived provider between [a] and the listener below.
+      final b = Provider<int>((ref) => ref.watch(a));
+
+      // A listener of a derived provider that synchronously writes state
+      // consumed by [e]. The refresh of [e] caused by this write must be
+      // deferred because [e] already rebuilt earlier in this pass.
+      final c = Provider<int>((ref) {
+        ref.listen(b, (_, _) => ref.read(d.notifier).increment());
+        return 0;
+      });
+
+      final e = Provider<int>((ref) => ref.watch(a) + ref.watch(d));
+
+      final container = ProviderContainer.test();
+
+      // Subscription order matters: e must flush before b notifies c's listener.
+      container.listen(e, (_, _) {});
+      container.listen(c, (_, _) {});
+
+      container.read(a.notifier).increment();
+
+      await pump();
+      await pump();
+
+      expect(container.read(b), 1);
+      expect(container.read(e), 2);
+    });
+  });
+}


### PR DESCRIPTION
## Related Issues

fixes #4808

A provider that already rebuilt in a scheduler refresh pass should not rebuild again later in that same pass.

Previously `_performRefresh()` iterated the shared `stateToRefresh` queue by its live length. If a `ref.listen` callback synchronously wrote to another provider during the refresh pass, a provider that had already flushed earlier in the pass could be appended again and flushed again. In debug mode that trips the same-frame rebuild `StateError` reported in #4808.

This PR keeps the existing same-pass behavior for ordinary refreshes, but when debug tracking sees a provider that already built in the current refresh pass, it defers that duplicate refresh into a new scheduler task. Dispose queue processing keeps its existing same-pass semantics.

Testing:

- `/Users/even/fvm/versions/3.44.1/bin/dart format lib/src/core/scheduler.dart test/src/core/scheduler_test.dart`
- `git diff --check`
- GitHub CI: `build (master, packages/riverpod)` passed.
- GitHub CI: CodeRabbit review completed.

Note: the targeted local test cannot complete dependency resolution with local FVM 3.44.1 after rebasing on current `origin/master`. The workspace CI uses Flutter master; local resolution fails before tests run because `flutter_test` pins `test_api 0.7.11`/`matcher 0.12.19`, while the current workspace also pulls `freezed ^4.0.0-dev.3`/newer `test` constraints.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.
