### PR TITLE
docs: fix broken links, an unclosed admonition and small typos

### DIFF
--- a/website/docs/concepts/about_hooks.mdx
+++ b/website/docs/concepts/about_hooks.mdx
@@ -284,7 +284,7 @@ For more information about hooks, see [flutter_hooks].
 Since hooks are independent from Riverpod, it is necessary to install hooks
 separately. If you want to use them, installing [hooks_riverpod] is not
 enough. You will still need to add [flutter_hooks] to your dependencies.
-See <Link documentID="introduction/getting_started" hash="installing-the-package" />) for more information.
+See <Link documentID="introduction/getting_started" hash="installing-the-package" /> for more information.
 
 ### Usage
 

--- a/website/docs/concepts2/consumers.mdx
+++ b/website/docs/concepts2/consumers.mdx
@@ -102,7 +102,7 @@ Riverpod offers various refactors in IDEs like VSCode and Android Studio.
 
 ![Refactor to Consumer](/img/intro/convert_to_class_provider.gif)
 
-To enable them in your IDE, see <Link documentID="introduction/getting_started" hash="enabling-riverpod_lintcustom_lint" />
+To enable them in your IDE, see <Link documentID="introduction/getting_started" hash="enabling-riverpod_lint" />
 :::
 
 [ref]: https://pub.dev/documentation/hooks_riverpod/latest/hooks_riverpod/Ref-class.html

--- a/website/docs/concepts2/containers.mdx
+++ b/website/docs/concepts2/containers.mdx
@@ -9,7 +9,7 @@ import allProviders from 'raw-loader!./containers/all_providers.dart';
 import familyProviders from 'raw-loader!./containers/all_providers_family.dart';
 
 [ProviderContainer] is _the_ central piece of Riverpod's architecture.  
-In Riverpod, [Providers](./providers.mdx) hold no state themselves. Instead,
+In Riverpod, <Link documentID="concepts2/providers" /> hold no state themselves. Instead,
 the state of a given provider is stored inside this container object.
 
 [ProviderScope] is a widget that creates a [ProviderContainer] and exposes it to the 
@@ -77,7 +77,7 @@ In Flutter applications, you shouldn't use [ProviderContainer] directly.
 Instead, you should use [ProviderScope], which is a widget equivalent of [ProviderContainer].
 
 The end-result is the same: Create a [ProviderScope] in your `main`. After that, you can
-use [Consumers](./consumers.mdx) to read and modify providers in your widgets.
+use <Link documentID="concepts2/consumers" /> to read and modify providers in your widgets.
 
 ```dart
 import 'package:flutter/material.dart';

--- a/website/docs/concepts2/mutations.mdx
+++ b/website/docs/concepts2/mutations.mdx
@@ -21,7 +21,7 @@ to react to state changes.
 A common use-case is displaying a loading indicator while a form is being submitted
 
 In short, mutations are to achieve effects such as this:
-![Submit progress indicator](/img/concepts2/mutations/spinner.gif)!
+![Submit progress indicator](/img/concepts2/mutations/spinner.gif)
 
 Without mutations, you would have to store the progress of the form submission
 directly inside the state of a provider. This is not ideal as it pollutes the

--- a/website/docs/from_provider/motivation/motivation.mdx
+++ b/website/docs/from_provider/motivation/motivation.mdx
@@ -93,7 +93,7 @@ to automatically destroy its providers' state when they're no-longer used.
 With Provider, [we have to] rely on scoping providers to dispose the state when it stops being used.  
 But this isn't easy, as it gets tricky when state is shared between pages.
 
-Riverpod solves this with easy-to-understand APIs such as [autodispose] and [Ref.keepAlive].  
+Riverpod solves this with easy-to-understand APIs such as [autodispose] and [Ref.keepAlive][keepAlive].  
 These two APIs enable flexible and creative caching strategies (e.g. time-based caching):
 
 <AutoSnippet language="dart" {...autoDispose}></AutoSnippet>

--- a/website/docs/how_to/cancel.mdx
+++ b/website/docs/how_to/cancel.mdx
@@ -4,7 +4,7 @@ version: 1
 ---
 
 import { Link } from "/src/components/Link";
-import { AutoSnippet, When } from "/src/components/CodeSnippet";
+import { AutoSnippet } from "/src/components/CodeSnippet";
 import homeScreen from "!raw-loader!./cancel/home_screen.dart";
 import extension from "!raw-loader!./cancel/extension.dart";
 import detailScreen from "./cancel/detail_screen";

--- a/website/docs/how_to/testing.mdx
+++ b/website/docs/how_to/testing.mdx
@@ -156,6 +156,7 @@ You should instead write:
 If using code-generation, for the above to work, your mock will have to
 be placed in the same file as the Notifier you are mocking.
 Otherwise you would not have access to the `_$MyNotifier` class.
+:::
 
 Then, to use your notifier you could do:
 

--- a/website/docs/whats_new.mdx
+++ b/website/docs/whats_new.mdx
@@ -925,7 +925,7 @@ Consider:
   `}
 ></AutoSnippet>
 
-In you run this on [Dartpad](https://dartpad.dev/), you will see that its prints:
+If you run this on [Dartpad](https://dartpad.dev/), you will see that its prints:
 
 ```
 // First print


### PR DESCRIPTION
The small English-side fixes I offered while translating the docs for #4818. Each is one line; feel free to take the whole thing or cherry-pick.

| File | Problem |
|---|---|
| `concepts2/containers.mdx` | `[Providers](./providers.mdx)` and `[Consumers](./consumers.mdx)` are reported as broken links by the build — switched to the `<Link documentID=... />` component the rest of the page already uses |
| `concepts2/consumers.mdx` | links to `getting_started` with `hash="enabling-riverpod_lintcustom_lint"`, but that heading is now `## Enabling riverpod_lint`, so the anchor resolves to nothing |
| `concepts2/mutations.mdx` | stray `!` after the spinner image, which renders as a literal exclamation mark |
| `from_provider/motivation/motivation.mdx` | prose uses `[Ref.keepAlive]` but the only definition is `[keepAlive]`, so it renders as bracketed text instead of a link — used the two-bracket form to keep the visible text |
| `how_to/testing.mdx` | the `:::info` near the end is never closed, so the two paragraphs that follow it get swallowed into the admonition |
| `how_to/cancel.mdx` | imports `When` from `CodeSnippet` but never uses it |
| `whats_new.mdx` | "**In** you run this on Dartpad" → "If" |
| `concepts/about_hooks.mdx` | stray unmatched `)` after a `<Link />` |

### Verification

`yarn build` passes for all 12 locales. Before this change the build reported a broken link on `/docs/concepts2/containers`; after it, **English has zero broken links**. The remaining ones the build reports are pre-existing and live in the `it`, `ja`, `ko` and `zh-Hans` translations, untouched here.

The one judgement call worth naming is the `:::info` in `how_to/testing.mdx`. I closed it after the "Otherwise you would not have access to the `_$MyNotifier` class." line, since "Then, to use your notifier you could do:" and the `<AutoSnippet>` that follows read as a continuation of the main narrative rather than part of the note. Say the word if you meant them to be inside it.

The Turkish translations in #4819–#4823 already reflect all of these, so nothing there needs updating either way.
