### PR TITLE
Depend on test_api instead of test

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased fix
+
+- Depend on `test_api` instead of `test`. Riverpod only used `addTearDown`, which
+  `test` re-exports unchanged from `test_api`, so `ProviderContainer.test` is
+  unaffected. This removes 34 transitive packages from the dependency graph of
+  every project that uses Riverpod, including `analyzer`, whose version ceiling
+  was blocking other tooling. (thanks to @samithahansaka)
+
 ## 3.4.2 - 2026-07-28
 
 Fix a different source of `markNeedsBuild` error. Those are tricky!

--- a/packages/riverpod/lib/src/framework.dart
+++ b/packages/riverpod/lib/src/framework.dart
@@ -12,7 +12,7 @@ import 'package:listen/listen.dart';
 import 'package:meta/meta.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:state_notifier/state_notifier.dart';
-import 'package:test/test.dart' as test;
+import 'package:test_api/scaffolding.dart' as test;
 import 'package:uuid/uuid.dart';
 
 import './common/tenable.dart';

--- a/packages/riverpod/pubspec.yaml
+++ b/packages/riverpod/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   meta: ^1.15.0
   stack_trace: ^1.12.1
   state_notifier: ">=0.7.2 <2.0.0"
-  test: ^1.0.0
+  test_api: ^0.7.0
   uuid: ^4.5.1
 
 dev_dependencies:
@@ -37,4 +37,5 @@ dev_dependencies:
   mockito: ^5.0.0
   path: ^1.9.0
   riverpod_devtool_generator: ^0.0.0
+  test: ^1.0.0
   trotter: ^2.0.0-dev.1

--- a/packages/riverpod_sqflite/CHANGELOG.md
+++ b/packages/riverpod_sqflite/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased fix
+
+- Moved `test` to `dev_dependencies`. It was never imported from `lib/`.
+  (thanks to @samithahansaka)
+
 ## 0.4.6 - 2026-07-28
 ### Dependency changes
 

--- a/packages/riverpod_sqflite/pubspec.yaml
+++ b/packages/riverpod_sqflite/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   meta: ^1.15.0
   riverpod: 3.4.2
   sqflite: ^2.4.1
-  test: ^1.25.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   sqflite_common_ffi: ^2.3.4+4
+  test: ^1.25.8


### PR DESCRIPTION
## Related Issues

fixes #4844

## Checklist

- [x] I have updated the `CHANGELOG.md` of the relevant packages.
- [x] If this contains new features or behavior changes, I have updated the documentation to match those changes.
      No behaviour change: `addTearDown` resolves to the same function, so `ProviderContainer.test` is unaffected.

---

One note on scope, since it goes slightly beyond what was discussed in #4844.

`riverpod_sqflite` also declared `test` as a runtime dependency, but never imported it from `lib/` at all. I moved it to `dev_dependencies` in the same PR, as it is the same issue and was previously reported in #4308. Happy to split it out if you would rather keep this to `riverpod` alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing dependencies to use the lightweight `test_api` package where needed.
  * Moved the full `test` package to development-only dependencies.
  * Reduced transitive dependencies by 34 packages.

* **Documentation**
  * Added unreleased changelog entries documenting the dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->