### PR TITLE
docs: update runBuild documentation to match actual return type

### DIFF
--- a/packages/riverpod/lib/misc.dart
+++ b/packages/riverpod/lib/misc.dart
@@ -23,4 +23,5 @@ export 'src/internals.dart'
         AsyncProviderListenable,
         CustomProviderListenable,
         ProviderTransformer2,
-        SyncProviderTransformer2;
+        SyncProviderTransformer2,
+        WhenComplete;

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -31,7 +31,7 @@ base mixin _ProviderRefreshable<OutT, InT> implements Refreshable<OutT> {
 void Function()? debugCanModifyProviders;
 
 /// A Future-like that support synchronous completion.
-@publicInCodegen
+@publicInMisc
 typedef WhenComplete = void Function(void Function() cb)?;
 
 /// Mixin to help implement logic for listening to [Future]s/[Stream]s and setup

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -31,7 +31,6 @@ base mixin _ProviderRefreshable<OutT, InT> implements Refreshable<OutT> {
 void Function()? debugCanModifyProviders;
 
 /// A Future-like that support synchronous completion.
-@internal
 @publicInCodegen
 typedef WhenComplete = void Function(void Function() cb)?;
 

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -32,6 +32,7 @@ void Function()? debugCanModifyProviders;
 
 /// A Future-like that support synchronous completion.
 @publicInMisc
+@publicInCodegen
 typedef WhenComplete = void Function(void Function() cb)?;
 
 /// Mixin to help implement logic for listening to [Future]s/[Stream]s and setup

--- a/packages/riverpod/lib/src/core/provider/notifier_provider.dart
+++ b/packages/riverpod/lib/src/core/provider/notifier_provider.dart
@@ -37,13 +37,14 @@ typedef RunNotifierBuild<NotifierT, CreatedT> =
 /// ```dart
 /// mixin MyMixin<T> extends AnyNotifier<T, FutureOr<T>> {
 ///   @override
-///   void runBuild() {
+///   WhenComplete runBuild() {
 ///     // It is safe to use "ref" here.
 ///     listenSelf((prev, next) => print("New state $next"));
 ///
 ///     print('Before build');
-///     super.runBuild();
+///     final result = super.runBuild();
 ///     print('After build');
+///     return result;
 ///   }
 /// }
 /// ```
@@ -148,10 +149,11 @@ abstract class AnyNotifier<StateT, ValueT> {
   /// ```dart
   /// mixin LoggingMixin<T> on AnyNotifier<T> {
   ///   @override
-  ///   void runBuild() {
+  ///   WhenComplete runBuild() {
   ///     print('Will build $this');
-  ///     super.runBuild();
+  ///     final result = super.runBuild();
   ///     print('Did build $this');
+  ///     return result;
   ///   }
   /// }
   /// ```


### PR DESCRIPTION
This PR updates the runBuild documentation to correctly state that it returns WhenComplete instead of void, and makes WhenComplete public as it's part of the public API.

## Changes
- Updated runBuild documentation to use WhenComplete instead of void
- Removed @internal from WhenComplete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed `WhenComplete` via `misc.dart`, making it available alongside the other misc exports.

* **Documentation**
  * Updated `AnyNotifier` override examples to show `runBuild` returning a result and properly returning the `super.runBuild()` output.
  * Refined the examples for using `listenSelf` in combination with custom build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->