### PR TITLE
Fix markNeedsBuild issue

### DIFF
--- a/packages/flutter_riverpod/CHANGELOG.md
+++ b/packages/flutter_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+Fix a different source of `markNeedsBuild` error. Those are tricky!
+
 ## 3.4.1 - 2026-07-26
 
 - Update devtool extension
@@ -1595,4 +1599,3 @@ The behavior is the same. Only the syntax changed.
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-

--- a/packages/flutter_riverpod/test/src/core/provider_element_test.dart
+++ b/packages/flutter_riverpod/test/src/core/provider_element_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'provider_subscription_test.dart';
+
+void main() {
+  testWidgets('invalidating an unlistened keepAlive graph then re-watching it '
+      'during build must neither throw nor freeze the scheduler', (
+    tester,
+  ) async {
+    // https://github.com/rrousselGit/riverpod/issues/4812
+    var count = 0;
+    final counterProvider = NotifierProvider<DeferredNotifier<int>, int>(
+      () => DeferredNotifier((ref, self) => count),
+    );
+    final parentProvider = Provider<int>((ref) => ref.watch(counterProvider));
+    final childAProvider = Provider<int>((ref) => ref.watch(parentProvider));
+    final childBProvider = Provider<int>((ref) => ref.watch(parentProvider));
+
+    Widget pageA() {
+      return Consumer(
+        builder: (context, ref, _) {
+          final a = ref.watch(childAProvider);
+          final b = ref.watch(childBProvider);
+          return Text('a=$a b=$b', textDirection: TextDirection.ltr);
+        },
+      );
+    }
+
+    // 1. Mount and activate the graph (a page watches it).
+    await tester.pumpWidget(ProviderScope(child: pageA()));
+    final container = tester.container();
+
+    expect(find.text('a=0 b=0'), findsOneWidget);
+
+    // 2. Navigate away: no listener left -> the keepAlive graph is inactive.
+    await tester.pumpWidget(const ProviderScope(child: SizedBox()));
+
+    // 3. The root dependency changes while the graph is unlistened. The
+    //    refresh task runs, but skips the inactive elements: the graph
+    //    stays dirty.
+    count++;
+    container.invalidate(counterProvider);
+    await tester.pump();
+
+    // 4. Navigate back: PageA.build re-watches the stale graph.
+    await tester.pumpWidget(ProviderScope(child: pageA()));
+    expect(find.text('a=1 b=1'), findsOneWidget);
+
+    // 5. The scheduler must still be functional afterwards.
+    count++;
+    container.invalidate(counterProvider);
+    await tester.pump();
+    await tester.pump();
+
+    expect(container.read(counterProvider), 2);
+    expect(
+      find.text('a=2 b=2'),
+      findsOneWidget,
+      reason:
+          'scheduler is frozen: the providers were invalidated but '
+          'never rebuilt',
+    );
+  });
+}

--- a/packages/hooks_riverpod/CHANGELOG.md
+++ b/packages/hooks_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+Fix a different source of `markNeedsBuild` error. Those are tricky!
+
 ## 3.4.1 - 2026-07-26
 
 - Update devtool extension
@@ -1799,4 +1803,3 @@ The behavior is the same. Only the syntax changed.
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+Fix a different source of `markNeedsBuild` error. Those are tricky!
+
 ## 3.4.1 - 2026-07-26
 
 - Update devtool extension
@@ -1564,4 +1568,3 @@ The behavior is the same. Only the syntax changed.
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-

--- a/packages/riverpod/lib/src/core/element.dart
+++ b/packages/riverpod/lib/src/core/element.dart
@@ -826,7 +826,14 @@ The provider ${_debugCurrentlyBuildingElement!.origin} modified $origin while bu
 
     runOnDispose();
     mayNeedDispose();
-    if (!_isFlushing) {
+
+    if (
+    // It is redundant to request for a refresh during flushing as the rebuild
+    // will happen immediately
+    !_isFlushing
+        // Don't schedule refresh for paused providers. Those are paused afterall!
+        &&
+        isActive) {
       container.scheduler.scheduleProviderRefresh(this);
     }
 


### PR DESCRIPTION
This happens when a paused provider is resumed while listened by another paused providers. This caused the second paused provider to be scheduled for a refresh even though it does not want a refresh anyway

fixes #4812

## Related Issues

fixes #your-issue-number

<!--
  Update to link the issue that is going to be fixed by this.
  Unless this concerns documentation, make sure to create an issue first
  before raising a PR.

  You do not need to describe what this PR is doing, as this should
  already be covered by the associated issue.
  If the linked issue isn't enough, then chances are a new issue
  is needed.

  Don't hesitate to create many issues! This can avoid working
  on something, only to have your PR closed or have to be rewritten
  due to a disagreement/misunderstanding.
 -->

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
      Changelog files must be edited under the form:

  ```md
  ## Unreleased fix/major/minor

  - Description of your change. (thanks to @yourGithubId)
  ```

- [x] If this contains new features or behavior changes,
      I have updated the documentation to match those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue that could trigger a `markNeedsBuild` error when navigating back to a screen with an invalidated, inactive provider.
  - Prevented the scheduler from becoming stuck when providers are refreshed while not being watched.
  - Ensured providers recompute correctly and the UI displays updated values after returning to a screen or triggering subsequent refreshes.

- **Documentation**
  - Added unreleased patch notes describing the fix across supported Riverpod packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->