### PR TITLE
riverpod_lint: require Dart 3.13 so unsupported SDKs fail fast instead of hanging analysis

### DIFF
--- a/packages/riverpod_lint/CHANGELOG.md
+++ b/packages/riverpod_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Require Dart 3.13: the analysis server protocol needed by `analysis_server_plugin` 0.3.18 (pulled in by the analyzer 13 upgrade) ships in Dart 3.13. On earlier SDKs the plugin previously hung `dart analyze`; now version solving fails with a clear error instead (#4839).
+
 ## 3.1.8 - 2026-07-28
 ### Dependency changes
 

--- a/packages/riverpod_lint/pubspec.yaml
+++ b/packages/riverpod_lint/pubspec.yaml
@@ -14,7 +14,7 @@ topics:
   - lints
 
 environment:
-  sdk: ^3.12.0
+  sdk: ">=3.13.0-0 <4.0.0"
 
 resolution: workspace
 


### PR DESCRIPTION
Fixes the silent hang in #4839.

One line in `packages/riverpod_lint/pubspec.yaml`: `sdk: ^3.12.0` → `sdk: ">=3.13.0-0 <4.0.0"`, plus a changelog entry.

As traced in the issue, 3.1.7+'s analyzer 13 upgrade pulls `analysis_server_plugin` 0.3.18 into the analysis server's plugin sandbox, and the protocol it needs ships in Dart 3.13. On stable 3.12 the plugin resolves and compiles but never completes the server handshake, so `dart analyze` hangs at 0% CPU. With this constraint, 3.12 users get an immediate version-solving error naming the SDK requirement, and 3.13 users are unaffected (verified both directions on a local path-plugin checkout; matrix in the issue).

If you'd rather handle this by timing the analyzer 13 migration with 3.13's stable release instead, happy to close this in favor of that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Dart SDK version to 3.13.
  * Older Dart SDK versions now produce a clear dependency resolution error instead of hanging during analysis.

* **Documentation**
  * Added release notes documenting the updated Dart SDK requirement and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->