### PR TITLE
Fix markNeedsBuild exception when flushing a provider inside Widget lifecycle

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -3,6 +3,15 @@
 - Fix `invalidate`/`refresh` not finding providers and families when called
   from a scoped `ProviderScope` with overrides, if the provider was never
   read through that scope. (thanks to @itsUndefined)
+- Upgraded `analyzer` to `<15.0.0`
+- Deprecated `SyncProviderTransformerMixin`. It is replaced by the newly added APIs
+- Added `CustomProviderListenable`, a slightly simplified way of making custom provider extensions
+- Added the ability to do `ValueListenable<int> listenable = ref.watch(counterProvider.listenable)`.
+  This uses the new `pkg:listen`.
+- Fix `invalidate`/`refresh` not finding providers and families when called
+  from a scoped `ProviderContainer`/`ProviderScope` with overrides, if the
+  provider was never read through that scope. (thanks to @itsUndefined)
+- Fix markNeedsBuild exception when flushing a provider inside Widget lifecycle
 
 ## 3.3.2 - 2026-06-10
 
@@ -1572,4 +1581,3 @@ The behavior is the same. Only the syntax changed.
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-

--- a/packages/flutter_riverpod/test/src/core/consumer_test.dart
+++ b/packages/flutter_riverpod/test/src/core/consumer_test.dart
@@ -214,6 +214,35 @@ void main() {
         ),
       );
     });
+
+    testWidgets(
+      'mounting a Consumer that watches a paused provider does not throw',
+      (tester) async {
+        var count = 0;
+        final dep = Provider((ref) => count++);
+        final provider = Provider((ref) => ref.watch(dep));
+
+        await tester.pumpWidget(const ProviderScope(child: SizedBox()));
+
+        final container = tester.container();
+
+        container.read(provider);
+        container.invalidate(dep);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            child: Consumer(
+              builder: (c, ref, _) {
+                ref.watch(provider);
+                return const SizedBox();
+              },
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+      },
+    );
   });
 
   testWidgets('Riverpod test', (tester) async {

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Unreleased build
+
+- Fix `invalidate`/`refresh` not finding providers and families when called
+  from a scoped `ProviderScope` with overrides, if the provider was never
+  read through that scope. (thanks to @itsUndefined)
+- Upgraded `analyzer` to `<15.0.0`
+- Deprecated `SyncProviderTransformerMixin`. It is replaced by the newly added APIs
+- Added `CustomProviderListenable`, a slightly simplified way of making custom provider extensions
+- Added the ability to do `ValueListenable<int> listenable = ref.watch(counterProvider.listenable)`.
+  This uses the new `pkg:listen`.
+- Fix `invalidate`/`refresh` not finding providers and families when called
+  from a scoped `ProviderContainer`/`ProviderScope` with overrides, if the
+  provider was never read through that scope. (thanks to @itsUndefined)
+- Fix markNeedsBuild exception when flushing a provider inside Widget lifecycle
+
 ## 3.3.2 - 2026-06-10
 
 - Fixes assertion error when providers are unpaused.
@@ -1768,4 +1783,3 @@ The behavior is the same. Only the syntax changed.
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,5 +1,8 @@
-## Unreleased minor
+## Unreleased build
 
+- Fix `invalidate`/`refresh` not finding providers and families when called
+  from a scoped `ProviderScope` with overrides, if the provider was never
+  read through that scope. (thanks to @itsUndefined)
 - Upgraded `analyzer` to `<15.0.0`
 - Deprecated `SyncProviderTransformerMixin`. It is replaced by the newly added APIs
 - Added `CustomProviderListenable`, a slightly simplified way of making custom provider extensions
@@ -8,6 +11,8 @@
 - Fix `invalidate`/`refresh` not finding providers and families when called
   from a scoped `ProviderContainer`/`ProviderScope` with overrides, if the
   provider was never read through that scope. (thanks to @itsUndefined)
+- Fix markNeedsBuild exception when flushing a provider inside Widget lifecycle
+
 
 ## 3.3.2 - 2026-06-10
 

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -683,25 +683,34 @@ depending on itself.
     $Ref<StateT, ValueT> ref,
   );
 
-  /// A utility for re-initializing a provider when needed.
+  var _isFlushing = false;
+
+  /// Recomputes the state of the provider if necessary.
   ///
-  /// Calling [flush] will only re-initialize the provider if it needs to rerun.
-  /// This can involve:
+  /// This is called when:
+  /// - a provider is read
+  /// - a provider is listened
   /// - a previous call to [Ref.invalidateSelf]
   /// - a dependency of the provider has changed (such as when using [Ref.watch]).
   ///
   /// This is not meant for public consumption. Public API should hide
   /// [flush] from users, such that they don't need to care about invoking this function.
   void flush() {
-    if (!_didMount) {
-      _didMount = true;
-      mount();
-    }
+    final wasFlushing = _isFlushing;
+    _isFlushing = true;
+    try {
+      if (!_didMount) {
+        _didMount = true;
+        mount();
+      }
 
-    _maybeRebuildDependencies();
-    if (_mustRecomputeState) {
-      _mustRecomputeState = false;
-      _performRebuild();
+      _maybeRebuildDependencies();
+      if (_mustRecomputeState) {
+        _mustRecomputeState = false;
+        _performRebuild();
+      }
+    } finally {
+      _isFlushing = wasFlushing;
     }
   }
 
@@ -817,7 +826,9 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
 
     runOnDispose();
     mayNeedDispose();
-    container.scheduler.scheduleProviderRefresh(this);
+    if (!_isFlushing) {
+      container.scheduler.scheduleProviderRefresh(this);
+    }
 
     // We don't call this._markDependencyMayHaveChanged here because we voluntarily
     // do not want to set the _dependencyMayHaveChanged flag to true.


### PR DESCRIPTION
## Related Issues

fixes #4805

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `CustomProviderListenable`.
  * Added support for watching provider listenables through `pkg:listen`.
  * Deprecated `SyncProviderTransformerMixin` in favor of replacement APIs.

* **Bug Fixes**
  * Fixed provider invalidation and refresh with scoped overrides.
  * Prevented widget lifecycle exceptions when flushing providers.
  * Fixed errors when mounting consumers watching previously paused providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->