### PR TITLE
fix: avoid selectAsync notifications after disposal

### DIFF
--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -1577,3 +1577,4 @@ The behavior is the same. Only the syntax changed.
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
+

--- a/packages/riverpod/CHANGELOG.md
+++ b/packages/riverpod/CHANGELOG.md
@@ -5,6 +5,7 @@
   unaffected. This removes 34 transitive packages from the dependency graph of
   every project that uses Riverpod, including `analyzer`, whose version ceiling
   was blocking other tooling. (thanks to @samithahansaka)
+- Fix `selectAsync` notifying a closed subscription after an upstream refresh.
 
 ## 3.4.2 - 2026-07-28
 
@@ -1576,4 +1577,3 @@ The behavior is the same. Only the syntax changed.
 Initial release
 
 <!-- cSpell:ignoreRegExp @\w+ -->
-

--- a/packages/riverpod/lib/src/core/modifiers/select_async.dart
+++ b/packages/riverpod/lib/src/core/modifiers/select_async.dart
@@ -52,6 +52,8 @@ final class _AsyncSelector<InputT, OutputT>
         selectedCompleter!.complete(data);
         selectedCompleter = null;
       } else {
+        if (providerSub.closed) return;
+
         selectedFuture = Future.value(data);
         if (callListeners) {
           providerSub._notifyData(previousFuture, selectedFuture!);
@@ -70,6 +72,8 @@ final class _AsyncSelector<InputT, OutputT>
         selectedCompleter!.completeError(error, stack);
         selectedCompleter = null;
       } else {
+        if (providerSub.closed) return;
+
         selectedFuture = Future.error(error, stack);
         if (callListeners) {
           providerSub._notifyData(previousFuture, selectedFuture!);

--- a/packages/riverpod/test/src/core/modifiers/select_async_test.dart
+++ b/packages/riverpod/test/src/core/modifiers/select_async_test.dart
@@ -158,7 +158,7 @@ void main() {
 
       selectedSub.close();
       refresh.complete(2);
-      await container.pump();
+        await container.read(source.future);
 
       expect(sourceSub.read(), const AsyncData(2));
     });

--- a/packages/riverpod/test/src/core/modifiers/select_async_test.dart
+++ b/packages/riverpod/test/src/core/modifiers/select_async_test.dart
@@ -124,7 +124,7 @@ void main() {
 
         selectedSub.close();
         refresh.complete(2);
-        await container.pump();
+        await container.read(source.future);
 
         expect(sourceSub.read(), const AsyncData(2));
         expect(listenerCalls, 0);

--- a/packages/riverpod/test/src/core/modifiers/select_async_test.dart
+++ b/packages/riverpod/test/src/core/modifiers/select_async_test.dart
@@ -99,115 +99,55 @@ void main() {
     });
 
     test(
-      'resolves selector errors with `sub.read()` after the owner is disposed',
+      'does not notify after the selectAsync subscription is closed',
       () async {
         final container = ProviderContainer.test();
-        final controller = StreamController<int>();
-        addTearDown(controller.close);
-        final provider = Provider((ref) => ref);
 
-        final dep = StreamProvider<int>((ref) => controller.stream);
-        final error = StateError('selector failed');
+        final refresh = Completer<int>();
+        var isRefreshing = false;
+        final source = FutureProvider.autoDispose<int>((ref) {
+          return isRefreshing ? refresh.future : 1;
+        });
 
-        container.listen(dep, (p, n) {});
-        final sub = container.listen(provider, (a, b) {});
-        final future = sub.read().watch(dep.selectAsync((data) => throw error));
+        var listenerCalls = 0;
+        final sourceSub = container.listen(source, (previous, next) {});
+        final selectedSub = container.listen(
+          source.selectAsync((value) => value),
+          (previous, next) => listenerCalls++,
+        );
 
-        container.invalidate(provider);
-        controller.add(21);
+        expect(await selectedSub.read(), 1);
 
-        await expectLater(future, throwsProviderException(error));
+        isRefreshing = true;
+        container.invalidate(source);
+        await container.pump();
+
+        selectedSub.close();
+        refresh.complete(2);
+        await container.pump();
+
+        expect(sourceSub.read(), const AsyncData(2));
+        expect(listenerCalls, 0);
       },
     );
 
-    test('does not report selector errors after the dependent is disposed '
-        'during a refresh', () async {
+    test('does not report selector errors after the selectAsync subscription '
+        'is closed', () async {
+      final container = ProviderContainer.test();
+
       final refresh = Completer<int>();
       var isRefreshing = false;
       final source = FutureProvider.autoDispose<int>((ref) {
         return isRefreshing ? refresh.future : 1;
       });
-      final error = StateError('selector failed');
-      final derived = FutureProvider.autoDispose<int>((ref) {
-        return ref.watch(
-          source.selectAsync((value) {
-            if (value == 2) throw error;
-            return value;
-          }),
-        );
-      });
-      final container = ProviderContainer.test();
-
-      final sourceSub = container.listen(source, (previous, next) {});
-      final derivedSub = container.listen(derived, (previous, next) {});
-
-      expect(await container.read(derived.future), 1);
-
-      isRefreshing = true;
-      container.invalidate(source);
-      await container.pump();
-
-      derivedSub.close();
-      await container.pump();
-
-      refresh.complete(2);
-      await container.pump();
-
-      expect(sourceSub.read(), const AsyncData(2));
-    });
-
-    test('does not report upstream errors after the dependent is disposed '
-        'during a refresh', () async {
-      final refresh = Completer<int>();
-      var isRefreshing = false;
-      final source = FutureProvider.autoDispose<int>(
-        (ref) => isRefreshing ? refresh.future : 1,
-        retry: (_, _) => null,
-      );
-      final derived = FutureProvider.autoDispose<int>((ref) {
-        return ref.watch(source.selectAsync((value) => value));
-      });
-      final container = ProviderContainer.test();
-      final error = StateError('refresh failed');
-
-      final sourceSub = container.listen(source, (previous, next) {});
-      final derivedSub = container.listen(derived, (previous, next) {});
-
-      expect(await container.read(derived.future), 1);
-
-      isRefreshing = true;
-      container.invalidate(source);
-      await container.pump();
-
-      derivedSub.close();
-      await container.pump();
-
-      refresh.completeError(error);
-      await container.pump();
-
-      expect(
-        sourceSub.read(),
-        isA<AsyncError<int>>().having(
-          (value) => value.error,
-          'error',
-          same(error),
-        ),
-      );
-    });
-
-    test('does not call a closed selectAsync listener', () async {
-      final refresh = Completer<int>();
-      var isRefreshing = false;
-      final source = FutureProvider.autoDispose<int>((ref) {
-        return isRefreshing ? refresh.future : 1;
-      });
-      final container = ProviderContainer.test();
-      var listenerCalls = 0;
 
       final sourceSub = container.listen(source, (previous, next) {});
       final selectedSub = container.listen(
-        source.selectAsync((value) => value),
-        (previous, next) => listenerCalls++,
+        source.selectAsync((value) {
+          if (value == 2) throw StateError('selector failed');
+          return value;
+        }),
+        (previous, next) {},
       );
 
       expect(await selectedSub.read(), 1);
@@ -221,41 +161,7 @@ void main() {
       await container.pump();
 
       expect(sourceSub.read(), const AsyncData(2));
-      expect(listenerCalls, 0);
     });
-
-    test(
-      'does not notify after the dependent is disposed during a refresh',
-      () async {
-        final refresh = Completer<int>();
-        var isRefreshing = false;
-        final source = FutureProvider.autoDispose<int>((ref) {
-          return isRefreshing ? refresh.future : 1;
-        });
-        final derived = FutureProvider.autoDispose<int>((ref) {
-          return ref.watch(source.selectAsync((value) => value));
-        });
-        final container = ProviderContainer.test();
-
-        // Keep the source alive independently of the derived provider.
-        final sourceSub = container.listen(source, (previous, next) {});
-        final derivedSub = container.listen(derived, (previous, next) {});
-
-        expect(await container.read(derived.future), 1);
-
-        isRefreshing = true;
-        container.invalidate(source);
-        await container.pump();
-
-        derivedSub.close();
-        await container.pump();
-
-        refresh.complete(2);
-        await container.pump();
-
-        expect(sourceSub.read(), const AsyncData(2));
-      },
-    );
   });
 
   test('implements ProviderSubscription.read on AsyncData', () async {

--- a/packages/riverpod/test/src/core/modifiers/select_async_test.dart
+++ b/packages/riverpod/test/src/core/modifiers/select_async_test.dart
@@ -158,7 +158,7 @@ void main() {
 
       selectedSub.close();
       refresh.complete(2);
-        await container.read(source.future);
+      await container.read(source.future);
 
       expect(sourceSub.read(), const AsyncData(2));
     });

--- a/packages/riverpod/test/src/core/modifiers/select_async_test.dart
+++ b/packages/riverpod/test/src/core/modifiers/select_async_test.dart
@@ -97,6 +97,164 @@ void main() {
 
       await expectLater(future, throwsProviderException('err'));
     });
+
+    test(
+      'resolves selector errors with `sub.read()` after the owner is disposed',
+      () async {
+        final container = ProviderContainer.test();
+        final controller = StreamController<int>();
+        final provider = Provider((ref) => ref);
+        addTearDown(controller.close);
+        final dep = StreamProvider<int>((ref) => controller.stream);
+        final error = StateError('selector failed');
+
+        container.listen(dep, (p, n) {});
+        final sub = container.listen(provider, (a, b) {});
+        final future = sub.read().watch(dep.selectAsync((data) => throw error));
+
+        container.invalidate(provider);
+        controller.add(21);
+
+        await expectLater(future, throwsProviderException(error));
+      },
+    );
+
+    test('does not report selector errors after the dependent is disposed '
+        'during a refresh', () async {
+      final refresh = Completer<int>();
+      var isRefreshing = false;
+      final source = FutureProvider.autoDispose<int>((ref) {
+        return isRefreshing ? refresh.future : 1;
+      });
+      final error = StateError('selector failed');
+      final derived = FutureProvider.autoDispose<int>((ref) {
+        return ref.watch(
+          source.selectAsync((value) {
+            if (value == 2) throw error;
+            return value;
+          }),
+        );
+      });
+      final container = ProviderContainer.test();
+
+      final sourceSub = container.listen(source, (previous, next) {});
+      final derivedSub = container.listen(derived, (previous, next) {});
+
+      expect(await container.read(derived.future), 1);
+
+      isRefreshing = true;
+      container.invalidate(source);
+      await container.pump();
+
+      derivedSub.close();
+      await container.pump();
+
+      refresh.complete(2);
+      await container.pump();
+
+      expect(sourceSub.read(), const AsyncData(2));
+    });
+
+    test('does not report upstream errors after the dependent is disposed '
+        'during a refresh', () async {
+      final refresh = Completer<int>();
+      var isRefreshing = false;
+      final source = FutureProvider.autoDispose<int>(
+        (ref) => isRefreshing ? refresh.future : 1,
+        retry: (_, _) => null,
+      );
+      final derived = FutureProvider.autoDispose<int>((ref) {
+        return ref.watch(source.selectAsync((value) => value));
+      });
+      final container = ProviderContainer.test();
+      final error = StateError('refresh failed');
+
+      final sourceSub = container.listen(source, (previous, next) {});
+      final derivedSub = container.listen(derived, (previous, next) {});
+
+      expect(await container.read(derived.future), 1);
+
+      isRefreshing = true;
+      container.invalidate(source);
+      await container.pump();
+
+      derivedSub.close();
+      await container.pump();
+
+      refresh.completeError(error);
+      await container.pump();
+
+      expect(
+        sourceSub.read(),
+        isA<AsyncError<int>>().having(
+          (value) => value.error,
+          'error',
+          same(error),
+        ),
+      );
+    });
+
+    test('does not call a closed selectAsync listener', () async {
+      final refresh = Completer<int>();
+      var isRefreshing = false;
+      final source = FutureProvider.autoDispose<int>((ref) {
+        return isRefreshing ? refresh.future : 1;
+      });
+      final container = ProviderContainer.test();
+      var listenerCalls = 0;
+
+      final sourceSub = container.listen(source, (previous, next) {});
+      final selectedSub = container.listen(
+        source.selectAsync((value) => value),
+        (previous, next) => listenerCalls++,
+      );
+
+      expect(await selectedSub.read(), 1);
+
+      isRefreshing = true;
+      container.invalidate(source);
+      await container.pump();
+
+      selectedSub.close();
+      refresh.complete(2);
+      await container.pump();
+
+      expect(sourceSub.read(), const AsyncData(2));
+      expect(listenerCalls, 0);
+    });
+
+    test(
+      'does not notify after the dependent is disposed during a refresh',
+      () async {
+        final refresh = Completer<int>();
+        var isRefreshing = false;
+        final source = FutureProvider.autoDispose<int>((ref) {
+          return isRefreshing ? refresh.future : 1;
+        });
+        final derived = FutureProvider.autoDispose<int>((ref) {
+          return ref.watch(source.selectAsync((value) => value));
+        });
+        final container = ProviderContainer.test();
+
+        // Keep the source alive independently of the derived provider.
+        final sourceSub = container.listen(source, (previous, next) {});
+        final derivedSub = container.listen(derived, (previous, next) {});
+
+        expect(await container.read(derived.future), 1);
+
+        isRefreshing = true;
+        container.invalidate(source);
+        await container.pump();
+
+        derivedSub.close();
+        await container.pump();
+
+        refresh.complete(2);
+        await container.pump();
+
+        expect(sourceSub.read(), const AsyncData(2));
+      },
+    );
   });
 
   test('implements ProviderSubscription.read on AsyncData', () async {

--- a/packages/riverpod/test/src/core/modifiers/select_async_test.dart
+++ b/packages/riverpod/test/src/core/modifiers/select_async_test.dart
@@ -103,8 +103,9 @@ void main() {
       () async {
         final container = ProviderContainer.test();
         final controller = StreamController<int>();
-        final provider = Provider((ref) => ref);
         addTearDown(controller.close);
+        final provider = Provider((ref) => ref);
+
         final dep = StreamProvider<int>((ref) => controller.stream);
         final error = StateError('selector failed');
 


### PR DESCRIPTION
## Related Issues

fixes #4846

## Checklist

- [x] I have updated the `CHANGELOG.md` of the relevant packages.

## AI Disclaimer

I did let an AI agent write the tests in this PR. I have reviewed them manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `.selectAsync` so closed subscriptions no longer receive updates or errors after an upstream refresh.
  - Prevented selector notifications and errors after the selected subscription is disposed.
  - Ensured independently retained source data can continue resolving without affecting disposed listeners.

- **Tests**
  - Added regression coverage for disposal during refresh, including successful data updates and selector error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->