### PR TITLE
Fix listener leak

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -12,6 +12,7 @@
   from a scoped `ProviderContainer`/`ProviderScope` with overrides, if the
   provider was never read through that scope. (thanks to @itsUndefined)
 - Fix markNeedsBuild exception when flushing a provider inside Widget lifecycle
+- Fixed a listener leak if `ConsumerState.dispose` threw.
 
 ## 3.3.2 - 2026-06-10
 

--- a/packages/flutter_riverpod/lib/src/core/consumer.dart
+++ b/packages/flutter_riverpod/lib/src/core/consumer.dart
@@ -501,9 +501,6 @@ base class ConsumerStatefulElement extends StatefulElement
 
   @override
   void unmount() {
-    /// Calling `super.unmount()` will call `dispose` on the state
-    /// And [ListenManual] subscriptions should be closed after `dispose`
-    super.unmount();
     _tickerModeNotifier?.removeListener(_updateTickerMode);
 
     for (final dependency in _dependencies.values) {
@@ -512,12 +509,20 @@ base class ConsumerStatefulElement extends StatefulElement
     for (var i = 0; i < _listeners.length; i++) {
       _listeners[i].close();
     }
-    final manualListeners = _manualListeners?.toList();
-    if (manualListeners != null) {
-      for (final listener in manualListeners) {
-        listener.close();
+
+    // Prevents memory leaks if State.dispose throws.
+    try {
+      /// Calling `super.unmount()` will call `dispose` on the state
+      /// And [ListenManual] subscriptions should be closed after `dispose`
+      super.unmount();
+    } finally {
+      final manualListeners = _manualListeners?.toList();
+      if (manualListeners != null) {
+        for (final listener in manualListeners) {
+          listener.close();
+        }
+        _manualListeners = null;
       }
-      _manualListeners = null;
     }
   }
 

--- a/packages/flutter_riverpod/test/listen_test.dart
+++ b/packages/flutter_riverpod/test/listen_test.dart
@@ -150,6 +150,48 @@ void main() {
       ref.read(provider.notifier).state++;
       verifyNoMoreInteractions(listener);
     });
+
+    testWidgets('removes listeners on dispose even if State.dispose throws', (
+      tester,
+    ) async {
+      final provider = StateProvider((ref) => 0);
+      final listener = Listener<int>();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: ThrowingDisposeConsumer(
+            onDispose: () => throw Exception('Simulated dispose exception'),
+            builder: (context, ref) {
+              ref.listenManual(provider, listener.call);
+              ref.listen(provider, listener.call);
+              return Container();
+            },
+          ),
+        ),
+      );
+
+      final container = tester.container();
+
+      // Tap or just pump another widget to trigger unmount
+      final exceptions = <dynamic>[];
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        exceptions.add(details.exception);
+      };
+
+      await tester.pumpWidget(ProviderScope(child: Container()));
+
+      FlutterError.onError = originalOnError;
+
+      expect(exceptions, isNotEmpty);
+      expect(
+        exceptions.first.toString(),
+        contains('Simulated dispose exception'),
+      );
+
+      container.read(provider.notifier).state++;
+      verifyZeroInteractions(listener);
+    });
   });
 
   group('WidgetRef.listen', () {
@@ -393,5 +435,34 @@ class _DisposeListenOnceState extends ConsumerState<DisposeListenManual> {
   void dispose() {
     sub.read();
     super.dispose();
+  }
+}
+
+class ThrowingDisposeConsumer extends ConsumerStatefulWidget {
+  const ThrowingDisposeConsumer({
+    super.key,
+    required this.onDispose,
+    required this.builder,
+  });
+
+  final void Function() onDispose;
+  final Widget Function(BuildContext context, WidgetRef ref) builder;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _ThrowingDisposeConsumerState();
+}
+
+class _ThrowingDisposeConsumerState
+    extends ConsumerState<ThrowingDisposeConsumer> {
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(context, ref);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    widget.onDispose();
   }
 }

--- a/packages/flutter_riverpod/test/src/core/consumer_test.dart
+++ b/packages/flutter_riverpod/test/src/core/consumer_test.dart
@@ -947,10 +947,13 @@ void main() {
     FlutterError.onError = originalOnError;
 
     expect(exceptions, isNotEmpty);
-    expect(exceptions.first.toString(), contains('Simulated dispose exception'));
+    expect(
+      exceptions.first.toString(),
+      contains('Simulated dispose exception'),
+    );
 
     // Now modify the provider.
-    // If the subscriptions were not closed because dispose threw, 
+    // If the subscriptions were not closed because dispose threw,
     // markNeedsBuild() will be called on the defunct widget, crashing the test.
     container.read(_counterProvider.notifier).increment();
 
@@ -1056,10 +1059,12 @@ class _ThrowingDisposeConsumer extends ConsumerStatefulWidget {
   const _ThrowingDisposeConsumer({super.key});
 
   @override
-  _ThrowingDisposeConsumerState createState() => _ThrowingDisposeConsumerState();
+  _ThrowingDisposeConsumerState createState() =>
+      _ThrowingDisposeConsumerState();
 }
 
-class _ThrowingDisposeConsumerState extends ConsumerState<_ThrowingDisposeConsumer> {
+class _ThrowingDisposeConsumerState
+    extends ConsumerState<_ThrowingDisposeConsumer> {
   @override
   void dispose() {
     super.dispose();

--- a/packages/flutter_riverpod/test/src/core/consumer_test.dart
+++ b/packages/flutter_riverpod/test/src/core/consumer_test.dart
@@ -904,6 +904,58 @@ void main() {
 
     expect(find.text('21'), findsOneWidget);
   });
+
+  testWidgets('Dependencies are closed even if dispose throws', (tester) async {
+    final container = ProviderContainer();
+    var show = true;
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: StatefulBuilder(
+          builder: (context, setState) {
+            return Column(
+              children: [
+                if (show) const _ThrowingDisposeConsumer(),
+                GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      show = false;
+                    });
+                  },
+                  child: const Text('Remove', textDirection: TextDirection.ltr),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+
+    // Tap to remove the Consumer, which triggers its dispose()
+    // We expect a FlutterError because of the simulated exception in dispose
+    final exceptions = <dynamic>[];
+    final originalOnError = FlutterError.onError;
+    FlutterError.onError = (details) {
+      exceptions.add(details.exception);
+    };
+
+    await tester.tap(find.text('Remove'));
+    await tester.pump();
+
+    // Restore error handler
+    FlutterError.onError = originalOnError;
+
+    expect(exceptions, isNotEmpty);
+    expect(exceptions.first.toString(), contains('Simulated dispose exception'));
+
+    // Now modify the provider.
+    // If the subscriptions were not closed because dispose threw, 
+    // markNeedsBuild() will be called on the defunct widget, crashing the test.
+    container.read(_counterProvider.notifier).increment();
+
+    // The provider update should succeed without any defunct assertion errors.
+  });
 }
 
 class TestNotifier extends StateNotifier<int> {
@@ -988,5 +1040,35 @@ class _CallbackConsumerWidgetState
   @override
   Widget build(BuildContext context) {
     return Container();
+  }
+}
+
+class _Counter extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void increment() => state++;
+}
+
+final _counterProvider = NotifierProvider<_Counter, int>(_Counter.new);
+
+class _ThrowingDisposeConsumer extends ConsumerStatefulWidget {
+  const _ThrowingDisposeConsumer({super.key});
+
+  @override
+  _ThrowingDisposeConsumerState createState() => _ThrowingDisposeConsumerState();
+}
+
+class _ThrowingDisposeConsumerState extends ConsumerState<_ThrowingDisposeConsumer> {
+  @override
+  void dispose() {
+    super.dispose();
+    throw Exception('Simulated dispose exception');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.watch(_counterProvider);
+    return const SizedBox();
   }
 }


### PR DESCRIPTION
## Related Issues

fixes #4345

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed listener and provider subscription cleanup when a consumer widget’s `dispose` throws, preventing listener leaks and ensuring manual listeners are still closed and cleared during unmount.
* **Tests**
  * Added/expanded widget tests to verify listener removal and subscription closure even if `dispose` reports an error, including checks that no further interactions/assertion failures occur after provider updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->