### PR TITLE
Remove an unused export and fix the mutations anchor

### DIFF
--- a/website/docs/3.0_migration.mdx
+++ b/website/docs/3.0_migration.mdx
@@ -171,7 +171,7 @@ In the scenario where you didn't use a `Notifier`, you can refactor your provide
 
 ## ProviderObserver has its interface slightly changed
 
-For the sake of [mutations](./whats_new.mdx#mutations), 
+For the sake of [mutations](./whats_new.mdx#mutations-experimental), 
 the [ProviderObserver] interface has changed slightly.
 
 Instead of two separate parameters for [ProviderContainer] and [ProviderBase], 

--- a/website/docs/introduction/getting_started.mdx
+++ b/website/docs/introduction/getting_started.mdx
@@ -121,8 +121,6 @@ Now that we have installed [Riverpod], we can start using it.
 
 The following snippets showcase how to use our new dependency to make a "Hello world":
 
-export const foo = 42;
-
 <Tabs
   groupId="riverpod"
   defaultValue="flutter_riverpod"


### PR DESCRIPTION
Two more small ones, both surfaced while translating (follow-up to #4824).

**`introduction/getting_started.mdx`** — `export const foo = 42;` sits between the "Usage example: Hello world" prose and the `<Tabs>` block. Nothing on the site references `foo`, so it looks like a leftover test artifact.

**`3.0_migration.mdx:174`** — links to `./whats_new.mdx#mutations`, but the heading on that page is `## Mutations (experimental)`, so the anchor is `#mutations-experimental`. The link currently resolves to the top of the page rather than the section.

`yarn build` passes with no broken links.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Riverpod 3.0 migration guide link for the updated `ProviderObserver` interface.
  * Removed an unintended code line from the “Hello world” getting-started example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->