### PR TITLE
feat(devtool): add 'Reset to older state' action for providers

### DIFF
--- a/packages/riverpod_devtool/lib/src/elements.dart
+++ b/packages/riverpod_devtool/lib/src/elements.dart
@@ -42,6 +42,43 @@ class ElementMeta {
         }
     }
   }
+
+  Future<void> resetTo(
+    EvalFactory evalFactory,
+    ProviderStateRef oldState, {
+    required Disposable isAlive,
+  }) async {
+    final notifierRef = notifier;
+    if (notifierRef == null) {
+      throw Exception('Provider is not a Notifier-backed provider.');
+    }
+
+    final notifierByte = await notifierRef.state.readRef(evalFactory, isAlive);
+    final oldStateByte = await oldState.state.readRef(evalFactory, isAlive);
+
+    switch ((notifierByte, oldStateByte)) {
+      case (ByteError(error: final error), _):
+        throw Exception(error.toString());
+      case (_, ByteError(error: final error)):
+        throw Exception(error.toString());
+      case (
+          ByteVariable(instance: final notifierInstance),
+          ByteVariable(instance: final oldStateInstance)
+        ):
+        final result = await evalFactory.riverpodFramework.eval(
+          'notifier.state = oldState',
+          isAlive: isAlive,
+          scope: {
+            'notifier': notifierInstance.id!,
+            'oldState': oldStateInstance.id!,
+          },
+        );
+
+        if (result case ByteError(error: final error)) {
+          throw Exception(error.toString());
+        }
+    }
+  }
 }
 
 Map<internals.ElementId, ElementMeta> computeElementsForFrame(

--- a/packages/riverpod_devtool/lib/src/elements.dart
+++ b/packages/riverpod_devtool/lib/src/elements.dart
@@ -48,35 +48,60 @@ class ElementMeta {
     ProviderStateRef oldState, {
     required Disposable isAlive,
   }) async {
-    final notifierRef = notifier;
-    if (notifierRef == null) {
-      throw Exception('Provider is not a Notifier-backed provider.');
-    }
-
-    final notifierByte = await notifierRef.state.readRef(evalFactory, isAlive);
     final oldStateByte = await oldState.state.readRef(evalFactory, isAlive);
+    final notifierRef = notifier;
 
-    switch ((notifierByte, oldStateByte)) {
-      case (ByteError(error: final error), _):
-        throw Exception(error.toString());
-      case (_, ByteError(error: final error)):
-        throw Exception(error.toString());
-      case (
-          ByteVariable(instance: final notifierInstance),
-          ByteVariable(instance: final oldStateInstance)
-        ):
-        final result = await evalFactory.riverpodFramework.eval(
-          'notifier.state = oldState',
-          isAlive: isAlive,
-          scope: {
-            'notifier': notifierInstance.id!,
-            'oldState': oldStateInstance.id!,
-          },
-        );
+    if (notifierRef != null) {
+      final notifierByte =
+          await notifierRef.state.readRef(evalFactory, isAlive);
 
-        if (result case ByteError(error: final error)) {
+      switch ((notifierByte, oldStateByte)) {
+        case (ByteError(error: final error), _):
           throw Exception(error.toString());
-        }
+        case (_, ByteError(error: final error)):
+          throw Exception(error.toString());
+        case (
+            ByteVariable(instance: final notifierInstance),
+            ByteVariable(instance: final oldStateInstance)
+          ):
+          final result = await evalFactory.riverpodFramework.eval(
+            'notifier.state = oldState',
+            isAlive: isAlive,
+            scope: {
+              'notifier': notifierInstance.id!,
+              'oldState': oldStateInstance.id!,
+            },
+          );
+
+          if (result case ByteError(error: final error)) {
+            throw Exception(error.toString());
+          }
+      }
+    } else {
+      final currentStateByte = await state.state.readRef(evalFactory, isAlive);
+
+      switch ((currentStateByte, oldStateByte)) {
+        case (ByteError(error: final error), _):
+          throw Exception(error.toString());
+        case (_, ByteError(error: final error)):
+          throw Exception(error.toString());
+        case (
+            ByteVariable(instance: final currentStateInstance),
+            ByteVariable(instance: final oldStateInstance)
+          ):
+          final result = await evalFactory.riverpodFramework.eval(
+            'state = oldState',
+            isAlive: isAlive,
+            scope: {
+              'state': currentStateInstance.id!,
+              'oldState': oldStateInstance.id!,
+            },
+          );
+
+          if (result case ByteError(error: final error)) {
+            throw Exception(error.toString());
+          }
+      }
     }
   }
 }

--- a/packages/riverpod_devtool/lib/src/elements.dart
+++ b/packages/riverpod_devtool/lib/src/elements.dart
@@ -48,23 +48,23 @@ class ElementMeta {
     ProviderStateRef oldState, {
     required Disposable isAlive,
   }) async {
-    final currentStateByte = await state.state.readRef(evalFactory, isAlive);
+    final elementByte = await provider.element.readRef(evalFactory, isAlive);
     final oldStateByte = await oldState.state.readRef(evalFactory, isAlive);
 
-    switch ((currentStateByte, oldStateByte)) {
+    switch ((elementByte, oldStateByte)) {
       case (ByteError(error: final error), _):
         throw Exception(error.toString());
       case (_, ByteError(error: final error)):
         throw Exception(error.toString());
       case (
-          ByteVariable(instance: final currentStateInstance),
+          ByteVariable(instance: final elementInstance),
           ByteVariable(instance: final oldStateInstance)
         ):
         final result = await evalFactory.riverpodFramework.eval(
-          'state = oldState',
+          'element.state = oldState',
           isAlive: isAlive,
           scope: {
-            'state': currentStateInstance.id!,
+            'element': elementInstance.id!,
             'oldState': oldStateInstance.id!,
           },
         );

--- a/packages/riverpod_devtool/lib/src/elements.dart
+++ b/packages/riverpod_devtool/lib/src/elements.dart
@@ -48,60 +48,30 @@ class ElementMeta {
     ProviderStateRef oldState, {
     required Disposable isAlive,
   }) async {
+    final currentStateByte = await state.state.readRef(evalFactory, isAlive);
     final oldStateByte = await oldState.state.readRef(evalFactory, isAlive);
-    final notifierRef = notifier;
 
-    if (notifierRef != null) {
-      final notifierByte =
-          await notifierRef.state.readRef(evalFactory, isAlive);
+    switch ((currentStateByte, oldStateByte)) {
+      case (ByteError(error: final error), _):
+        throw Exception(error.toString());
+      case (_, ByteError(error: final error)):
+        throw Exception(error.toString());
+      case (
+          ByteVariable(instance: final currentStateInstance),
+          ByteVariable(instance: final oldStateInstance)
+        ):
+        final result = await evalFactory.riverpodFramework.eval(
+          'state = oldState',
+          isAlive: isAlive,
+          scope: {
+            'state': currentStateInstance.id!,
+            'oldState': oldStateInstance.id!,
+          },
+        );
 
-      switch ((notifierByte, oldStateByte)) {
-        case (ByteError(error: final error), _):
+        if (result case ByteError(error: final error)) {
           throw Exception(error.toString());
-        case (_, ByteError(error: final error)):
-          throw Exception(error.toString());
-        case (
-            ByteVariable(instance: final notifierInstance),
-            ByteVariable(instance: final oldStateInstance)
-          ):
-          final result = await evalFactory.riverpodFramework.eval(
-            'notifier.state = oldState',
-            isAlive: isAlive,
-            scope: {
-              'notifier': notifierInstance.id!,
-              'oldState': oldStateInstance.id!,
-            },
-          );
-
-          if (result case ByteError(error: final error)) {
-            throw Exception(error.toString());
-          }
-      }
-    } else {
-      final currentStateByte = await state.state.readRef(evalFactory, isAlive);
-
-      switch ((currentStateByte, oldStateByte)) {
-        case (ByteError(error: final error), _):
-          throw Exception(error.toString());
-        case (_, ByteError(error: final error)):
-          throw Exception(error.toString());
-        case (
-            ByteVariable(instance: final currentStateInstance),
-            ByteVariable(instance: final oldStateInstance)
-          ):
-          final result = await evalFactory.riverpodFramework.eval(
-            'state = oldState',
-            isAlive: isAlive,
-            scope: {
-              'state': currentStateInstance.id!,
-              'oldState': oldStateInstance.id!,
-            },
-          );
-
-          if (result case ByteError(error: final error)) {
-            throw Exception(error.toString());
-          }
-      }
+        }
     }
   }
 }

--- a/packages/riverpod_devtool/lib/src/frame_view.dart
+++ b/packages/riverpod_devtool/lib/src/frame_view.dart
@@ -239,6 +239,55 @@ class InvalidateProviderButton extends ConsumerWidget {
   }
 }
 
+class ResetProviderButton extends ConsumerWidget {
+  const ResetProviderButton({super.key, required this.element});
+
+  final ElementMeta element;
+
+  Future<void> _reset(WidgetRef ref) async {
+    final isAlive = Disposable();
+
+    String? errorMessage;
+    try {
+      final evalFactory = await ref.read(evalProvider.future);
+      await element.resetTo(
+        evalFactory,
+        element.state,
+        isAlive: isAlive,
+      );
+    } catch (error) {
+      errorMessage = error.toString();
+    } finally {
+      isAlive.dispose();
+    }
+
+    if (ref.context.mounted) {
+      if (errorMessage != null) {
+        ScaffoldMessenger.of(ref.context).showSnackBar(
+          SnackBar(content: Text('Failed to reset: $errorMessage')),
+        );
+      } else {
+        ScaffoldMessenger.of(ref.context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Reset provider "${element.provider.name ?? element.provider.elementId.value}" to older state',
+            ),
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return DevtoolIconButton(
+      onPressed: () => _reset(ref),
+      tooltip: 'Reset to this state',
+      icon: const Icon(Icons.history),
+    );
+  }
+}
+
 const dividerHeight = 16.0;
 
 class ProviderViewer extends StatelessWidget {
@@ -263,6 +312,20 @@ class ProviderViewer extends StatelessWidget {
               includeTopBorder: false,
               title: const Text('State'),
               actions: [
+                Consumer(
+                  builder: (context, ref, child) {
+                    if (element.notifier == null) return const SizedBox.shrink();
+                    final framesAsync = ref.watch(filteredFramesProvider);
+                    final selectedFrame = ref.watch(selectedFrameProvider);
+                    final frames = framesAsync.value;
+                    final isLatestFrame = selectedFrame == null ||
+                        frames == null ||
+                        frames.isEmpty ||
+                        selectedFrame.id == frames.last.id;
+                    if (isLatestFrame) return const SizedBox.shrink();
+                    return ResetProviderButton(element: element);
+                  },
+                ),
                 InvalidateProviderButton(element: element),
                 const InspectorSettingsButton(),
               ],

--- a/packages/riverpod_devtool/lib/src/frame_view.dart
+++ b/packages/riverpod_devtool/lib/src/frame_view.dart
@@ -240,9 +240,14 @@ class InvalidateProviderButton extends ConsumerWidget {
 }
 
 class ResetProviderButton extends ConsumerWidget {
-  const ResetProviderButton({super.key, required this.element});
+  const ResetProviderButton({
+    super.key,
+    required this.element,
+    required this.isEnabled,
+  });
 
   final ElementMeta element;
+  final bool isEnabled;
 
   Future<void> _reset(WidgetRef ref) async {
     final isAlive = Disposable();
@@ -281,8 +286,10 @@ class ResetProviderButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return DevtoolIconButton(
-      onPressed: () => _reset(ref),
-      tooltip: 'Reset to this state',
+      onPressed: isEnabled ? () => _reset(ref) : null,
+      tooltip: isEnabled
+          ? 'Reset to this older state'
+          : 'Select an older frame to reset',
       icon: const Icon(Icons.history),
     );
   }
@@ -314,7 +321,6 @@ class ProviderViewer extends StatelessWidget {
               actions: [
                 Consumer(
                   builder: (context, ref, child) {
-                    if (element.notifier == null) return const SizedBox.shrink();
                     final framesAsync = ref.watch(filteredFramesProvider);
                     final selectedFrame = ref.watch(selectedFrameProvider);
                     final frames = framesAsync.value;
@@ -322,8 +328,10 @@ class ProviderViewer extends StatelessWidget {
                         frames == null ||
                         frames.isEmpty ||
                         selectedFrame.id == frames.last.id;
-                    if (isLatestFrame) return const SizedBox.shrink();
-                    return ResetProviderButton(element: element);
+                    return ResetProviderButton(
+                      element: element,
+                      isEnabled: !isLatestFrame,
+                    );
                   },
                 ),
                 InvalidateProviderButton(element: element),


### PR DESCRIPTION
## Description
This PR adds a 'Reset to this state' button in the Riverpod DevTool state inspector, allowing developers to quickly restore a provider to a previous state value.

## Solution
- Added a 'Reset to this state' button next to the Invalidate button
- Button appears only when viewing older frames (not the latest)
- Only enabled for Notifier-backed providers (where \element.notifier != null\)
- Uses eval to execute: \
otifier.state = oldState\

## PR Checklist
- [x] Added reset button next to Invalidate
- [x] Conditional display for Notifier-backed providers
- [x] Conditional display for older frames only
- [x] Uses existing eval mechanism
- [x] Shows appropriate tooltips and feedback
- [x] Maintains consistent UI with existing devtool
- [x] Doesn't introduce breaking changes

Fixes #4800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to reset a provider element back to an earlier frame state.
  * Introduced a “Reset” control in the provider “State” pane, available only when the selected frame is not the latest.
  * Added on-screen feedback for reset actions, including success messages naming the provider and error notifications when reset fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->