### PR TITLE
fix: don't let scheduleRefresh throw setState-during-build and freeze the scheduler

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased fix
+
+- Fix `scheduleRefresh` throwing the debug-only "setState() called during build"
+  `FlutterError` and freezing the `ProviderScheduler`. (thanks to @xianjianlf2)
+
 ## 3.3.2 - 2026-06-10
 
 - Fixes assertion error when providers are unpaused.

--- a/packages/flutter_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/flutter_riverpod/lib/src/core/provider_scope.dart
@@ -315,9 +315,28 @@ final class _UncontrolledProviderScopeState
     _cancelAsyncTask?.call();
     _cancelAsyncTask = null;
 
-    setState(() {
-      _task = task;
-    });
+    try {
+      setState(() {
+        _task = task;
+      });
+    }
+    // Deliberate: the debug-only "called during build" assertion is thrown
+    // as a FlutterError, and letting it escape wedges the scheduler.
+    // ignore: avoid_catching_errors
+    on FlutterError {
+      // "setState() or markNeedsBuild() called during build".
+      //
+      // A refresh was requested while a widget below this scope is building.
+      // This can happen without any user-code mistake: for example, a
+      // widget's `ref.watch` during build can flush a stale keepAlive graph,
+      // which synchronously notifies other dependents, whose `invalidateSelf`
+      // ends up here. Marking an ancestor scope dirty during a descendant's
+      // build is not allowed, but `_task` was assigned before the throw, so
+      // the timer fallback below still schedules the refresh right after the
+      // current frame. Letting the error escape instead would leave the
+      // scheduler with a pending task that never runs, freezing all provider
+      // refreshes (https://github.com/rrousselGit/riverpod/issues/4812).
+    }
 
     _vsyncTimer?.cancel();
     _vsyncTimer = Timer(Duration.zero, () {

--- a/packages/flutter_riverpod/test/src/core/provider_scope_test.dart
+++ b/packages/flutter_riverpod/test/src/core/provider_scope_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class Counter extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void increment() => state++;
+}
+
+// All keepAlive (non-autoDispose), like repositories/services in a real app.
+// Fork topology: two dependents of a shared parent.
+final counterProvider = NotifierProvider<Counter, int>(Counter.new);
+final parentProvider = Provider<int>((ref) => ref.watch(counterProvider));
+final childAProvider = Provider<int>((ref) => ref.watch(parentProvider));
+final childBProvider = Provider<int>((ref) => ref.watch(parentProvider));
+
+class PageA extends ConsumerWidget {
+  const PageA({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final a = ref.watch(childAProvider);
+    final b = ref.watch(childBProvider);
+    return Text('a=$a b=$b', textDirection: TextDirection.ltr);
+  }
+}
+
+void main() {
+  // Regression test for https://github.com/rrousselGit/riverpod/issues/4812
+  // and https://github.com/rrousselGit/riverpod/issues/4805.
+  testWidgets('invalidating an unlistened keepAlive graph then re-watching it '
+      'during build must neither throw nor freeze the scheduler', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    Widget app(Widget child) =>
+        UncontrolledProviderScope(container: container, child: child);
+
+    // 1. Mount and activate the graph (a page watches it).
+    await tester.pumpWidget(app(const PageA()));
+    expect(find.text('a=0 b=0'), findsOneWidget);
+
+    // 2. Navigate away: no listener left -> the keepAlive graph is
+    //    inactive.
+    await tester.pumpWidget(app(const SizedBox()));
+
+    // 3. The root dependency changes while the graph is unlistened. The
+    //    refresh task runs, but skips the inactive elements: the graph
+    //    stays dirty.
+    container.read(counterProvider.notifier).increment();
+    await tester.pump();
+
+    // 4. Navigate back: PageA.build re-watches the stale graph. The
+    //    shared parent flushes in place and synchronously notifies its
+    //    other dependent, whose invalidateSelf reaches
+    //    _UncontrolledProviderScopeState.scheduleRefresh while PageA is
+    //    building. This must not call setState() during build.
+    await tester.pumpWidget(app(const PageA()));
+    expect(find.text('a=1 b=1'), findsOneWidget);
+
+    // 5. The scheduler must still be functional afterwards.
+    container.read(counterProvider.notifier).increment();
+    await tester.pump();
+    await tester.pump();
+
+    expect(container.read(counterProvider), 2);
+    expect(
+      find.text('a=2 b=2'),
+      findsOneWidget,
+      reason:
+          'scheduler is frozen: the providers were invalidated but '
+          'never rebuilt',
+    );
+  });
+}


### PR DESCRIPTION
## Related Issues

fixes #4812
fixes #4805

`scheduleRefresh` calling `setState` while the widget tree is building throws the debug-only "setState() or markNeedsBuild() called during build" `FlutterError`, which escapes and freezes the `ProviderScheduler` (production reports include go_router `StatefulShellRoute` tab switches).

This PR catches that debug-only `FlutterError` inside `scheduleRefresh` in `provider_scope.dart`. `_task` is assigned before `markNeedsBuild` throws, so the existing `Timer(Duration.zero)` fallback still carries the refresh; release-mode behavior is byte-identical. The catch uses a deliberate `// ignore: avoid_catching_errors` with a justification comment.

Two honest notes:

- #4805's TickerMode-resume repro is not separately encoded as a test; both stack traces go through the same `setState` line in `scheduleRefresh`, so the shared-code-path argument is what links it. Happy to add a dedicated test if you'd prefer.
- A first attempt (skipping `markNeedsBuild` during `persistentCallbacks`) broke the #3498 regression test — `setState` during build is legal for descendant scopes — which is why try/catch was chosen instead.

Testing: new widget test built from #4812's repro is red before and green after; `flutter test` 150 passing including the #3498 regression test; analyze/format clean.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [ ] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where refreshing providers during Flutter’s build phase could trigger an error and freeze subsequent provider updates.
  - Provider refreshes now continue safely after the current frame, improving reliability when widgets are mounted, unmounted, and rebuilt.

- **Tests**
  - Added coverage for provider updates across widget lifecycle changes, including remounting and refreshed displayed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->